### PR TITLE
Fix file exporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "node-pv": "^0.1.5",
     "progress": "^1.1.8",
     "promptly": "1.0.0",
+    "request": "^2.79.0",
     "shell-escape": "^0.2.0",
     "single-line-log": "^1.1.2",
     "superagent": "^2.0.0",

--- a/src/bin/vip-files.js
+++ b/src/bin/vip-files.js
@@ -6,6 +6,7 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 const async = require( 'async' );
 const progress = require( 'progress' );
+const request = require( 'request' );
 
 // Ours
 const api = require( '../lib/api' );
@@ -60,15 +61,10 @@ program
 										},
 									};
 
-									https.get( filedata, download => {
-										download.pipe( newFile );
-										download.on( 'end', () => {
-											bar.tick();
-											newFile.close( callback );
-										}).on( 'error', err => {
-											fs.unlink( dest );
-											callback( err );
-										});
+									var url = 'https://' + site.domain_name + file.file_path;
+									request.get( url ).pipe( newFile ).on( 'close', () => {
+										bar.tick();
+										callback();
 									});
 								}, err => cb( err ) );
 							});

--- a/src/bin/vip-files.js
+++ b/src/bin/vip-files.js
@@ -51,16 +51,6 @@ program
 									utils.mkdirp( dir );
 									var newFile = fs.createWriteStream( dest );
 
-									// Download the file
-									var filedata = {
-										host: 'files.vipv2.net',
-										servername: 'files.vipv2.net',
-										path: file.file_path,
-										headers: {
-											'Host': site.domain_name,
-										},
-									};
-
 									var url = 'https://' + site.domain_name + file.file_path;
 									request.get( url ).pipe( newFile ).on( 'close', () => {
 										bar.tick();


### PR DESCRIPTION
The file exporter was having some problems downloading partial files.
Adding the request library to take care of this. It would be nice if we
could use superagent, but we already tried that and it doesn't seem to
work :( Maybe we should switch to request for everything?

Fixes #140