### PR TITLE
wp bulk upgrade initial commit

### DIFF
--- a/src/bin/vip-site.js
+++ b/src/bin/vip-site.js
@@ -12,7 +12,10 @@ const hostUtils   = require( '../lib/host' );
 program
 	.command( 'upgrade' )
 	.description( 'Update/Rebuild a site\'s web containers based on DC allocation records or default config' )
-	.option( '-s, --pagesize <pagesize>', 'Number of sites to update per batch', 5, parseInt )
+	.option( '-c, --client <client_id>', 'Client to target' )
+	.option( '-l, --launched', 'Target launched sites only?' )
+	.option( '-s, --search <search>', 'Search for sites to upgrade' )
+	.option( '-n, --pagesize <pagesize>', 'Number of sites to update per batch', 5, parseInt )
 	.option( '-e, --environment <env>', 'Environment to target' )
 	.option( '-w, --wp <version>', 'WordPress version to target' )
 	.action( ( options ) => {
@@ -29,6 +32,18 @@ program
 
 			if ( options.wp ) {
 				query.wp = options.wp;
+			}
+
+			if ( options.client ) {
+				query.client_id = options.client;
+			}
+
+			if ( options.launched ) {
+				query.launched = 1;
+			}
+
+			if ( options.search ) {
+				query.search = options.search;
 			}
 
 			utils.displayNotice( [

--- a/src/bin/vip-site.js
+++ b/src/bin/vip-site.js
@@ -8,6 +8,46 @@ const utils       = require( '../lib/utils' );
 const siteUtils   = require( '../lib/site' );
 const hostUtils   = require( '../lib/host' );
 
+
+program
+	.command( 'upgrade' )
+	.description( 'Update/Rebuild a site\'s web containers based on DC allocation records or default config' )
+	.option( '-s, --pagesize <pagesize>', 'Number of sites to update per batch', 5, parseInt )
+	.option( '-e, --environment <env>', 'Environment to target' )
+	.option( '-w, --wp <version>', 'WordPress version to target' )
+	.action( ( options ) => {
+			// TODO: Optionally pass in a site ID for single site upgrade
+			let query = {};
+
+			if ( options.pagesize ) {
+				query.pagesize = options.pagesize;
+			}
+
+			if ( options.environment ) {
+				query.environment_name = options.environment;
+			}
+
+			if ( options.wp ) {
+				query.wp = options.wp;
+			}
+
+			utils.displayNotice( [
+				'Triggering web server update/rebuild:',
+				query,
+			] );
+
+			// TODO: Return host action IDs in api response so we can poll them
+			siteUtils.update( null, query )
+				.then( data => {
+					console.log( data.sites );
+					return data.sites.map( d => d.domain_name );
+				})
+				.then( ids => {
+					console.log( ids );
+				})
+				.catch( err => console.error( err.message ) );
+	});
+
 program
 	.command( 'search <query>' )
 	.description( 'Search sites' )

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,10 +1,18 @@
 // Ours
 const api = require( '../lib/api' );
 
-export function update( site ) {
+export function update( site, opts ) {
+	opts = opts || {};
+	site = site || {};
+
+	let url = Object.keys( opts ).length > 0 ?
+		`/actions/upgrade_wp` :
+		`/actions/${site.client_site_id}/upgrade_wp`;
+
 	return new Promise( ( resolve, reject ) => {
 		api
-			.post( '/actions/' + site.client_site_id + '/upgrade_wp' )
+			.post( url )
+			.query( opts )
 			.end( ( err, res ) => {
 				if ( err ) {
 					let message = err.response.error;


### PR DESCRIPTION
Named `vip site upgrade` for now to avoid collision with existing site
update command. For now it just starts upgrades and lists the sites.
Eventually we need to list the related host actions in the API so that
we can easily poll them. We can also optionally take a site ID and use
the same command for single-site upgrades as well as bulk upgrades.