### PR TITLE
Fix `vip sandbox delete` docs

### DIFF
--- a/src/bin/vip-sandbox.js
+++ b/src/bin/vip-sandbox.js
@@ -101,7 +101,6 @@ program
 program
 	.command( 'delete <site>' )
 	.description( 'Delete existing sandbox' )
-	.option( '--all', 'Delete all stopped sandbox containers' )
 	.action( ( site, options ) => {
 		utils.findSite( site, ( err, site ) => {
 			if ( err ) {


### PR DESCRIPTION
Removes non-functional `--all` option from `vip sandbox delete`. To delete all containers, you can use `vip sandbox purge`.

Fixes #215 