### PR TITLE
Fix running sandbox limit race condition

### DIFF
--- a/src/lib/sandbox.js
+++ b/src/lib/sandbox.js
@@ -217,7 +217,7 @@ export function createSandboxForSite( site, cb ) {
 
 			var total = res.body.totalrecs;
 			var running = res.body.data.filter( s => {
-				return s.containers[0].state === 'running';
+				return s.containers[0].state !== 'stopped';
 			}).length;
 
 			if ( running > 5 ) {


### PR DESCRIPTION
When a sandbox is created, the state doesn't immediately switch to
running. We should consider all active containers that aren't stopped to
be running for this purpose.