### PR TITLE
Bulk Upgrades: Don't hang on stopped/uninitialized containers

### DIFF
--- a/src/bin/vip-site.js
+++ b/src/bin/vip-site.js
@@ -100,7 +100,11 @@ program
 
 								let done = sites.every( site => {
 									return site.every( container => {
-										return container.software_stack_name === defaultStack && container.state === 'running';
+										if ( container.state !== 'running' && container.state !== 'stopped' && container.state !== 'uninitialized' ) {
+											return false;
+										}
+
+										return container.software_stack_name === defaultStack;
 									});
 								});
 


### PR DESCRIPTION
We don't care about stopped/uninitialized containers during upgrades.
(At least not for the purposes of the bulk upgrade; we may want to
delete any stopped containers that can't be upgraded in the API.)
We need to ignore these so as to not get the upgrader stuck.

Fixes #176