### PR TITLE
Fix sandbox stop

### DIFF
--- a/src/bin/vip-sandbox.js
+++ b/src/bin/vip-sandbox.js
@@ -16,22 +16,6 @@ function maybeConfirm( prompt, doPrompt, cb ) {
 	cb( null, true );
 }
 
-function maybePrompt( site, prompt, cb ) {
-	if ( prompt ) {
-		sandbox.listSandboxes({ client_site_id: site, index: true }, () => {
-			promptly.prompt( 'Which container?', { default: 1 }, ( err, container ) => {
-				if ( err ) {
-					return console.error( err );
-				}
-
-				cb( container );
-			});
-		});
-	} else {
-		cb();
-	}
-}
-
 program
 	.command( 'list' )
 	.alias( 'ls' )
@@ -110,64 +94,6 @@ program
 					sandbox.stop( sbox[0], err => {
 						if ( err ) {
 							return console.error( err );
-						}
-					});
-				});
-			});
-		});
-	});
-
-program
-	.command( 'pause <site>' )
-	.description( 'Pause existing sandbox' )
-	.option( '--all', 'Pause all running sandbox containers' )
-	.action( ( site, options ) => {
-		utils.findSite( site, ( err, site ) => {
-			if ( err ) {
-				return console.error( err );
-			}
-
-			if ( ! site ) {
-				return console.error( 'Specified site does not exist. Try the ID.' );
-			}
-
-			sandbox.getSandboxesForSite( site, ( err, sbox ) => {
-				if ( err ) {
-					return console.error( err );
-				}
-
-				if ( ! sbox ) {
-					return console.error( 'Sandbox does not exist for requested site.' );
-				}
-
-				maybePrompt( site.client_site_id, sbox.length > 1 && ! options.all, container => {
-					if ( container < 1 || container > sbox.length ) {
-						return console.error( 'Invalid container' );
-					} else if ( container ) {
-						sbox = sbox.slice( container - 1, container );
-					}
-
-					sbox.forEach( sbox => {
-						if ( sbox.state === 'running' ) {
-							return api
-								.post( '/containers/' + sbox.container_id + '/pause' )
-								.end( err => {
-									if ( err ) {
-										console.error( err.response.error );
-									}
-								});
-						}
-
-						// We don't care about non-running containers for bulk actions
-						if ( options.all ) {
-							return;
-						}
-
-						switch( sbox.state ) {
-						case 'paused':
-							return console.error( 'Requested sandbox is already paused' );
-						default:
-							return console.error( 'Cannot pause sandbox for requested site' );
 						}
 					});
 				});


### PR DESCRIPTION
This finishes transitioning sandbox stop logic to the
/sandboxes/:id/stop endpoint. This is needed because the /container/stop
endpoint isn't granular enough to give start/stop access to a specific
set of containers (i.e. on your sandbox host). It is important because
it means we're now stopping all containers on your sandbox host for a
given site when you run `vip sandbox stop`. In practice, this is unlikely
to change anything unless you were creating multiple running sandbox containers
at once.

This PR also removes the maybePrompt helper function, which we were
using to decide which sandbox container to take action on if you had
multiple. We were only using it in the `vip sandbox pause` subcommand
anymore, which is also being removed becuase there is no
`/sandboxes/:id/pause` endpoint (yet).

Finally, this PR updates some variable names from "container" to
"sandbox" because we're actually passing sandbox objects around, which
are similar to containers, but have an ID field necessary for the
/sandboxes endpoints.