### PR TITLE
Run vip migration cleanup after import

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -296,9 +296,11 @@ program
 				api
 					.post( '/sites/' + site.client_site_id + '/wp-cli' )
 					.send({
-						command: 'cache',
-						args: [ 'flush' ],
+						command: 'vip',
+						args: [ 'migration', 'cleanup' ],
 						namedvars: {
+							'yes': true,
+							'network': true,
 							'skip-plugins': true,
 							'skip-themes': true,
 						},


### PR DESCRIPTION
This switches the `wp cache flush` that runs after database imports to `wp vip migration cleanup`, which flushes the cache after some other cleanup.

https://github.com/Automattic/vip-go-mu-plugins/pull/786