### PR TITLE
Add `site update` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   ],
   "repository": "git@github.com:Automattic/vip-cli.git",
   "license": "MIT",
+  "engines": {
+    "node" : ">=0.12"
+  },
   "scripts": {
     "postinstall": "tabtab install --name vip --auto || echo 'Could not install tab completions'",
     "postuninstall": "./scripts/postuninstall",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "progress": "^1.1.8",
     "promptly": "1.0.0",
     "shell-escape": "^0.2.0",
+    "single-line-log": "^1.1.2",
     "superagent": "^2.0.0",
     "tabtab": "^2.0.0",
     "throttle": "^1.0.3",

--- a/src/bin/vip-site.js
+++ b/src/bin/vip-site.js
@@ -1,0 +1,80 @@
+const program = require( 'commander' );
+const log = require('single-line-log').stdout;
+
+// Ours
+const utils       = require( '../lib/utils' );
+const siteUtils   = require( '../lib/site' );
+const hostUtils   = require( '../lib/host' );
+
+program
+	.command( 'update <site>' )
+	.description( 'Update/Rebuild a site\'s web containers based on DC allocation records or default config' )
+	.action( site => {
+		utils.findSite( site, ( err, site ) => {
+			if ( err ) {
+				return console.error( err );
+			}
+
+			if ( ! site ) {
+				return console.error( 'Specified site does not exist. Try the ID.' );
+			}
+
+			let updateCheckInterval;
+
+			const checkStatus = ( actionId ) => {
+				siteUtils.getContainers( site )
+					.then( containers => {
+						return containers.filter( container => container.container_type_id === 1 ); // WEB = 1
+					} )
+					.then( webContainers => {
+						const hostId = webContainers[0].host_id;
+						hostUtils.getHostAction( hostId, actionId )
+							.then( action => {
+								if ( ! action ) {
+									clearInterval( updateCheckInterval );
+									console.log( '' );
+									console.log( 'Update complate 🎉🎉🎉' );
+									return;
+								}
+
+								const output = [];
+								output.push( `## Container Status (updated ${ new Date().toISOString() }):` );
+
+								webContainers.forEach( container => output.push( `#${ container.container_id } - ${ container.container_name } - ${ container.state }` ) );
+
+								output.push( '' );
+								output.push( '## wp-cli (`core update-db`) Status:' );
+								output.push( `Action #${ action.host_action_id }: ${ action.status }` );
+
+								log( output.join( '\n' ) );
+							} )
+							.catch( err => console.log( 'Failed to get host action: ' + err.message ) );
+					} )
+					.catch( err => console.log( 'Failed to check status: ' + err.message ) );
+			};
+
+			utils.displayNotice( [
+				'Triggering web server update/rebuild:',
+				`-- Site: ${ site.domain_name } (#${ site.client_site_id })`,
+				'-- Environment: ' + site.environment_name,
+			] );
+
+			siteUtils.update( site )
+				.then( data => {
+					console.log( '' );
+					console.log( `${ data.data } (action #${ data.result })` );
+					console.log( '' );
+
+					return data.result;
+				} )
+				.then( actionId => {
+					updateCheckInterval = setInterval( () => checkStatus( actionId ), 2000 );
+				} )
+				.catch( err => console.error( err.message ) );
+		} )
+	} );
+
+program.parse(process.argv);
+if ( ! process.argv.slice( 2 ).length ) {
+	program.help();
+}

--- a/src/bin/vip-site.js
+++ b/src/bin/vip-site.js
@@ -30,13 +30,6 @@ program
 						const hostId = webContainers[0].host_id;
 						hostUtils.getHostAction( hostId, actionId )
 							.then( action => {
-								if ( ! action ) {
-									clearInterval( updateCheckInterval );
-									console.log( '' );
-									console.log( 'Update complete 🎉🎉🎉' );
-									return;
-								}
-
 								const output = [];
 								output.push( `## Container Status (updated ${ new Date().toISOString() }):` );
 
@@ -44,10 +37,21 @@ program
 
 								output.push( '' );
 								output.push( '## wp-cli (`core update-db`) Status:' );
-								output.push( `Action #${ action.host_action_id }: ${ action.status } on host #${ hostId }` );
+
+								if ( action ) {
+									output.push( `Action #${ action.host_action_id }: ${ action.status } on host #${ hostId }` );
+								} else {
+									output.push( `Action #${ actionId }: completed on host #${ hostId }` );
+								}
 								output.push( '' );
 
 								log( output.join( '\n' ) );
+
+								if ( ! action ) {
+									clearInterval( updateCheckInterval );
+									console.log( '' );
+									console.log( 'Update complete 🎉🎉🎉' );
+								}
 							} )
 							.catch( err => console.log( 'Failed to get host action: ' + err.message ) );
 					} )

--- a/src/bin/vip-site.js
+++ b/src/bin/vip-site.js
@@ -33,7 +33,7 @@ program
 								if ( ! action ) {
 									clearInterval( updateCheckInterval );
 									console.log( '' );
-									console.log( 'Update complate 🎉🎉🎉' );
+									console.log( 'Update complete 🎉🎉🎉' );
 									return;
 								}
 
@@ -44,7 +44,8 @@ program
 
 								output.push( '' );
 								output.push( '## wp-cli (`core update-db`) Status:' );
-								output.push( `Action #${ action.host_action_id }: ${ action.status }` );
+								output.push( `Action #${ action.host_action_id }: ${ action.status } on host #${ hostId }` );
+								output.push( '' );
 
 								log( output.join( '\n' ) );
 							} )

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -61,6 +61,7 @@ utils.getCredentials( ( err, user ) => {
 			program
 				.command( 'sandbox <action> <site>', 'Maintain sandbox containers' )
 				.command( 'stacks <action>', 'Maintain software stacks on the current host' )
+				.command( 'site <action>', 'Perform actions on a site' )
 		}
 
 		tab.on( 'deploy', ( data, done ) => {

--- a/src/lib/host.js
+++ b/src/lib/host.js
@@ -1,0 +1,19 @@
+// Ours
+const api = require( '../lib/api' );
+
+export function getHostAction( hostId, actionId ) {
+	return new Promise( ( resolve, reject ) => {
+		api
+			.get( '/hosts/' + hostId + '/actions/' + actionId )
+			.end( ( err, res ) => {
+				if ( err ) {
+					if ( 404 != err.status ) {
+						return reject( new Error( 'Failed to get host action: ' + err.response.error ) );
+					}
+					return resolve( null );
+				}
+
+				return resolve( res.body.data[0] );
+			} );
+	} );
+}

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,0 +1,43 @@
+// Ours
+const api = require( '../lib/api' );
+
+export function update( site ) {
+	return new Promise( ( resolve, reject ) => {
+		api
+			.post( '/actions/' + site.client_site_id + '/upgrade_wp' )
+			.end( ( err, res ) => {
+				if ( err ) {
+					let message = err.response.error;
+					if ( err.response.body ) {
+						message += ' | ' + err.response.body.message;
+					}
+
+					return reject( new Error( message ) );
+				}
+
+				if ( ! res.body || 'success' !== res.body.status ) {
+					return reject( new Error( 'Failed to create rebuild/upgrade actions for site' ) );
+				}
+
+				return resolve( res.body );
+		} );
+	} );
+}
+
+export function getContainers( site ) {
+	return new Promise( ( resolve, reject ) => {
+		api
+			.get( '/sites/' + site.client_site_id + '/containers' )
+			.end( ( err, res ) => {
+				if ( err ) {
+					return reject( err.response.error );
+				}
+
+				if ( ! res.body || 'success' !== res.body.status ) {
+					return reject( new Error( 'Failed to fetch containers for site.' ) );
+				}
+
+				return resolve( res.body.data );
+			} );
+	} );
+}


### PR DESCRIPTION
Triggers an `upgrade_wp` action for the given site and provides progress on container state throughout.

```
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
Triggering web server update/rebuild:
-- Site: example.com (#309)
-- Environment: production
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

Successfully created wp upgrade host action for site 123 (action #123456)

## Container Status (updated 2017-01-11T19:33:38.406Z):
#10006 - example-comgo-vipco_web_0004 - running
#10007 - example-comgo-vipco_web_0005 - running

## wp-cli Status:
Action #123456: queued
Update complate 🎉🎉🎉
```

We wait for the `core update-db` host action to complete as the signal that we're done. The `Container Status` and `wp-cli Status` sections update throughout the process.