### PR TITLE
Files importer: lower memory usage for huge directories

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -49,6 +49,21 @@ program
 
 					var processFiles = function( importing, callback ) {
 						var queue = async.priorityQueue( ( file, cb ) => {
+							// Handle pointers separately - add next 5k files + next pointer if necessary
+							if ( 'ptr:' === file.substring( 0, 4 ) ) {
+								var parts = file.split(':');
+								var offset = parseInt( parts[1] );
+								var file = parts[2];
+
+								return imports.queueDir( file, offset, function( q ) {
+									q.forEach(i => {
+										queue.push( i.item, i.priority );
+									});
+
+									return cb();
+								});
+							}
+
 							async.waterfall([
 								function( cb ) {
 									fs.realpath( file, cb );
@@ -61,20 +76,11 @@ program
 								}
 							], function( err, file, stats ) {
 								if ( stats.isDirectory() ) {
-									var files = fs.readdirSync( file );
+									imports.queueDir( file, 0, function( q ) {
+										q.forEach(i => {
+											queue.push( i.item, i.priority );
+										});
 
-									fs.readdir( file, ( err, files ) => {
-										if ( files.length > 10000 ) {
-											// TODO: Limit queue size to 5k-ish (if there are less than 10000 items, don't both)
-											// 1. Insert first 5k items
-											// 2. Insert dummy file/pointer to 5K+1 (lower priority than files, higher priority than directories)
-											// 3. Handle pointers separately - add next 5k files + next pointer if necessary
-										}
-
-										files = files.map( f => file + '/' + f );
-
-										var depth = file.split( '/' ).length;
-										queue.push( files, 0 - depth );
 										return cb();
 									});
 								} else if ( stats.isFile() ) {

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -55,6 +55,7 @@ program
 								var offset = parseInt( parts[1] );
 								var file = parts[2];
 
+								// Queue next batch of files in this directory
 								return imports.queueDir( file, offset, function( q ) {
 									q.forEach(i => {
 										queue.push( i.item, i.priority );
@@ -76,6 +77,7 @@ program
 								}
 							], function( err, file, stats ) {
 								if ( stats.isDirectory() ) {
+									// Init directory queueing with offset=0
 									imports.queueDir( file, 0, function( q ) {
 										q.forEach(i => {
 											queue.push( i.item, i.priority );

--- a/src/src/import.js
+++ b/src/src/import.js
@@ -43,8 +43,10 @@ module.exports = {
 
 			// Queue next 5k files
 			files = files.slice( offset, offset + 5000 );
-			files = files.map(f => dir + '/' + f);
 			offset += 5000;
+
+			// Queue files with absolute path
+			files = files.map(f => dir + '/' + f);
 
 			var ptr = 'ptr:' + offset + ':' + dir;
 			return cb([
@@ -53,6 +55,7 @@ module.exports = {
 					item: files
 				},
 				{
+					// Process the pointer after this batch of files
 					priority: priority + 1,
 					item: ptr
 				}

--- a/src/src/import.js
+++ b/src/src/import.js
@@ -25,5 +25,38 @@ module.exports = {
 			req.write( data );
 			req.end();
 		});
+	},
+	queueDir: function( dir, offset, cb ) {
+		var priority = 0 - dir.split( '/' ).length;
+
+		fs.readdir( dir, ( err, files ) => {
+			if ( files.length - offset < 10000 ) {
+				// If there are less than 2 full rounds of files left, just do them all now
+				files = files.slice( offset, offset + 10000 );
+				files = files.map(f => dir + '/' + f);
+
+				return cb([{
+					item: files,
+					priority: priority
+				}]);
+			}
+
+			// Queue next 5k files
+			files = files.slice( offset, offset + 5000 );
+			files = files.map(f => dir + '/' + f);
+			offset += 5000;
+
+			var ptr = 'ptr:' + offset + ':' + dir;
+			return cb([
+				{
+					priority: priority,
+					item: files
+				},
+				{
+					priority: priority + 1,
+					item: ptr
+				}
+			]);
+		});
 	}
 };


### PR DESCRIPTION
When a single directory has tons of images, we have to avoid putting
every file in the queue at the same time. In the extreme case, a site
could have all files in the same directory, which results in a list of
all files being stored in RAM.

This addresses that by only putting 5k files at a time in the queue to
process. If there are more than that, we add the first 5k files and a
placeholder to be processed after that. When we get to the placeholder,
we read the directory list again and add the next 5k files until all
files have been processed. This adds approximately N/5000 more disk
operations, but can significantly reduce RAM usage.

The 5000 limit was just a guess. We can adjust that if necessary.

Note: While this effectively addresses the problem of a few directories
with lots (> 50k) of files, RAM usage will likely still be pretty high
if there are many directories with lots of files each, though lower than
it would be without this fix.