### PR TITLE
Show info about command we're running on sandbox

### DIFF
--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -39,9 +39,13 @@ program
 			}
 
 			var ays = s.environment_name == "production" ? 'This is the database for PRODUCTION. Are you sure?' : 'Are you sure?';
-			console.log( "Client Site:", s.client_site_id );
-			console.log( "Primary Domain:", s.domain_name );
-			console.log( "Environment:", s.environment_name );
+
+			utils.displayNotice( [
+				'Connecting to database:',
+				`-- Site: ${ s.domain_name } (#${ s.client_site_id })`,
+				'-- Environment: ' + s.environment_name,
+			] );
+
 			promptly.confirm( ays, ( err, t ) => {
 				if ( err ) {
 					return console.error( err );

--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -5,6 +5,7 @@ const colors = require( 'colors/safe' );
 // Ours
 const api = require( './api' );
 const config = require( './config' );
+const utils = require( './utils' );
 
 export function runOnExistingContainer( site, sbox, command ) {
 	switch( sbox.state ) {
@@ -49,30 +50,24 @@ export function runCommand( container, command ) {
 		'env', 'TERM=xterm',
 	];
 
-	let notice = '';
+	const notice = [];
 
 	if ( ! command || command.length < 1 ) {
 		run.push( 'bash' );
 
-		notice = 'Logging in to sandbox container:'
-			+ '\n'
-			+ container.container_name;
+		notice.push( 'Logging in to sandbox:' );
 	} else {
 		run = run.concat( command );
 
-		notice = 'Running command:'
-			+ '\n'
-			+ command
-			+ '\n' + '\n'
-			+ 'On container:'
-			+ '\n'
-			+ container.container_name;
+		notice.push( 'Running command on container:' );
+		notice.push( `-- Command: ${ command }` );
 	}
 
-	if ( notice ) {
-		console.log( '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-' );
-		console.log( notice );
-		console.log( '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-' );
+	if ( notice.length > 0 ) {
+		notice.push( `-- Container: ${ container.container_name }` );
+		notice.push( `-- Site: ${ container.domain_name } (#${ container.client_site_id })` );
+
+		utils.displayNotice( notice );
 	}
 
 	// TODO: Handle file references as arguments

--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -49,10 +49,30 @@ export function runCommand( container, command ) {
 		'env', 'TERM=xterm',
 	];
 
+	let notice = '';
+
 	if ( ! command || command.length < 1 ) {
 		run.push( 'bash' );
+
+		notice = 'Logging in to sandbox container:'
+			+ '\n'
+			+ container.container_name;
 	} else {
 		run = run.concat( command );
+
+		notice = 'Running command:'
+			+ '\n'
+			+ command
+			+ '\n' + '\n'
+			+ 'On container:'
+			+ '\n'
+			+ container.container_name;
+	}
+
+	if ( notice ) {
+		console.log( '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-' );
+		console.log( notice );
+		console.log( '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-' );
 	}
 
 	// TODO: Handle file references as arguments

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -148,3 +148,13 @@ export function mkdirp( dir ) {
 		fs.mkdirSync( dir );
 	}
 }
+
+export function displayNotice( notice ) {
+	if ( ! Array.isArray( notice ) ) {
+		notice = [ notice ];
+	}
+
+	console.log( '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-' );
+	notice.forEach( msg => console.log( msg ) );
+	console.log( '-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-' );
+}


### PR DESCRIPTION
Especially, when we run `sandbox start`, it's not always obvious we've been switched into the sandbox shell. This displays a notice that hopefully helps make that a bit clearer.

```
$ node build/bin/vip.js sandbox start example.com
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
Logging in to sandbox container:
example-com-vipco_web_dev_0001
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
```