### PR TITLE
Add ability to skip confirmation step

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -113,11 +113,11 @@ export function findSite( domain, cb ) {
 export function findAndConfirmSite( site, action, cb ) {
 	findSite( site, ( err, s ) => {
 		if ( err ) {
-			return console.error( err );
+			return cb( err );
 		}
 
 		if ( ! s ) {
-			return console.error( "Couldn't find site:", site );
+			return cb( new Error( "Couldn't find site:" + site ) );
 		}
 
 		displayNotice( [
@@ -128,7 +128,7 @@ export function findAndConfirmSite( site, action, cb ) {
 
 		promptly.confirm( 'Are you sure?', { output: process.stderr }, ( err, yes ) => {
 			if ( err ) {
-				return console.error( err );
+				return cb( err );
 			}
 
 			if ( ! yes ) {
@@ -136,7 +136,7 @@ export function findAndConfirmSite( site, action, cb ) {
 				return;
 			}
 
-			cb( s );
+			cb( null, s );
 		});
 	});
 }


### PR DESCRIPTION
For DB imports. If we need to loop through and import a batch of files, it's helpful to explictly skip the confirmation step, if needed.