### PR TITLE
Cleanup Round 2

### DIFF
--- a/src/bin/vip-api.js
+++ b/src/bin/vip-api.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-var program = require( 'commander' );
-var querystring = require('querystring');
+const program = require( 'commander' );
+const querystring = require('querystring');
 
 // Ours
-var api = require( '../lib/api' );
+const api = require( '../lib/api' );
 
 function parseData(d) {
 	try {
@@ -63,7 +63,6 @@ program
 	});
 
 program.parse( process.argv );
-
 if ( ! process.argv.slice( 2 ).length ) {
 	program.outputHelp();
 }

--- a/src/bin/vip-cli.js
+++ b/src/bin/vip-cli.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const program = require('commander');
+const spawn = require('child_process').spawn;
+
+// Ours
+const utils = require('../lib/utils');
+
+program
+	.arguments( 'cli <site> [command...]' )
+	.action( ( site, command, options ) => {
+		utils.getSandboxForSite( site, ( err, sandbox ) => {
+			if ( err ) {
+				return console.error( err );
+			}
+
+			var run = [
+				'exec',
+				'-u', '1001',
+				'-it', sandbox.container_name,
+				'env', 'TERM=xterm',
+			];
+
+			if ( command.length < 1 ) {
+				run.push( 'bash' );
+			} else {
+				run = run.concat( command );
+
+				// TODO: Define this in wp-cli.yml
+				if ( "wp" == command[0] ) {
+					run.push( '--path=/var/www' );
+				}
+			}
+
+			// TODO: Handle file references as arguments
+			spawn( 'docker', run, { stdio: 'inherit' } );
+		});
+	});
+
+program.parse(process.argv);
+if ( ! process.argv.slice( 2 ).length ) {
+	program.help();
+}

--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const program = require('commander');
+const promptly = require( 'promptly' );
+const which = require( 'which' );
+
+// Ours
+const api = require('../lib/api');
+const db = require( '../lib/db' );
+const utils = require('../lib/utils');
+
+program
+	.arguments( '<site>' )
+	.action( ( site, options ) => {
+		try {
+			var mysql_exists = which.sync( 'mysql' );
+		} catch (e) {
+			return console.error( 'MySQL client is required and not installed.' );
+		}
+
+		utils.findSite( site, ( err, s ) => {
+			if ( err ) {
+				return console.error( err );
+			}
+
+			if ( ! s ) {
+				return console.error( "Couldn't find site:", site );
+			}
+
+			if ( ! require('tty').isatty(1) ) {
+				console.log( '-- Site:', s.client_site_id );
+				console.log( '-- Domain:', s.domain_name );
+				console.log( '-- Environment:', s.environment_name );
+				return db.exportDB( s, err => {
+					if ( err ) {
+						return console.error( err );
+					}
+				});
+			}
+
+			var ays = s.environment_name == "production" ? 'This is the database for PRODUCTION. Are you sure?' : 'Are you sure?';
+			console.log( "Client Site:", s.client_site_id );
+			console.log( "Primary Domain:", s.domain_name );
+			console.log( "Environment:", s.environment_name );
+			promptly.confirm( ays, ( err, t ) => {
+				if ( err ) {
+					return console.error( err );
+				}
+
+				if ( ! t ) {
+					return;
+				}
+
+				return db.getCLI( s, err => {
+					if ( err ) {
+						return console.error( err );
+					}
+				});
+			});
+		});
+	});
+
+program.parse(process.argv);
+if ( ! process.argv.slice( 2 ).length ) {
+	program.help();
+}

--- a/src/bin/vip-deploy.js
+++ b/src/bin/vip-deploy.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const program = require( 'commander' );
+
+// Ours
+const api = require( '../lib/api' );
+
+program
+	.arguments( '<site> <sha>' )
+	.action( ( site, sha, options ) => {
+		api
+			.post('/sites/' + site + '/revisions/' + sha + '/deploy' )
+			.end( err => {
+				if (err) {
+					console.error(err.response.error)
+				}
+			})
+	})
+
+program.parse( process.argv );
+if ( ! process.argv.slice( 2 ).length ) {
+	program.help();
+}

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -160,6 +160,7 @@ program
 
 program
 	.command( 'sql <site> <file>' )
+	.alias( 'database' )
 	.description( 'Import SQL to a VIP Go site' )
 	.action( ( site, file ) => {
 		try {
@@ -175,22 +176,21 @@ program
 				}
 
 				api
-				.post( '/sites/' + site.client_site_id + '/wp-cli' )
-				.send({
-					command: "cache",
-					args: [ "flush" ],
-					namedvars: {
-						"skip-plugins": true,
-						"skip-themes": true,
-					},
-				})
-				.end();
+					.post( '/sites/' + site.client_site_id + '/wp-cli' )
+					.send({
+						command: "cache",
+						args: [ "flush" ],
+						namedvars: {
+							"skip-plugins": true,
+							"skip-themes": true,
+						},
+					})
+					.end();
 			});
 		});
 	});
 
-	program.parse( process.argv );
-
-	if ( ! process.argv.slice( 2 ).length ) {
-		program.outputHelp();
-	}
+program.parse( process.argv );
+if ( ! process.argv.slice( 2 ).length ) {
+	program.outputHelp();
+}

--- a/src/bin/vip-login.js
+++ b/src/bin/vip-login.js
@@ -1,14 +1,13 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
-var program = require('commander');
-var promptly = require( 'promptly' );
-var async    = require( 'async' );
+const program = require('commander');
+const promptly = require( 'promptly' );
+const async    = require( 'async' );
 
 // Ours
-var utils = require( '../lib/utils' );
+const utils = require( '../lib/utils' );
 
-program
-	.parse( process.argv );
+program.parse( process.argv );
 
 utils.getCredentials( ( err, user ) => {
 	var userprompt = user && user.userId ? 'User ID (' + user.userId + '):' : 'User ID:';

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 /**
  * The command line vip tool
@@ -6,17 +6,13 @@
 
 process.title = 'vip';
 
-var program = require( 'commander' );
-var promptly = require( 'promptly' );
-var tab = require( 'tabtab' )({ name: 'vip' });
-var which = require( 'which' );
-const spawn = require('child_process').spawn;
+const program = require( 'commander' );
+const tab = require( 'tabtab' )({ name: 'vip' });
 
 // Ours
-var packageJSON = require( '../../package.json' );
-var utils = require( '../lib/utils' );
-var api = require( '../lib/api' );
-var db = require( '../lib/db' );
+const packageJSON = require( '../../package.json' );
+const utils = require( '../lib/utils' );
+const api = require( '../lib/api' );
 
 var is_vip = false;
 var noAuth = [
@@ -37,11 +33,11 @@ utils.getCredentials( ( err, user ) => {
 
 	program
 		.version( packageJSON.version )
-		.command( 'login', 'setup an access token to use with the CLI' )
+		.command( 'login', 'Setup an access token to use with the CLI' )
 
 	program
 		.command( 'logout' )
-		.description( 'delete the stored access token' )
+		.description( 'Delete the stored access token' )
 		.action( () => {
 			utils.deleteCredentials();
 		});
@@ -49,138 +45,40 @@ utils.getCredentials( ( err, user ) => {
 	// internal VIP commands
 	if (!!is_vip) {
 		program
-			.command( 'api', 'Authenticated API requests' )
-			.command( 'import', 'import to VIP Go' );
+			.command( 'api <method> <endpoint>', 'Authenticated API requests' )
+			.command( 'cli <site> [command...]', 'Run a CLI command on agiven sandbox' )
+			.command( 'db <site>', 'Connect to a given VIP Go database' )
+			.command( 'deploy <site> <sha>', 'Deploy given git sha' )
+			.command( 'import', 'Import to VIP Go' )
 
-		program
-			.command( 'cli <site> [command...]' )
-			.description( 'Run a CLI command on a given sandbox' )
-			.action( ( site, command, options ) => {
-				utils.getSandboxForSite( site, ( err, sandbox ) => {
-					if ( err ) {
-						return console.error( err );
-					}
-
-					var run = [
-						'exec',
-						'-u', '1001',
-						'-it', sandbox.container_name,
-						'env', 'TERM=xterm',
-					];
-
-					if ( command.length < 1 ) {
-						run.push( 'bash' );
-					} else {
-						run = run.concat( command );
-
-						// TODO: Define this in wp-cli.yml
-						if ( "wp" == command[0] ) {
-							run.push( '--path=/var/www' );
-						}
-					}
-
-					// TODO: Handle file references as arguments
-					spawn( 'docker', run, { stdio: 'inherit' } );
-				});
-			});
-
-		program
-			.command( 'db <site>' )
-			.option( '-e, --export', 'Export the given database to stdout' )
-			.description( 'Connect to a given VIP Go database' )
-			.action( ( site, options ) => {
-				try {
-					var mysql_exists = which.sync( 'mysql' );
-				} catch (e) {
-					return console.error( 'MySQL client is required and not installed.' );
-				}
-
-				utils.findSite( site, ( err, s ) => {
-					if ( err ) {
-						return console.error( err );
-					}
-
-					if ( ! s ) {
-						return console.error( "Couldn't find site:", site );
-					}
-
-					if ( options.export ) {
-						console.log( '-- Site:', s.client_site_id );
-						console.log( '-- Domain:', s.domain_name );
-						console.log( '-- Environment:', s.environment_name );
-						return db.exportDB( s, err => {
-							if ( err ) {
-								return console.error( err );
-							}
-						});
-					}
-
-					var ays = s.environment_name == "production" ? 'This is the database for PRODUCTION. Are you sure?' : 'Are you sure?';
-					console.log( "Client Site:", s.client_site_id );
-					console.log( "Primary Domain:", s.domain_name );
-					console.log( "Environment:", s.environment_name );
-					promptly.confirm( ays, ( err, t ) => {
-						if ( err ) {
-							return console.error( err );
-						}
-
-						if ( ! t ) {
-							return;
-						}
-
-						return db.getCLI( s, err => {
-							if ( err ) {
-								return console.error( err );
-							}
-						});
-					});
-				});
-			});
-
-	program
-		.command( 'deploy <site> <sha>' )
-		.description( 'deploy given git SHA')
-		.action( (site, sha) => {
-			// TODO: Make sha optional, deploy latest
-			// TODO: Take domain name for site
-
+		tab.on( 'deploy', ( data, done ) => {
 			api
-				.post('/sites/' + site + '/revisions/' + sha + '/deploy' )
-				.end( err => {
-					if (err) {
-						console.error(err.response.error)
+				.get( '/search' )
+				.query( 'search', data.lastPartial )
+				.end( ( end, res ) => {
+					if ( err ) {
+						return done( err );
 					}
-				})
-		})
 
-	tab.on( 'deploy', ( data, done ) => {
-		api
-			.get( '/search' )
-			.query( 'search', data.lastPartial )
-			.end( ( end, res ) => {
-				if ( err ) {
-					return done( err );
-				}
+					var mapped, sites = [];
 
-				var mapped, sites = [];
-
-				// Add initial domain to suggestions list
-				sites = res.body.data.map( s => {
-					return s.domain_name;
-				});
-
-				// Add mapped domains to suggestions list
-				for( let i = 0; i < res.body.data.length; i++ ) {
-					mapped = res.body.data[i].mapped_domains.map( d => {
-						return d.domain_name;
+					// Add initial domain to suggestions list
+					sites = res.body.data.map( s => {
+						return s.domain_name;
 					});
 
-					sites = sites.concat( mapped );
-				}
+					// Add mapped domains to suggestions list
+					for( let i = 0; i < res.body.data.length; i++ ) {
+						mapped = res.body.data[i].mapped_domains.map( d => {
+							return d.domain_name;
+						});
 
-				return done( null, sites );
+						sites = sites.concat( mapped );
+					}
+
+					return done( null, sites );
+				});
 			});
-		});
 	}
 
 	// Tab complete top level commands!
@@ -197,7 +95,6 @@ utils.getCredentials( ( err, user ) => {
 	tab.start();
 
 	program.parse( process.argv );
-
 	var cmds = program.commands.map(c => c._name);
 	var subCmd = program.args.pop()._name || process.argv[2];
 


### PR DESCRIPTION
* All sub-commands get their own executable -- keeps vip.js easier to read and maintain
* Use const for all module requires
* Include as much usage information as possible in command definitions

Also: Deprecate --export for `vip db`. You can still use export and
shouldn't notice a difference unless you're trying to see the full
database in your terminal (probably not that useful). Instead, we detect
when stdout is piped and assume you want a mysqldump.