### PR TITLE
Check if import file exists

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -228,6 +228,7 @@ program
 program
 	.command( 'sql <site> <file>' )
 	.alias( 'database' )
+	.alias( 'db' )
 	.description( 'Import SQL to a VIP Go site' )
 	.option( '-t, --throttle <mb>', 'SQL import transfer limit in MB/s', 1, parseFloat )
 	.action( ( site, file, options ) => {
@@ -240,6 +241,12 @@ program
 		var opts = {
 			throttle: options.throttle,
 		};
+
+		try {
+			var stats = fs.lstatSync( file );
+		} catch( e ) {
+			return console.error( 'Failed to get import file (%s) due to the following error:\n%s', file, e.message );
+		}
 
 		utils.findAndConfirmSite( site, 'Importing SQL for site:', site => {
 			db.importDB( site, file, opts, err => {


### PR DESCRIPTION
Throw and error and bail if it doesn't.

```
build/bin/vip.js import db ellaminnowpea.xyz file.js
Failed to get import file (file.js) due to the following error:
ENOENT: no such file or directory, lstat 'file.js'
```

Fixes #137