### PR TITLE
Add helper command to run CLI commands on containers

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -54,9 +54,7 @@ utils.getCredentials( ( err, user ) => {
 		program
 			.command( 'cli <site> [command...]' )
 			.description( 'Run a CLI command on a given sandbox' )
-			.option( '-y, --yes', 'Are you sure?' )
 			.action( ( site, command, options ) => {
-				// TODO: If options.yes, don't ask for confirmation
 				utils.getSandboxForSite( site, ( err, sandbox ) => {
 					if ( err ) {
 						return console.error( err );

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -14,6 +14,7 @@ var packageJSON = require( '../../package.json' );
 var utils = require( '../src/utils' );
 var api = require( '../src/api' );
 var db = require( '../src/db' );
+const spawn = require('child_process').spawn;
 
 var is_vip = false;
 
@@ -49,6 +50,36 @@ utils.getCredentials( ( err, user ) => {
 		program
 			.command( 'api', 'Authenticated API requests' )
 			.command( 'import', 'import to VIP Go' );
+
+		program
+			.command( 'cli <site> [command...]' )
+			.description( 'Run a CLI command on a given sandbox' )
+			.option( '-y, --yes', 'Are you sure?' )
+			.action( ( site, command, options ) => {
+				// TODO: If options.yes, don't ask for confirmation
+				utils.getSandboxForSite( site, ( err, sandbox ) => {
+					var run = [
+						'exec',
+						'-u', '1001',
+						'-it', sandbox.container_name,
+						'env', 'TERM=xterm',
+					];
+
+					if ( command.length < 1 ) {
+						run.push( 'bash' );
+					} else {
+						run = run.concat( command );
+
+						// TODO: Define this in wp-cli.yml
+						if ( "wp" == command[0] ) {
+							run.push( '--path=/var/www' );
+						}
+					}
+
+					// TODO: Handle file references as arguments
+					spawn( 'docker', run, { stdio: 'inherit' } );
+				});
+			});
 
 		program
 			.command( 'db <site>' )

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -58,6 +58,10 @@ utils.getCredentials( ( err, user ) => {
 			.action( ( site, command, options ) => {
 				// TODO: If options.yes, don't ask for confirmation
 				utils.getSandboxForSite( site, ( err, sandbox ) => {
+					if ( err ) {
+						return console.error( err );
+					}
+
 					var run = [
 						'exec',
 						'-u', '1001',

--- a/src/src/utils.js
+++ b/src/src/utils.js
@@ -136,7 +136,7 @@ var utils = {
 		});
 	},
 	getSandboxForSite: function( site, cb ) {
-		this.findAndConfirmSite( site, site => {
+		this.findSite( site, site => {
 			var api = require( './api' );
 			api
 				.get( '/sandboxes' )

--- a/src/src/utils.js
+++ b/src/src/utils.js
@@ -135,6 +135,30 @@ var utils = {
 			});
 		});
 	},
+	getSandboxForSite: function( site, cb ) {
+		this.findAndConfirmSite( site, site => {
+			var api = require( './api' );
+			api
+				.get( '/sandboxes' )
+				.query({
+					'user_id': api.auth.apiUserId,
+					'client_site_id': site.client_site_id,
+				})
+				.end( ( err, res ) => {
+					if ( err ) {
+						return cb( err );
+					}
+
+					var data = res.body.data;
+
+					if ( ! data || ! data[0] ) {
+						return cb( new Error( 'No sandbox exists for given site' ) );
+					}
+
+					return cb( null, data[0].containers[0] );
+				});
+		});
+	},
 };
 
 module.exports = utils;


### PR DESCRIPTION
Runs a given command on a local container for the site specified.
If a container doesn't exist, output an error.

TODO:
* [x] Option to silence confirmation when we redirect stdout
* [ ] Deal with filenames as parameters

Fixes #28 