### PR TITLE
Don't require uploads at the start of the path

### DIFF
--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -49,7 +49,7 @@ export class Importer {
 			}
 
 			// Check filename
-			if ( ! /^uploads\/[a-zA-Z0-9\/\._-]+$/.test( file ) ) {
+			if ( ! /uploads\/[a-zA-Z0-9\/\._-]+$/.test( file ) ) {
 				let err = new Error( 'Invalid filename:' + file );
 				console.log( err.toString() );
 				return callback( err );


### PR DESCRIPTION
We need `uploads` to be in the file path, but it doesn't necessarily have to be the first thing in the path. There can be some prefix and we'll still upload it to the correct place.

Fixes #279 