### PR TITLE
Add basic site search command

### DIFF
--- a/src/bin/vip-site.js
+++ b/src/bin/vip-site.js
@@ -1,10 +1,47 @@
 const program = require( 'commander' );
 const log = require( 'single-line-log' ).stdout;
+const Table = require( 'cli-table' );
 
 // Ours
+const api         = require( '../lib/api' );
 const utils       = require( '../lib/utils' );
 const siteUtils   = require( '../lib/site' );
 const hostUtils   = require( '../lib/host' );
+
+program
+	.command( 'search <query>' )
+	.description( 'Search sites' )
+	.action( query => {
+		api.get( '/sites' )
+			.query({ 'search': query, pagesize: 10 })
+			.end( ( err, res ) => {
+				if ( err ) {
+					return console.error( err.response.error );
+				}
+
+				var table = new Table({
+					head: [
+						'ID',
+						'Name',
+						'Domain',
+					],
+					style: {
+						head: ['blue'],
+					},
+				});
+
+				res.body.data.forEach( s => {
+					table.push( [
+						s.client_site_id,
+						s.name || s.domain_name,
+						s.primary_domain.domain_name,
+					] );
+				});
+
+				console.log( table.toString() );
+				console.log( res.body.result + ' of ' + res.body.totalrecs + ' results.' );
+			});
+	});
 
 program
 	.command( 'update <site>' )


### PR DESCRIPTION
Slowly chipping away at the reasons I need to switch over to the admin console.

I somewhat often have to load the admin console to search for a site -- maybe to find the exact spelling of a site name or to get the site ID for searching through logs.

This is pretty basic for now. It just include the ID, Name, and Primary Domain Name of first 10 search results. Over time we can add filters and optionally output more fields. Would also be nice to standardize formatting across the various `list` commands per https://github.com/Automattic/vip-cli/issues/117