### PR TITLE
Block files imports to non-production environments

### DIFF
--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -28,6 +28,7 @@ program
 	.option( '--intermediate', 'Upload intermediate images', false )
 	.option( '--skip-check-exists', 'Skip file checking if the file already exists', false )
 	.option( '-p, --parallel <threads>', 'Number of files to process in parallel. Default: 5', 5, parseInt )
+	.option( '--force', 'Allow import to production site' )
 	.option( '-t, --types <types>', 'File extensions to import', imports.default_types, list )
 	.option( '--aws-key <key>', 'AWS Key' )
 	.option( '--aws-secret <key>', 'AWS Secret' )
@@ -41,6 +42,11 @@ program
 		utils.findAndConfirmSite( site, 'Importing files for site:', ( err, site ) => {
 			if ( err || ! site ) {
 				return console.log( 'Error finding site' );
+			}
+
+			if ( site.environment_name !== 'production' && ! options.force ) {
+				console.log( 'Error: Use --force flag to import files to non-production environment. More info: https://wp.me/PCYsg-7cn#unionfs' );
+				return;
 			}
 
 			files.list( site, { 'pagesize': 0 }) // just need totalrecs here


### PR DESCRIPTION
Don't allow file imports to non-production environments by default
because UnionFS makes them available to all child environments
automatically.

Fixes #146