### PR TITLE
Fix single site upgrade

### DIFF
--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -5,9 +5,13 @@ export function update( site, opts ) {
 	opts = opts || {};
 	site = site || {};
 
-	let url = Object.keys( opts ).length > 0 ?
-		`/actions/upgrade_wp` :
-		`/actions/${site.client_site_id}/upgrade_wp`;
+	var url;
+
+	if ( opts.client_site_id ) {
+		url = `/actions/${opts.client_site_id}/upgrade_wp`;
+	} else {
+		url = '/actions/upgrade_wp';
+	}
 
 	return new Promise( ( resolve, reject ) => {
 		api

--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -7,8 +7,8 @@ export function update( site, opts ) {
 
 	var url;
 
-	if ( opts.client_site_id ) {
-		url = `/actions/${opts.client_site_id}/upgrade_wp`;
+	if ( site && site.client_site_id ) {
+		url = `/actions/${site.client_site_id}/upgrade_wp`;
 	} else {
 		url = '/actions/upgrade_wp';
 	}


### PR DESCRIPTION
Since we're passing the client_site_id as an option now, that's what we have to check to build the upgrade URL

Note: We still need to figure out how to handle the different responses or add the `failed` and `success` arrays to the single site response.