### PR TITLE
Add 'build:watch' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "postuninstall": "./scripts/postuninstall",
     "prepublish": "npm run build",
     "build": "babel -q src --out-dir=build",
+    "build:watch": "babel src --out-dir=build --watch",
     "test": "eslint src test"
   },
   "main": "build/index.js",


### PR DESCRIPTION
For continuous building while developing.

```
$ npm run build:watch

> wpvip-cli@0.14.0-dev build:watch /home/vipdev/cli
> babel src --out-dir=build --watch

src/bin/vip-api.js -> build/bin/vip-api.js
src/bin/vip-db.js -> build/bin/vip-db.js
...
```

Fixes #127 