### PR TITLE
Stop unused containers

### DIFF
--- a/src/bin/vip-cli.js
+++ b/src/bin/vip-cli.js
@@ -29,11 +29,11 @@ program
 							return console.error( err );
 						}
 
-						sandbox.runCommand( sbox, command );
+						sandbox.runOnExistingContainer( site, sbox, command );
 					});
 				}
 
-				sandbox.runCommand( sbox, command );
+				sandbox.runOnExistingContainer( site, sbox, command );
 			});
 		});
 	});

--- a/src/bin/vip-sandbox.js
+++ b/src/bin/vip-sandbox.js
@@ -58,36 +58,7 @@ program
 					return console.error( 'Sandbox does not exist for requested site.' );
 				}
 
-				switch( sbox.state ) {
-					case 'stopped':
-						return api
-							.post( '/containers/' + sbox.container_id + '/start' )
-							.end( ( err, res ) => {
-								if ( err ) {
-									return console.error( err );
-								}
-
-								sandbox.waitForRunningSandbox( site, ( err, sbox ) => {
-									sandbox.runCommand( sbox );
-								});
-							});
-					case 'paused':
-						return api
-							.post( '/containers/' + sbox.container_id + '/unpause' )
-							.end( ( err, res ) => {
-								if ( err ) {
-									return console.error( err.response.error );
-								}
-
-								sandbox.waitForRunningSandbox( site, ( err, sbox ) => {
-									sandbox.runCommand( sbox );
-								});
-							});
-					case 'running':
-						return sandbox.runCommand( sbox );
-					default:
-						return console.error( 'Cannot start sandbox for requested site' );
-				}
+				sandbox.runOnExistingContainer( site, sbox );
 			});
 		});
 	});


### PR DESCRIPTION
When you exit a sandbox container, we stop it. The next time you run
a command, we automatically start the stopped container instead of
creating a new one. In the future we can clean up stopped containers
after some time.

Fixes #52 
Depends on #54 