### PR TITLE
Fix sandbox start when sbox file doesn't exist

### DIFF
--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -57,10 +57,8 @@ export function runCommand( container, command ) {
 
 	// TODO: Handle file references as arguments
 	config.get( 'sbox', ( err, list ) => {
-		if ( err ) {
-			if ( err.code !== "ENOENT" ) {
-				return console.error( err );
-			}
+		if ( err && err.code !== "ENOENT" ) {
+			return console.error( err );
 		}
 
 		if ( ! list ) {

--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -58,7 +58,9 @@ export function runCommand( container, command ) {
 	// TODO: Handle file references as arguments
 	config.get( 'sbox', ( err, list ) => {
 		if ( err ) {
-			return console.error( err );
+			if ( err.code !== "ENOENT" ) {
+				return console.error( err );
+			}
 		}
 
 		if ( ! list ) {


### PR DESCRIPTION
Watch for ENOENT and continue with sandbox start when the file doesn't exist.

Fixes #95