### PR TITLE
Add configured innodb buffer pool size to `vip db buffer-pool`

### DIFF
--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -5,8 +5,10 @@ const promptly = require( 'promptly' );
 const which = require( 'which' );
 
 // Ours
+const api = require( '../lib/api' );
 const db = require( '../lib/db' );
 const utils = require( '../lib/utils' );
+const siteUtils   = require( '../lib/site' );
 
 program
 	.arguments( '<site>' )
@@ -88,19 +90,44 @@ program
 			console.log( '-- Environment:', site.environment_name );
 			console.log( '-- Growth Factor:', factor );
 
-			let query = `SELECT
+			let query = `(SELECT
 				CEILING(SUM(data_length)/POWER(1024,2)) data_mb,
 				CEILING(SUM(index_length)/POWER(1024,2)) index_mb,
 				CEILING(SUM(data_length+index_length)/POWER(1024,2)) total_mb,
-				CEILING(SUM(data_length+index_length)*${factor}/POWER(1024,2)) innodb_mb
-			FROM information_schema.tables WHERE engine='InnoDB'`;
+				CEILING(SUM(data_length+index_length)*${factor}/POWER(1024,2)) innodb_mb,
+				@@innodb_buffer_pool_size/POWER(1024,2) configured_mb
+				FROM information_schema.tables WHERE engine='InnoDB')`;
 
 			db.query( site, query, err => {
 				if ( err ) {
 					return console.error( err );
 				}
 			});
-		});
+
+			// get master container with API call
+			api
+				.get( '/sites/' + site.client_site_id + '/containers?is_db_master=true' )
+				.end( ( err, res ) => {
+					if ( err ) {
+						return console.error( 'Failed API call to master container!');
+					}
+					var masterContainer = res.body.data[0].container_id;
+
+					// get master container metadata
+					api
+						.get( '/containers/' + masterContainer + '/meta/innodb_buffer_pool_size' )
+						.end( ( err, res ) => {
+							if ( err ) {
+								return console.error( 'Failed API call to master container metadata!' );
+							}
+
+							var metadata = res.body.data[0].meta_value.slice( 0, -1 );
+							console.log( '-- Configured InnoDB (mb): ' + metadata );	
+						});
+
+				});
+			});
+
 	});
 
 program.parse( process.argv );

--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -124,7 +124,7 @@ program
 								metadata = '128';
 							}
 							else {
-								metadata = res.body.data[0].meta_value.slice( 0, -1 );;
+								metadata = res.body.data[0].meta_value.slice( 0, -1 );
 							}
 	
 							console.log( '-- Configured InnoDB (mb): ' + metadata );	

--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -109,7 +109,7 @@ program
 				.get( '/sites/' + site.client_site_id + '/containers?is_db_master=true' )
 				.end( ( err, res ) => {
 					if ( err ) {
-						return console.error( 'Error retrieving master container!');
+						return console.error( 'Error retrieving master container!' );
 					}
 					var masterContainer = res.body.data[0].container_id;
 
@@ -129,7 +129,7 @@ program
 							}
 						});
 				});
-			});
+		});
 	});
 
 program.parse( process.argv );

--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -94,8 +94,8 @@ program
 				CEILING(SUM(data_length)/POWER(1024,2)) data_mb,
 				CEILING(SUM(index_length)/POWER(1024,2)) index_mb,
 				CEILING(SUM(data_length+index_length)/POWER(1024,2)) total_mb,
-				CEILING(SUM(data_length+index_length)*${factor}/POWER(1024,2)) innodb_mb,
-				@@innodb_buffer_pool_size/POWER(1024,2) configured_mb
+				@@innodb_buffer_pool_size/POWER(1024,2) mariadb_current_mb,
+				CEILING(SUM(data_length+index_length)*${factor}/POWER(1024,2)) suggested_mb 
 				FROM information_schema.tables WHERE engine='InnoDB')`;
 
 			db.query( site, query, err => {
@@ -118,14 +118,14 @@ program
 						.get( '/containers/' + masterContainer + '/meta/innodb_buffer_pool_size' )
 						.end( ( err, res ) => {
 							if ( err.response.statusCode === 404 ) {
-								console.log( '-- Configured InnoDB via API: Not configured' );
+								console.log( '-- Master DB config on API (mb): Not configured' );
 							}
 							else if ( err ) {
 								console.log( 'Error retrieving innodb_buffer_pool_size!' );
 							}
 							else {
 								var metadata = res.body.data[0].meta_value.slice( 0, -1 );
-								console.log( '-- Configured InnoDB via API (mb): ' + metadata );
+								console.log( '-- Master DB config on API (mb): ' + metadata );
 							}
 						});
 				});

--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -117,11 +117,16 @@ program
 					api
 						.get( '/containers/' + masterContainer + '/meta/innodb_buffer_pool_size' )
 						.end( ( err, res ) => {
-							if ( err ) {
-								return console.error( 'Failed API call to master container metadata!' );
-							}
+							var metadata;
 
-							var metadata = res.body.data[0].meta_value.slice( 0, -1 );
+							// set innodb buffer pool size at default
+							if ( err ) {
+								metadata = '128';
+							}
+							else {
+								metadata = res.body.data[0].meta_value.slice( 0, -1 );;
+							}
+	
 							console.log( '-- Configured InnoDB (mb): ' + metadata );	
 						});
 

--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -127,12 +127,9 @@ program
 								var metadata = res.body.data[0].meta_value.slice( 0, -1 );
 								console.log( '-- Configured InnoDB via API (mb): ' + metadata );
 							}
-
 						});
-
 				});
 			});
-
 	});
 
 program.parse( process.argv );

--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -109,7 +109,7 @@ program
 				.get( '/sites/' + site.client_site_id + '/containers?is_db_master=true' )
 				.end( ( err, res ) => {
 					if ( err ) {
-						return console.error( 'Failed API call to master container!');
+						return console.error( 'Error retrieving master container!');
 					}
 					var masterContainer = res.body.data[0].container_id;
 
@@ -117,17 +117,17 @@ program
 					api
 						.get( '/containers/' + masterContainer + '/meta/innodb_buffer_pool_size' )
 						.end( ( err, res ) => {
-							var metadata;
-
-							// set innodb buffer pool size at default
-							if ( err ) {
-								metadata = '128';
+							if ( err.response.statusCode === 404 ) {
+								console.log( '-- Configured InnoDB via API: Not configured' );
+							}
+							else if ( err ) {
+								console.log( 'Error retrieving innodb_buffer_pool_size!' );
 							}
 							else {
-								metadata = res.body.data[0].meta_value.slice( 0, -1 );
+								var metadata = res.body.data[0].meta_value.slice( 0, -1 );
+								console.log( '-- Configured InnoDB via API (mb): ' + metadata );
 							}
-	
-							console.log( '-- Configured InnoDB (mb): ' + metadata );	
+
 						});
 
 				});


### PR DESCRIPTION
Howdy!

As per #234, it would be nice if folks could get the configured InnoDB buffer pool size with the command `vip db buffer-pool <site>`.  This PR does just that by pulling the data from both the global SQL variable and the metadata container via API for it.  We do both methods because if there ever was a difference in values, we would see it side-by-side.

Sample output:
```
-- Site: 334
-- Domain: vccircle-com-develop.go-vip.co
-- Environment: develop
-- Growth Factor: 0.75
-- Configured InnoDB (mb): 128
+---------+----------+----------+-----------+---------------+
| data_mb | index_mb | total_mb | innodb_mb | configured_mb |
+---------+----------+----------+-----------+---------------+
|     515 |      163 |      677 |       508 |           128 |
+---------+----------+----------+-----------+---------------+
``` 