### PR TITLE
Don't import file archives by default

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -65,7 +65,6 @@ const default_types = [
 	'js',
 	'pdf',
 	'class',
-	'tar','zip','gz','gzip','rar','7z',
 	'psd',
 	'xcf',
 	'doc',


### PR DESCRIPTION
Even if WordPress allows gz, zip, tar, etc. we probably don't want to blindly import these. The importer will put them in a report and if it turns out that we do need to import them, we can always add them in `--extra-types`