### PR TITLE
Imply the version from the package itself!

### DIFF
--- a/bin/vip-configure.js
+++ b/bin/vip-configure.js
@@ -8,7 +8,6 @@ var promptly = require( 'promptly' );
 var utils = require( '../src/utils' );
 
 program
-	.version('0.0.1')
 	.parse( process.argv );
 
 async.series({

--- a/bin/vip.js
+++ b/bin/vip.js
@@ -7,9 +7,10 @@
 process.title = 'vip';
 
 var program = require( 'commander' );
+var package = require( '../package.json' );
 
 program
-	.version( '0.0.1' )
+	.version( package.version )
 	.command( 'configure', 'configure the cli settings' )
 	.parse( process.argv );
 


### PR DESCRIPTION
We can use the version set in package.json to set the version in the
CLI. We also shouldn't need the version in sub-commands as that's
inherited from the main CLI.