### PR TITLE
Add support for importing .zip and .gz mysql dumps

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -10,6 +10,7 @@ const exec     = require('child_process').exec;
 const escape   = require( 'shell-escape' );
 const which = require( 'which' );
 
+
 // Ours
 const api      = require( '../lib/api' );
 const utils    = require( '../lib/utils' );


### PR DESCRIPTION
Stream the import through gunzip or unzip, depending on the file type.
There may be more reliable ways to determine the compression method.

NOTE: Makes the import progress completely wrong. Not really sure how we
can get an accurate file size without reading the whole file into memory
first, which seems like a waste of time. The data still seems useful
and is accurate for uncompressed files, so I think we should leave it
in place.

Fixes #40