### PR TITLE
Wait for transitioning containers

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -171,5 +171,5 @@ export function showLoading( msg ) {
 	const loading = loadingSprite[ loadingIndex ];
 	loadingIndex++;
 
-	log( `${ msg } ${ loading }` );
+	log( `${ msg } ${ loading }\n` );
 }


### PR DESCRIPTION
Instead of a message that transitioning containers cannot be actioned
on, we can poll the container state and take action when they're ready.