### PR TITLE
Separate build script from pre-install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "scripts": {
     "postinstall": "tabtab install --name vip --auto || echo 'Could not install tab completions'",
-    "prepublish": "babel -q src --out-dir=build"
+    "prepublish": "npm run build",
+    "build": "babel -q src --out-dir=build"
   },
   "bin": {
     "vip": "build/bin/vip.js"


### PR DESCRIPTION
Makes development easier/faster to not have to run `npm install` (or the full babel command) all the time.