### PR TITLE
Make db export use single-transaction and quick

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -73,10 +73,12 @@ export function importDB( site, file, opts, callback ) {
 }
 
 export function exportDB( site, callback ) {
-	getConnection( site, ( err, args ) => {
+	getConnection( site, ( err, connectionArgs ) => {
 		if ( err ) {
 			return callback( err );
 		}
+
+		let args = connectionArgs.concat( [ '--single-transaction', '--quick' ] );
 
 		spawn( 'mysqldump', args, { stdio: 'inherit' });
 	});


### PR DESCRIPTION
To avoid placing a large blocking LOCK on tables when generating the export.

https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction
https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_quick