### PR TITLE
Add imports

### DIFF
--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+var http = require( 'https' );
 var fs = require( 'fs' );
 var program = require( 'commander' );
 var async = require( 'async' );
@@ -7,6 +8,7 @@ var progress = require( 'progress' );
 var mysql = require( 'mysql' );
 var api = require( '../src/api' );
 var utils = require( '../src/utils' );
+var request = require( 'superagent' );
 
 function list(v) {
 	return v.split(',');
@@ -15,10 +17,15 @@ function list(v) {
 program
 	.command( 'files <site> <directory>' )
 	.description( 'Import files to a VIP Go site' )
-	.option( '-t, --types <types>', 'Types of files to import', ['jpg', 'jpeg', 'png', 'gif'], list )
-	.option( '-p, --parallel <threads>', 'Number of parallel uploads', 5, parseInt )
+	.option( '-t, --types <types>', 'Types of files to import. Default: jpg,jpeg,png,gif', ['jpg', 'jpeg', 'png', 'gif'], list )
+	.option( '-p, --parallel <threads>', 'Number of parallel uploads. Default: 5', 5, parseInt )
 	.option( '-i, --intermediate', 'Upload intermediate images' )
+	.option( '-f, --fast', 'Skip existing file check' )
 	.action( ( site, directory, options ) => {
+		if ( 0 > directory.indexOf( 'uploads' ) ) {
+			return console.error( 'Invalid uploads directory. Uploads must be in uploads/' );
+		}
+
 		utils.findAndConfirmSite( site, site => {
 			api
 				.get( '/sites/' + site.client_site_id + '/meta/files_access_token' )
@@ -27,6 +34,11 @@ program
 						return console.error( err.response.error );
 					}
 
+					if ( ! res.body || ! res.body.data || ! res.body.data[0] || ! res.body.data[0].meta_value ) {
+						return console.error( 'Could not get files access token' );
+					}
+
+					var access_token = res.body.data[0].meta_value;
 					// TODO: Progress bar
 
 					// Simple async queue with limit 5
@@ -40,6 +52,7 @@ program
 							files = files.map( f => file + '/' + f );
 							queue.push( files, 0 - depth );
 						} else {
+							var filepath = file.split( 'uploads' );
 							var ext = file.split( '.' );
 							ext = ext[ ext.length - 1 ];
 
@@ -51,10 +64,64 @@ program
 								return cb( new Error( 'Skipping intermediate image: ' + file ) );
 							}
 
-							// TODO: Upload file
-						}
+							if ( ! filepath[1] ) {
+								return cb( new Error( 'Invalid file path. Files must be in uploads/ directory.' ) );
+							}
 
-						cb();
+							var url = 'https://files.vipv2.net/wp-content/uploads' + filepath[1];
+							var filename = file.split( '/' );
+							filename = filename[ filename.length - 1 ];
+
+							var upload = ( file, cb ) => {
+								var data = fs.readFileSync( file );
+
+								var req = http.request({
+									hostname: 'files.vipv2.net',
+									method: 'PUT',
+									path: '/wp-content/uploads' + filepath[1],
+									headers: {
+										'X-Client-Site-ID': site.client_site_id,
+										'X-Access-Token': access_token,
+										'Content-Length': Buffer.byteLength( data ),
+									}
+								}, res => {
+									console.log( "Uploading: ", file );
+
+									if ( res.statusCode !== 200 ) {
+										console.log( "Response Code: ", res.statusCode );
+									}
+
+									cb();
+								});
+
+								req.write( data );
+								req.end();
+							};
+
+							// Upload file
+							if ( options.fast ) {
+								return upload( file, cb );
+							} else {
+								request
+									.get( url )
+									.set({ 'X-Client-Site-ID': site.client_site_id })
+									.set({ 'X-Access-Token': access_token })
+									.set({ 'X-Action': 'file_exists' })
+									.timeout( 2000 )
+									.end( ( err, res ) => {
+										if ( res && res.notFound ) {
+											return upload( file, cb );
+										} else if ( err ) {
+											console.log( err );
+											return cb( err );
+										} else {
+											console.log( "File exists: ", file );
+										}
+
+										cb();
+									});
+							}
+						}
 					}, options.parallel );
 
 					queue.push( directory, 1 );

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -39,6 +39,13 @@ program
 							files = files.map( f => file + '/' + f );
 							queue.push( files, 0 - depth );
 						} else {
+							var ext = file.split( '.' );
+							ext = ext[ ext.length - 1 ];
+
+							if ( ! ext || options.types.indexOf( ext ) < 0 ) {
+								return cb( new Error( "Unsupported filetype: " + file ) );
+							}
+
 							// TODO: Upload file
 						}
 

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -203,11 +203,22 @@ program
 							});
 						}, err => {
 							connection.end();
-							// TODO: Queue cache flush
 
 							if ( err ) {
 								console.error( err );
 							}
+
+							api
+								.post( '/sites/' + site.client_site_id + '/wp-cli' )
+								.send({
+									command: "cache",
+									args: [ "flush" ],
+									namedvars: {
+										"skip-plugins": true,
+										"skip-themes": true,
+									},
+								})
+								.end();
 						});
 					});
 				});

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-var http = require( 'https' );
-var fs = require( 'fs' );
-var program = require( 'commander' );
-var async = require( 'async' );
+var http     = require( 'https' );
+var fs       = require( 'fs' );
+var program  = require( 'commander' );
+var async    = require( 'async' );
 var progress = require( 'progress' );
-var mysql = require( 'mysql' );
-var api = require( '../src/api' );
-var utils = require( '../src/utils' );
-var request = require( 'superagent' );
+var mysql    = require( 'mysql' );
+var api      = require( '../src/api' );
+var utils    = require( '../src/utils' );
+var request  = require( 'superagent' );
 
 function list(v) {
 	return v.split(',');
@@ -43,17 +43,19 @@ program
 
 					// Simple async queue with limit 5
 					var queue = async.priorityQueue( ( file, cb ) => {
-						var file = fs.realpathSync( file );
+						var file  = fs.realpathSync( file );
 						var stats = fs.lstatSync( file );
 						var depth = file.split( '/' ).length;
 
 						if ( stats.isDirectory() ) {
 							var files = fs.readdirSync( file );
-							files = files.map( f => file + '/' + f );
+							files     = files.map( f => file + '/' + f );
+
 							queue.push( files, 0 - depth );
 						} else {
 							var filepath = file.split( 'uploads' );
-							var ext = file.split( '.' );
+							var ext      = file.split( '.' );
+
 							ext = ext[ ext.length - 1 ];
 
 							if ( ! ext || options.types.indexOf( ext ) < 0 ) {
@@ -68,8 +70,9 @@ program
 								return cb( new Error( 'Invalid file path. Files must be in uploads/ directory.' ) );
 							}
 
-							var url = 'https://files.vipv2.net/wp-content/uploads' + filepath[1];
+							var url      = 'https://files.vipv2.net/wp-content/uploads' + filepath[1];
 							var filename = file.split( '/' );
+
 							filename = filename[ filename.length - 1 ];
 
 							var upload = ( file, cb ) => {
@@ -77,9 +80,9 @@ program
 
 								var req = http.request({
 									hostname: 'files.vipv2.net',
-									method: 'PUT',
-									path: '/wp-content/uploads' + filepath[1],
-									headers: {
+									method:   'PUT',
+									path:     '/wp-content/uploads' + filepath[1],
+									headers:  {
 										'X-Client-Site-ID': site.client_site_id,
 										'X-Access-Token': access_token,
 										'Content-Length': Buffer.byteLength( data ),
@@ -94,9 +97,9 @@ program
 									cb();
 								});
 
-								req.on('socket', function (socket) {
-									socket.setTimeout(10000);  
-									socket.on('timeout', function() {
+								req.on( 'socket', function ( socket ) {
+									socket.setTimeout( 10000 );
+									socket.on( 'timeout', function() {
 									    req.abort();
 									});
 								});
@@ -181,6 +184,7 @@ program
 
 								// Report progress
 								bar.tick();
+
 								cb();
 							});
 						}, err => {

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -39,7 +39,7 @@ program
 					}
 
 					var access_token = res.body.data[0].meta_value;
-					// TODO: Progress bar
+					var bar = new progress( 'Importing [:bar] :percent :etas', { total: 1500 } );
 
 					// Simple async queue with limit 5
 					var queue = async.priorityQueue( ( file, cb ) => {
@@ -85,10 +85,10 @@ program
 										'Content-Length': Buffer.byteLength( data ),
 									}
 								}, res => {
-									console.log( "Uploading: ", file );
+									bar.tick();
 
 									if ( res.statusCode !== 200 ) {
-										console.log( "Response Code: ", res.statusCode );
+										return cb( res.statusCode, file );
 									}
 
 									cb();
@@ -112,12 +112,11 @@ program
 										if ( res && res.notFound ) {
 											return upload( file, cb );
 										} else if ( err ) {
-											console.log( err );
+											bar.tick();
 											return cb( err );
-										} else {
-											console.log( "File exists: ", file );
 										}
 
+										bar.tick();
 										cb();
 									});
 							}

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -17,6 +17,7 @@ program
 	.description( 'Import files to a VIP Go site' )
 	.option( '-t, --types <types>', 'Types of files to import', ['jpg', 'jpeg', 'png', 'gif'], list )
 	.option( '-p, --parallel <threads>', 'Number of parallel uploads', 5, parseInt )
+	.option( '-i, --intermediate', 'Upload intermediate images' )
 	.action( ( site, directory, options ) => {
 		utils.findAndConfirmSite( site, site => {
 			api
@@ -44,6 +45,10 @@ program
 
 							if ( ! ext || options.types.indexOf( ext ) < 0 ) {
 								return cb( new Error( "Unsupported filetype: " + file ) );
+							}
+
+							if ( ! options.intermediate && /-\d+x\d+\.\w{3,4}$/.test( file ) ) {
+								return cb( new Error( 'Skipping intermediate image: ' + file ) );
 							}
 
 							// TODO: Upload file

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -94,6 +94,13 @@ program
 									cb();
 								});
 
+								req.on('socket', function (socket) {
+									socket.setTimeout(10000);  
+									socket.on('timeout', function() {
+									    req.abort();
+									});
+								});
+
 								req.write( data );
 								req.end();
 							};

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+var fs = require( 'fs' );
+var program = require( 'commander' );
+var async = require( 'async' );
+var mysql = require( 'mysql' );
+var api = require( '../src/api' );
+var utils = require( '../src/utils' );
+
+function list(v) {
+	return v.split(',');
+}
+
+program
+	.command( 'files <site> <directory>' )
+	.description( 'Import files to a VIP Go site' )
+	.option( '-t, --types', 'Types of files to import', list, ['jpg', 'jpeg', 'png', 'gif'] )
+	.option( '-p, --parallel', 'Number of parallel uploads', parseInt, 5 )
+	.action( ( site, directory ) => {
+		utils.findAndConfirmSite( site, site => {
+			api
+				.get( '/sites/' + site.client_site_id + '/meta/files_access_token' )
+				.end( ( err, res ) => {
+					if ( err ) {
+						return console.error( err.response.error );
+					}
+
+					// TODO: List files recursively
+					// TODO: Upload files in parallel
+					// TODO: Progress bar
+				});
+		});
+	});
+
+program
+	.command( 'sql <site> <file>' )
+	.description( 'Import SQL to a VIP Go site' )
+	.action( ( site, file ) => {
+		var progress = require( 'progress' );
+
+		utils.findAndConfirmSite( site, site => {
+
+			// Get mysql info
+			api
+				.get( '/sites/' + site.client_site_id + '/masterdb' )
+				.end( ( err, res ) => {
+					if ( err ) {
+						return console.error( err.response.error );
+					}
+
+					var db = res.body,
+						sql = fs.readFileSync( file ).toString()
+							.split( /;(\r\n|\r|\n)/ )
+							.map( s => s.trim() )
+							.filter( s => s.length > 0 );
+
+					var connection = mysql.createConnection({
+						host: db.host,
+						port: db.port,
+						user: db.username,
+						password: db.password,
+						database: db.name,
+					});
+
+					var bar = new progress( 'Importing [:bar] :percent :etas', { total: sql.length } );
+
+					// Test DB connection
+					connection.query( 'SELECT 1', err => {
+						if ( err ) {
+							return console.error( err );
+						}
+
+						async.eachSeries( sql, ( sql, cb ) => {
+
+							// Import sql
+							connection.query( sql, err => {
+								if ( err ) {
+									return cb( err );
+								}
+
+								// Report progress
+								bar.tick();
+								cb();
+							});
+						}, err => {
+							connection.end();
+							// TODO: Queue cache flush
+
+							if ( err ) {
+								console.error( err );
+							}
+						});
+					});
+				});
+		});
+	});
+
+program.parse( process.argv );
+
+if ( ! process.argv.slice( 2 ).length ) {
+	program.outputHelp();
+}

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -118,8 +118,8 @@ program
 									.set({ 'X-Access-Token': access_token })
 									.set({ 'X-Action': 'file_exists' })
 									.timeout( 2000 )
-									.end( ( err, res ) => {
-										if ( res && res.notFound ) {
+									.end( err => {
+										if ( err && err.status === 404 ) {
 											return upload( file, cb );
 										} else if ( err ) {
 											bar.tick();

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -39,7 +39,7 @@ program
 					}
 
 					var access_token = res.body.data[0].meta_value;
-					var bar = new progress( 'Importing [:bar] :percent :etas', { total: 1500 } );
+					var bar = new progress( 'Importing [:bar] :percent :etas', { total: 1500, incomplete: ' ', renderThrottle: 100 } );
 
 					// Simple async queue with limit 5
 					var queue = async.priorityQueue( ( file, cb ) => {
@@ -166,7 +166,7 @@ program
 						database: db.name,
 					});
 
-					var bar = new progress( 'Importing [:bar] :percent :etas', { total: sql.length } );
+					var bar = new progress( 'Importing [:bar] :percent :etas', { total: sql.length, incomplete: ' ', renderThrottle: 100 } );
 
 					// Test DB connection
 					connection.query( 'SELECT 1', err => {

--- a/bin/vip-import.js
+++ b/bin/vip-import.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
-var http     = require( 'https' );
-var fs       = require( 'fs' );
-var program  = require( 'commander' );
-var async    = require( 'async' );
-var progress = require( 'progress' );
-var mysql    = require( 'mysql' );
-var api      = require( '../src/api' );
-var utils    = require( '../src/utils' );
-var request  = require( 'superagent' );
+const http     = require( 'https' );
+const fs       = require( 'fs' );
+const program  = require( 'commander' );
+const async    = require( 'async' );
+const progress = require( 'progress' );
+const mysql    = require( 'mysql' );
+const api      = require( '../src/api' );
+const utils    = require( '../src/utils' );
+const request  = require( 'superagent' );
 
 function list(v) {
 	return v.split(',');

--- a/bin/vip.js
+++ b/bin/vip.js
@@ -9,7 +9,7 @@ process.title = 'vip';
 var program = require( 'commander' );
 var promptly = require( 'promptly' );
 var which = require( 'which' );
-var package = require( '../package.json' );
+var packageJSON = require( '../package.json' );
 var utils = require( '../src/utils' );
 var api = require( '../src/api' );
 
@@ -17,7 +17,7 @@ var api = require( '../src/api' );
 var is_vip = true;
 
 program
-	.version( package.version )
+	.version( packageJSON.version )
 	.command( 'configure', 'configure the cli settings' )
 
 // internal VIP commands

--- a/bin/vip.js
+++ b/bin/vip.js
@@ -23,7 +23,8 @@ program
 // internal VIP commands
 if (!!is_vip) {
 	program
-		.command( 'api', 'Authenticated API requests' );
+		.command( 'api', 'Authenticated API requests' )
+		.command( 'import', 'import to VIP Go' );
 
 	program
 		.command( 'db <site>' )

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mysql": "^2.11.1",
     "progress": "^1.1.8",
     "promptly": "1.0.0",
+    "shell-escape": "^0.2.0",
     "superagent": "^2.0.0",
     "vip": "automattic/vip-js-sdk",
     "which": "^1.2.10"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "vip": "bin/vip.js"
   },
   "dependencies": {
-    "async": "1.5.2",
+    "async": "^1.5.2",
     "commander": "2.9.0",
+    "mysql": "^2.11.1",
+    "progress": "^1.1.8",
     "promptly": "1.0.0",
     "vip": "automattic/vip-js-sdk",
     "which": "^1.2.10"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mysql": "^2.11.1",
     "progress": "^1.1.8",
     "promptly": "1.0.0",
+    "superagent": "^2.0.0",
     "vip": "automattic/vip-js-sdk",
     "which": "^1.2.10"
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,12 +91,13 @@ var utils = {
 			console.log( "Primary Domain:", s.domain_name );
 			console.log( "Environment:", s.environment_name );
 
-			promptly.confirm( "Are you sure?", ( err, t ) => {
+			promptly.confirm( "Are you sure?", ( err, yes ) => {
 				if ( err ) {
 					return console.error( err );
 				}
 
-				if ( ! t ) {
+				if ( ! yes ) {
+					// Bails. Do not pass go. Do not collect $200.
 					return;
 				}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 const fs = require( 'fs' );
 const crypto = require( 'crypto' );
+const promptly = require( 'promptly' );
 
 var s_token_iv = 'XWRCbboGgpK1Q23c';
 var s_token_ky = 'w3C1LwkexA8exKsjuYxRBCHOhqMZ5Wiy4mYPT4UxiJOvKNF7hSLwwt7dqpYyj3cA';
@@ -75,6 +76,33 @@ var utils = {
 
 				cb( null, site );
 			});
+	},
+	findAndConfirmSite: function( site, cb ) {
+		utils.findSite( site, ( err, s ) => {
+			if ( err ) {
+				return console.error( err );
+			}
+
+			if ( ! s ) {
+				return console.error( "Couldn't find site:", site );
+			}
+
+			console.log( "Client Site:", s.client_site_id );
+			console.log( "Primary Domain:", s.domain_name );
+			console.log( "Environment:", s.environment_name );
+
+			promptly.confirm( "Are you sure?", ( err, t ) => {
+				if ( err ) {
+					return console.error( err );
+				}
+
+				if ( ! t ) {
+					return;
+				}
+
+				cb( s );
+			});
+		});
 	},
 };
 


### PR DESCRIPTION
Adds two new commands:

```
$ vip import sql --help

  Usage: sql [options] <site> <file>

  Import SQL to a VIP Go site

  Options:

    -h, --help  output usage information
```

```
$ vip import files --help

  Usage: files [options] <site> <directory>

  Import files to a VIP Go site

  Options:

    -h, --help                output usage information
    -t, --types <types>       Types of files to import
    -p, --parallel <threads>  Number of parallel uploads
    -i, --intermediate        Upload intermediate images
    -f, --fast                Skip existing file check
```