### PR TITLE
vip sandbox: Run as `nobody`

### DIFF
--- a/src/bin/vip-sandbox.js
+++ b/src/bin/vip-sandbox.js
@@ -42,6 +42,7 @@ program
 program
 	.command( 'start <site>' )
 	.description( 'Start a sandbox and switch you to the container namespace' )
+	.option( '-r, --root', 'Start sandbox as root' )
 	.action( site => {
 		utils.findSite( site, ( err, site ) => {
 			if ( err ) {

--- a/src/bin/vip-sandbox.js
+++ b/src/bin/vip-sandbox.js
@@ -43,7 +43,7 @@ program
 	.command( 'start <site>' )
 	.description( 'Start a sandbox and switch you to the container namespace' )
 	.option( '-r, --root', 'Start sandbox as root' )
-	.action( site => {
+	.action( ( site, options ) => {
 		utils.findSite( site, ( err, site ) => {
 			if ( err ) {
 				return console.error( err );
@@ -51,6 +51,11 @@ program
 
 			if ( ! site ) {
 				return console.error( 'Specified site does not exist. Try the ID.' );
+			}
+
+			var opts = {};
+			if ( options.root ) {
+				opts.user = 'root';
 			}
 
 			sandbox.getSandboxForSite( site, ( err, sbox ) =>  {
@@ -64,11 +69,11 @@ program
 							return console.error( err );
 						}
 
-						sandbox.runOnExistingContainer( site, sbox );
+						sandbox.runOnExistingContainer( site, sbox, null, opts );
 					});
 				}
 
-				sandbox.runOnExistingContainer( site, sbox );
+				sandbox.runOnExistingContainer( site, sbox, null, opts );
 			});
 		});
 	});

--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -43,9 +43,14 @@ export function runOnExistingContainer( site, sbox, command ) {
 	});
 }
 
-export function runCommand( container, command ) {
+export function runCommand( container, command, opts ) {
+	opts = Object.assign( opts || {}, {
+		'user': 'nobody',
+	});
+
 	var run = [
 		'exec',
+		'--user', opts.user,
 		'-it', container.container_name,
 		'env', 'TERM=xterm',
 	];

--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -8,7 +8,9 @@ const api = require( './api' );
 const config = require( './config' );
 const utils = require( './utils' );
 
-export function runOnExistingContainer( site, sbox, command ) {
+export function runOnExistingContainer( site, sbox, command, opts ) {
+	opts = opts || {};
+
 	maybeStateTransition( site, state => {
 		switch( state ) {
 		case 'stopped':
@@ -20,7 +22,7 @@ export function runOnExistingContainer( site, sbox, command ) {
 					}
 
 					waitForRunningSandbox( site, ( err, sbox ) => {
-						runCommand( sbox, command );
+						runCommand( sbox, command, opts );
 					});
 				});
 		case 'paused':
@@ -32,11 +34,11 @@ export function runOnExistingContainer( site, sbox, command ) {
 					}
 
 					waitForRunningSandbox( site, ( err, sbox ) => {
-						runCommand( sbox, command );
+						runCommand( sbox, command, opts );
 					});
 				});
 		case 'running':
-			return runCommand( sbox, command );
+			return runCommand( sbox, command, opts );
 		default:
 			return console.error( 'Cannot start sandbox for requested site' );
 		}
@@ -44,9 +46,9 @@ export function runOnExistingContainer( site, sbox, command ) {
 }
 
 export function runCommand( container, command, opts ) {
-	opts = Object.assign( opts || {}, {
+	opts = Object.assign({
 		'user': 'nobody',
-	});
+	}, opts || {});
 
 	var run = [
 		'exec',


### PR DESCRIPTION
So we don't have to pass `--allow--root` to every wp-cli command.

Historically it's intentionally impossible to define allow-root in
a config file (https://github.com/wp-cli/wp-cli/issues/1838). Maybe
needs to be reconsidered in Docker containers, but for now let's run
as `nobody` by default.