### PR TITLE
Add an example to encourage use of double dashes for run commands

### DIFF
--- a/src/bin/vip-sandbox.js
+++ b/src/bin/vip-sandbox.js
@@ -18,7 +18,7 @@ program
 
 program
 	.command( 'run <site> <command...>' )
-	.description( 'Run a wp-cli command on a sandbox container' )
+	.description( 'Run a wp-cli command on a sandbox container. Use a double dash (--) before the WP CLI command, example:' + "\n" + '  vip sandbox run exhibit.go-vip.co -- wp user list --field=ID' )
 	.option( '--skip-confirm', 'Run the command without asking for confirmation' )
 	.allowUnknownOption()
 	.action( ( site, command, options ) => {


### PR DESCRIPTION
Here's what it looks like:

``` bash
$ vip sandbox run --help

  Usage: run [options] <site> <command...>

  Run a wp-cli command on a sandbox container. Use a double dash (--) before the WP CLI command, example:
vip sandbox run exhibit.go-vip.co -- wp user list --field=ID

  Options:

    -h, --help      output usage information
    --skip-confirm  Run the command without asking for confirmation
```