### PR TITLE
Sandbox: vip sandbox always starts as root

### DIFF
--- a/src/bin/vip-sandbox.js
+++ b/src/bin/vip-sandbox.js
@@ -44,7 +44,6 @@ program
 program
 	.command( 'start <site>' )
 	.description( 'Start a sandbox and switch you to the container namespace' )
-	.option( '-r, --root', 'Start sandbox as root' )
 	.action( ( site, options ) => {
 		utils.findSite( site, ( err, site ) => {
 			if ( err ) {
@@ -55,12 +54,7 @@ program
 				return console.error( 'Specified site does not exist. Try the ID.' );
 			}
 
-			var opts = {};
-			if ( options.root ) {
-				opts.user = 'root';
-			}
-
-			sandbox.getSandboxAndRun( site, null, opts );
+			sandbox.getSandboxAndRun( site, null, { user: 'root' });
 		});
 	});
 


### PR DESCRIPTION
Removes the `--root` flag of `vip sandbox start` and always starts as
`root`, but `vip sandbox run` always starts as `nobody`. Since `sandbox
run` doesn't open an interactive shell, it doesn't really make sense to
use it for write operations inside the container. It's mostly used for
running wp-cli commands.