### PR TITLE
Download files from the anycast IP address

### DIFF
--- a/src/bin/vip-files.js
+++ b/src/bin/vip-files.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const program = require( 'commander' );
-const http = require( 'http' );
+const https = require( 'https' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const async = require( 'async' );
@@ -61,7 +61,7 @@ program
 										},
 									};
 
-									http.get( filedata, download => {
+									https.get( filedata, download => {
 										download.pipe( newFile );
 										download.on( 'end', () => {
 											bar.tick();

--- a/src/bin/vip-files.js
+++ b/src/bin/vip-files.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const program = require( 'commander' );
-const https = require( 'https' );
+const http = require( 'http' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const async = require( 'async' );
@@ -53,15 +53,15 @@ program
 
 									// Download the file
 									var filedata = {
-										host: constants.FILES_SERVICE_ENDPOINT,
-										servername: constants.FILES_SERVICE_ENDPOINT,
+										host: constants.VIP_GO_ANYCAST_IP,
+										servername: constants.VIP_GO_ANYCAST_IP,
 										path: file.file_path,
 										headers: {
 											'Host': site.domain_name,
 										},
 									};
 
-									https.get( filedata, download => {
+									http.get( filedata, download => {
 										download.pipe( newFile );
 										download.on( 'end', () => {
 											bar.tick();

--- a/src/bin/vip-files.js
+++ b/src/bin/vip-files.js
@@ -54,7 +54,6 @@ program
 									// Download the file
 									var filedata = {
 										host: constants.VIP_GO_ANYCAST_IP,
-										servername: constants.VIP_GO_ANYCAST_IP,
 										path: file.file_path,
 										headers: {
 											'Host': site.domain_name,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,2 @@
 export const FILES_SERVICE_ENDPOINT = 'dfw-files.vipv2.net';
+export const VIP_GO_ANYCAST_IP = '192.0.66.2';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,2 @@
 export const FILES_SERVICE_ENDPOINT = 'dfw-files.vipv2.net';
-export const VIP_GO_ANYCAST_IP = '192.0.66.2';
+export const VIP_GO_ANYCAST_IP = 'files.go-vip.co';


### PR DESCRIPTION
The files service IP is upload-only. To read files, we must use the
anycast IP address. We're hard-coding it here in case the domain name
in question doesn't point to VIP Go.