### PR TITLE
Rename the binary to goop

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "build/index.js",
   "bin": {
-    "vip": "build/bin/vip.js",
+    "goop": "build/bin/vip.js",
     "go-search-replace": "build/go-search-replace"
   },
   "goSearchReplace": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "main": "build/index.js",
   "bin": {
-    "goop": "build/bin/vip.js",
+    "viggo": "build/bin/vip.js",
     "go-search-replace": "build/go-search-replace"
   },
   "goSearchReplace": {


### PR DESCRIPTION
We need to rename the binary because the new, public CLI will be `vip`.