### PR TITLE
Use single-line-log on `vip stacks update` output.

### DIFF
--- a/src/bin/vip-stacks.js
+++ b/src/bin/vip-stacks.js
@@ -1,4 +1,5 @@
 const program = require( 'commander' );
+const log = require( 'single-line-log' ).stdout;
 
 // Ours
 const api = require( '../lib/api' );
@@ -41,7 +42,7 @@ program
 										return;
 									}
 
-									console.log( 'Updating software stacks. status: ', res.body.data[0].status  );
+									log( 'Software Stack update: ' + res.body.data[0].status + "\n" );
 								});
 						}, 1000 );
 					});


### PR DESCRIPTION
Instead of repeatedly printing the same thing on a new line, we
can use single-line-log to update a single line.