### PR TITLE
Importer: Always use 'fast' mode for new sites.

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -13,6 +13,7 @@ const api      = require( '../lib/api' );
 const utils    = require( '../lib/utils' );
 const db = require( '../lib/db' );
 const imports = require( '../lib/import' );
+const files = require( '../lib/files' );
 
 function list( v ) {
 	return v.split( ',' );
@@ -97,167 +98,176 @@ program
 		}
 
 		utils.findAndConfirmSite( site, 'Importing files for site:', site => {
-			api
-				.get( '/sites/' + site.client_site_id + '/meta/files_access_token' )
-				.end( ( err, res ) => {
-					if ( err ) {
-						return console.error( err.response.error );
+			files.list( site, { 'pagesize': 1 })
+				.then( res => res.totalrecs )
+				.then( total => {
+					if ( total < 100 ) {
+						options.fast = true;
 					}
 
-					if ( ! res.body || ! res.body.data || ! res.body.data[0] || ! res.body.data[0].meta_value ) {
-						return console.error( 'Could not get files access token' );
-					}
-
-					var access_token = res.body.data[0].meta_value;
-					var bar, filecount = 0;
-					var logfile = `/tmp/import-${site.client_site_id}-${Date.now()}.log`;
-					var extensions = fs.createWriteStream( logfile + '.ext' );
-					var intermediates = fs.createWriteStream( logfile + '.int' );
-
-					var processFiles = function( importing, callback ) {
-						var queue = async.priorityQueue( ( file, cb ) => {
-							// Handle pointers separately - add next 5k files + next pointer if necessary
-							if ( 'ptr:' === file.substring( 0, 4 ) ) {
-								var parts = file.split( ':' );
-								var offset = parseInt( parts[1] );
-
-								file = parts[2];
-
-								// Queue next batch of files in this directory
-								return imports.queueDir( file, offset, function( q ) {
-									q.forEach( i => {
-										queue.push( i.item, i.priority );
-									});
-
-									return cb();
-								});
+					api
+						.get( '/sites/' + site.client_site_id + '/meta/files_access_token' )
+						.end( ( err, res ) => {
+							if ( err ) {
+								return console.error( err.response.error );
 							}
 
-							async.waterfall( [
-								function( cb ) {
-									fs.realpath( file, cb );
-								},
+							if ( ! res.body || ! res.body.data || ! res.body.data[0] || ! res.body.data[0].meta_value ) {
+								return console.error( 'Could not get files access token' );
+							}
 
-								function( file, cb ) {
-									fs.lstat( file, function( err, stats ) {
-										cb( err, file, stats );
-									});
-								},
-							], function( err, file, stats ) {
-								if ( err ) {
-									return cb( err );
-								} else if ( stats.isDirectory() ) {
-									// Init directory queueing with offset=0
-									imports.queueDir( file, 0, function( q ) {
-										q.forEach( i => {
-											queue.push( i.item, i.priority );
+							var access_token = res.body.data[0].meta_value;
+							var bar, filecount = 0;
+							var logfile = `/tmp/import-${site.client_site_id}-${Date.now()}.log`;
+							var extensions = fs.createWriteStream( logfile + '.ext' );
+							var intermediates = fs.createWriteStream( logfile + '.int' );
+
+							var processFiles = function( importing, callback ) {
+								var queue = async.priorityQueue( ( file, cb ) => {
+									// Handle pointers separately - add next 5k files + next pointer if necessary
+									if ( 'ptr:' === file.substring( 0, 4 ) ) {
+										var parts = file.split( ':' );
+										var offset = parseInt( parts[1] );
+
+										file = parts[2];
+
+										// Queue next batch of files in this directory
+										return imports.queueDir( file, offset, function( q ) {
+											q.forEach( i => {
+												queue.push( i.item, i.priority );
+											});
+
+											return cb();
 										});
-
-										return cb();
-									});
-								} else if ( stats.isFile() ) {
-									var filepath = file.split( 'uploads' );
-									var ext      = file.split( '.' );
-
-									ext = ext[ ext.length - 1 ];
-
-									if ( ! ext || ( options.types.indexOf( ext.toLowerCase() ) < 0 && options.extraTypes.indexOf( ext.toLowerCase() ) < 0 ) ) {
-										return extensions.write( file + '\n', cb );
 									}
 
-									if ( ! options.intermediate && /-\d+x\d+\.\w{3,4}$/.test( file ) ) {
-										return intermediates.write( file + '\n', cb );
-									}
+									async.waterfall( [
+										function( cb ) {
+											fs.realpath( file, cb );
+										},
 
-									if ( ! filepath[1] ) {
-										return cb( new Error( 'Invalid file path. Files must be in uploads/ directory.' ) );
-									}
+										function( file, cb ) {
+											fs.lstat( file, function( err, stats ) {
+												cb( err, file, stats );
+											});
+										},
+									], function( err, file, stats ) {
+										if ( err ) {
+											return cb( err );
+										} else if ( stats.isDirectory() ) {
+											// Init directory queueing with offset=0
+											imports.queueDir( file, 0, function( q ) {
+												q.forEach( i => {
+													queue.push( i.item, i.priority );
+												});
 
-									if ( ! importing ) {
-										filecount++;
+												return cb();
+											});
+										} else if ( stats.isFile() ) {
+											var filepath = file.split( 'uploads' );
+											var ext      = file.split( '.' );
 
-										if ( 0 === filecount % 10000 ) {
-											console.log( filecount );
-										}
+											ext = ext[ ext.length - 1 ];
 
-										return cb();
-									}
+											if ( ! ext || ( options.types.indexOf( ext.toLowerCase() ) < 0 && options.extraTypes.indexOf( ext.toLowerCase() ) < 0 ) ) {
+												return extensions.write( file + '\n', cb );
+											}
 
-									if ( options.fast ) {
-										bar.tick();
-										return imports.upload( site, file, access_token, cb );
-									} else {
-										request
-											.get( 'https://files.vipv2.net/wp-content/uploads' + filepath[1] )
-											.set({ 'X-Client-Site-ID': site.client_site_id })
-											.set({ 'X-Access-Token': access_token })
-											.set({ 'X-Action': 'file_exists' })
-											.timeout( 2000 )
-											.end( err => {
-												bar.tick();
+											if ( ! options.intermediate && /-\d+x\d+\.\w{3,4}$/.test( file ) ) {
+												return intermediates.write( file + '\n', cb );
+											}
 
-												if ( err && err.status === 404 ) {
-													return imports.upload( site, file, access_token, cb );
+											if ( ! filepath[1] ) {
+												return cb( new Error( 'Invalid file path. Files must be in uploads/ directory.' ) );
+											}
+
+											if ( ! importing ) {
+												filecount++;
+
+												if ( 0 === filecount % 10000 ) {
+													console.log( filecount );
 												}
 
-												return cb( err );
-											});
-									}
-								} else {
-									return cb();
+												return cb();
+											}
+
+											if ( options.fast ) {
+												bar.tick();
+												return imports.upload( site, file, access_token, cb );
+											} else {
+												request
+												.get( 'https://files.vipv2.net/wp-content/uploads' + filepath[1] )
+												.set({ 'X-Client-Site-ID': site.client_site_id })
+												.set({ 'X-Access-Token': access_token })
+												.set({ 'X-Action': 'file_exists' })
+												.timeout( 2000 )
+												.end( err => {
+													bar.tick();
+
+													if ( err && err.status === 404 ) {
+														return imports.upload( site, file, access_token, cb );
+													}
+
+													return cb( err );
+												});
+											}
+										} else {
+											return cb();
+										}
+									});
+								}, 5 );
+
+								if ( callback ) {
+									queue.drain = callback;
 								}
+
+								// Start it
+								queue.push( directory, 1 );
+							};
+
+							// TODO: Cache file count to disk, hash directory so we know if the contents change?
+							console.log( 'Counting files...' );
+							processFiles( false, function() {
+								bar = new progress( 'Importing [:bar] :percent (:current/:total) :etas', { total: filecount, incomplete: ' ', renderThrottle: 100 });
+								console.log( 'Importing ' + filecount + ' files...' );
+								processFiles( true, function() {
+									extensions.end();
+									intermediates.end();
+
+									let data;
+									let extHeader = "Skipped with unsupported extension:";
+									let intHeader = "Skipped intermediate images:";
+
+									extHeader += '\n' + '='.repeat( extHeader.length ) + '\n\n';
+									intHeader += '\n' + '='.repeat( intHeader.length ) + '\n\n';
+
+									fs.appendFileSync( logfile, extHeader );
+
+									try {
+										data = fs.readFileSync( logfile + '.ext' );
+										fs.appendFileSync( logfile, data + '\n\n' );
+										fs.unlinkSync( logfile + '.ext' );
+									} catch ( e ) {
+										fs.appendFileSync( logfile, "None\n\n" );
+									}
+
+
+									fs.appendFileSync( logfile, intHeader );
+
+									try {
+										data = fs.readFileSync( logfile + '.int' );
+										fs.appendFileSync( logfile, data + '\n\n' );
+										fs.unlinkSync( logfile + '.int' );
+									} catch ( e ) {
+										fs.appendFileSync( logfile, "None\n\n" );
+									}
+
+									console.log( `Import log: ${logfile}` );
+								});
 							});
-						}, 5 );
-
-						if ( callback ) {
-							queue.drain = callback;
-						}
-
-						// Start it
-						queue.push( directory, 1 );
-					};
-
-					// TODO: Cache file count to disk, hash directory so we know if the contents change?
-					console.log( 'Counting files...' );
-					processFiles( false, function() {
-						bar = new progress( 'Importing [:bar] :percent (:current/:total) :etas', { total: filecount, incomplete: ' ', renderThrottle: 100 });
-						console.log( 'Importing ' + filecount + ' files...' );
-						processFiles( true, function() {
-							extensions.end();
-							intermediates.end();
-
-							let data;
-							let extHeader = "Skipped with unsupported extension:";
-							let intHeader = "Skipped intermediate images:";
-
-							extHeader += '\n' + '='.repeat( extHeader.length ) + '\n\n';
-							intHeader += '\n' + '='.repeat( intHeader.length ) + '\n\n';
-
-							fs.appendFileSync( logfile, extHeader );
-
-							try {
-								data = fs.readFileSync( logfile + '.ext' );
-								fs.appendFileSync( logfile, data + '\n\n' );
-								fs.unlinkSync( logfile + '.ext' );
-							} catch ( e ) {
-								fs.appendFileSync( logfile, "None\n\n" );
-							}
-
-
-							fs.appendFileSync( logfile, intHeader );
-
-							try {
-								data = fs.readFileSync( logfile + '.int' );
-								fs.appendFileSync( logfile, data + '\n\n' );
-								fs.unlinkSync( logfile + '.int' );
-							} catch ( e ) {
-								fs.appendFileSync( logfile, "None\n\n" );
-							}
-
-							console.log( `Import log: ${logfile}` );
 						});
-					});
-				});
+				})
+				.catch( err => console.error( err ) );
 		});
 	});
 

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -7,13 +7,15 @@ const progress = require( 'progress' );
 const request  = require( 'superagent' );
 const which = require( 'which' );
 
-
 // Ours
 const api      = require( '../lib/api' );
 const utils    = require( '../lib/utils' );
 const db = require( '../lib/db' );
 const imports = require( '../lib/import' );
 const files = require( '../lib/files' );
+
+// Config
+const FORCE_FAST_IMPORT_LIMIT = 100;
 
 function list( v ) {
 	return v.split( ',' );
@@ -101,7 +103,7 @@ program
 			files.list( site, { 'pagesize': 1 })
 				.then( res => res.totalrecs )
 				.then( total => {
-					if ( total < 100 ) {
+					if ( total < FORCE_FAST_IMPORT_LIMIT ) {
 						options.fast = true;
 					}
 

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -1,0 +1,26 @@
+// Ours
+const api = require( './api' );
+
+export function list( site, opts ) {
+	return new Promise( ( resolve, reject ) => {
+		api
+			.get( '/sites/' + site.client_site_id + '/files' )
+			.query( opts )
+			.end( ( err, res ) => {
+				if ( err ) {
+					let message = err.response.error;
+					if ( err.response.body ) {
+						message += ' | ' + err.response.body.message;
+					}
+
+					return reject( new Error( message ) );
+				}
+
+				if ( ! res.body || 'success' !== res.body.status ) {
+					return reject( new Error( 'Failed to create rebuild/upgrade actions for site' ) );
+				}
+
+				return resolve( res.body );
+			});
+	});
+}

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,5 +1,5 @@
 // Ours
-const api = require( '../lib/api' );
+const api = require( './api' );
 
 export function update( site ) {
 	return new Promise( ( resolve, reject ) => {


### PR DESCRIPTION
Normally the importer sends a HEAD request for each file and skips it if
it already exists. This is designed to make imports faster by not
transfering lots of unnecessary data. If we know none of the files
exist, it's faster to skip the 404 checks though. There's an option for
this built into the importer now `--fast`, but it doesn't really get
used.

This detects "new" sites (currently defined by less than 100 images
uploaded) and skips the 404 checks automatically.