### PR TITLE
Switch to domain_name query for findSite

### DIFF
--- a/src/src/utils.js
+++ b/src/src/utils.js
@@ -81,7 +81,7 @@ var utils = {
 		} else {
 			request = api
 				.get( '/sites' )
-				.query({ search: domain });
+				.query({ domain_name: domain });
 		}
 
 		return request


### PR DESCRIPTION
The site parameter should be an exact match, which we can do with the
new domain_name query parameter on site queries.