### PR TITLE
Fix incomplete file downloads

### DIFF
--- a/src/bin/vip-files.js
+++ b/src/bin/vip-files.js
@@ -65,7 +65,7 @@ program
 										download.on( 'end', () => {
 											bar.tick();
 											callback();
-										});
+										}).on( 'error', callback );
 									});
 								}, err => cb( err ) );
 							});

--- a/src/bin/vip-files.js
+++ b/src/bin/vip-files.js
@@ -64,10 +64,7 @@ program
 										download.pipe( newFile );
 										download.on( 'end', () => {
 											bar.tick();
-											newFile.close( callback );
-										}).on( 'error', err => {
-											fs.unlink( dest );
-											callback( err );
+											callback();
 										});
 									});
 								}, err => cb( err ) );


### PR DESCRIPTION
Don't prematurely close the destination file. Since we're piping the
http stream to the writeStream, the file should automatically be closed.

Fixes #140