### PR TITLE
Importer: Limits options scope

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -67,22 +67,27 @@ program
 							var start = Date.now() / 1000;
 							var totalLength = 0;
 							let token = res.body.data[0].meta_value;
-							let importer = new imports.Importer({
-								checkExists: !options.skipCheckExists,
-								concurrency: options.parallel,
-								dryRun: !!options.dryRun,
-								intermediate: !!options.intermediate,
-								site: site,
-								token: token,
-								types: options.types,
-							}, count => {
-								var end = Date.now() / 1000;
-								var totalSeconds = end - start;
 
-								console.log( 'File count:', count );
-								console.log( 'Total size:', totalLength );
-								console.log( 'Bytes per second:', totalLength/totalSeconds );
-							});
+							try {
+								var importer = new imports.Importer({
+									checkExists: !options.skipCheckExists,
+									concurrency: options.parallel,
+									dryRun: !!options.dryRun,
+									intermediate: !!options.intermediate,
+									site: site,
+									token: token,
+									types: options.types,
+								}, count => {
+									var end = Date.now() / 1000;
+									var totalSeconds = end - start;
+
+									console.log( 'File count:', count );
+									console.log( 'Total size:', totalLength );
+									console.log( 'Bytes per second:', totalLength/totalSeconds );
+								});
+							} catch ( e ) {
+								return console.error( e.toString() );
+							}
 
 							// Set up consumer and producer
 							switch ( src.protocol ) {

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -9,7 +9,7 @@ const MAX_IMPORT_FILE_SIZE = 1024 * 1024 * 1024; // 1GB
 
 export class Importer {
 	constructor( opts, done ) {
-		this.opts = Object.assign({
+		opts = Object.assign({
 			checkExists: true,
 			concurrency: 5,
 			dryRun: false,
@@ -17,18 +17,18 @@ export class Importer {
 			types: default_types,
 		}, opts );
 
-		if ( ! this.opts.site ) {
+		if ( ! opts.site ) {
 			// TODO
 		}
 
-		if ( ! this.opts.token ) {
+		if ( ! opts.token ) {
 			// TODO
 		}
 
 		this.site = opts.site;
 		this.token = opts.token;
 
-		this.importer( this.opts, done );
+		this.importer( opts, done );
 	}
 
 	importer( opts, done ) {

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -17,12 +17,12 @@ export class Importer {
 			types: default_types,
 		}, opts );
 
-		if ( ! opts.site ) {
-			// TODO
+		if ( ! opts.site || ! opts.site.client_site_id ) {
+			throw new Error( 'Invalid VIP Go site' );
 		}
 
 		if ( ! opts.token ) {
-			// TODO
+			throw new Error( 'Invalid VIP Go Files Service token' );
 		}
 
 		this.site = opts.site;


### PR DESCRIPTION
We don't need access to the importer options anywhere else in the class, so let's limit the scope.