### PR TITLE
Handle invalid config in config files

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -3,8 +3,10 @@ const fs = require( 'fs' );
 const dir = require( 'os' ).homedir() + '/.vip-cli';
 
 export function get( file, callback ) {
+	let data = {};
+
 	try {
-		var data = fs.readFileSync( dir + '/' + file, 'utf8' );
+		data = fs.readFileSync( dir + '/' + file, 'utf8' );
 	} catch (e) {
 		return callback( e );
 	}
@@ -12,6 +14,9 @@ export function get( file, callback ) {
 	try {
 		data = JSON.parse( data );
 	} catch (e) {
+		if ( e.name === 'SyntaxError' ) {
+			return callback( null, {} );
+		}
 		return callback( e );
 	}
 
@@ -21,15 +26,9 @@ export function get( file, callback ) {
 export function set( file, update = {}, callback ) {
 	callback = callback || function() {};
 
-	fs.readFile( dir + '/' + file, ( err, data ) => {
+	get( file, ( err, data ) => {
 		if ( err ) {
 			data = {}
-		} else {
-			try {
-				data = JSON.parse( data )
-			} catch (e) {
-				return callback( e );
-			}
 		}
 
 		data = Object.assign( data, update );


### PR DESCRIPTION
If a config file has invalid data, we end up failing spectacularly. Better handle those cases by watching for SyntaxErrors.

Fixes #122 