### PR TITLE
Add safe-updates

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -90,6 +90,9 @@ export function getCLI( site, callback ) {
 			return callback( err );
 		}
 
+		// Block limit-less updates and selects
+		args.push( '--safe-updates' );
+
 		spawn( 'mysql', args, { stdio: 'inherit' });
 	});
 }


### PR DESCRIPTION
http://sql-info.de/mysql/notes/I-am-a-dummy.html

```
mysql> update wp_posts set post_content = 'test';
ERROR 1175 (HY000): You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
```