### PR TITLE
Standardize alerts for import commands

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -33,7 +33,7 @@ program
 			return console.error( 'Invalid uploads directory. Uploads must be in uploads/' );
 		}
 
-		utils.findAndConfirmSite( site, site => {
+		utils.findAndConfirmSite( site, 'Importing files for site:', site => {
 			api
 				.get( '/sites/' + site.client_site_id + '/meta/files_access_token' )
 				.end( ( err, res ) => {
@@ -177,7 +177,7 @@ program
 			throttle: options.throttle,
 		};
 
-		utils.findAndConfirmSite( site, site => {
+		utils.findAndConfirmSite( site, 'Importing SQL for site:', site => {
 			db.importDB( site, file, opts, err => {
 				if ( err ) {
 					return console.error( err );

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -109,7 +109,7 @@ export function findSite( domain, cb ) {
 		});
 }
 
-export function findAndConfirmSite( site, cb ) {
+export function findAndConfirmSite( site, action, cb ) {
 	findSite( site, ( err, s ) => {
 		if ( err ) {
 			return console.error( err );
@@ -119,9 +119,11 @@ export function findAndConfirmSite( site, cb ) {
 			return console.error( "Couldn't find site:", site );
 		}
 
-		console.log( "Client Site:", s.client_site_id );
-		console.log( "Primary Domain:", s.domain_name );
-		console.log( "Environment:", s.environment_name );
+		displayNotice( [
+			action,
+			`-- Site: ${ s.domain_name } (#${ s.client_site_id })`,
+			'-- Environment: ' + s.environment_name,
+		] );
 
 		promptly.confirm( "Are you sure?", ( err, yes ) => {
 			if ( err ) {


### PR DESCRIPTION
Uses the displayNotice util.

```
$ ./build/bin/vip import files example.com uploads/
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
Importing files for site:
-- Site: example.com (#123)
-- Environment: production
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
Are you sure?

$ ./build/bin/vip.js import sql example.com sql.sql
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
Importing SQL for site:
-- Site: example.com (#123)
-- Environment: production
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
Are you sure?
```