### PR TITLE
Use chunked encoding for uploading files

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -96,7 +96,6 @@ program
 										headers:  {
 											'X-Client-Site-ID': site.client_site_id,
 											'X-Access-Token': access_token,
-											'Content-Length': Buffer.byteLength( data ),
 										}
 									}, res => {
 										bar.tick();


### PR DESCRIPTION
Setting the content length disables the default chunked encoding. Trying to upload a file that is too large causes the files api to prematurely hang up. Fixes #38