### PR TITLE
Add acceptable_mb to buffer-pool estimate

### DIFF
--- a/src/bin/vip-db.js
+++ b/src/bin/vip-db.js
@@ -90,10 +90,12 @@ program
 			console.log( '-- Environment:', site.environment_name );
 			console.log( '-- Growth Factor:', factor );
 
+			const acceptableFactor = 0.5;
 			let query = `(SELECT
 				CEILING(SUM(data_length)/POWER(1024,2)) data_mb,
 				CEILING(SUM(index_length)/POWER(1024,2)) index_mb,
 				CEILING(SUM(data_length+index_length)/POWER(1024,2)) total_mb,
+				CEILING(SUM((data_length*${acceptableFactor})+index_length)/POWER(1024,2)) acceptable_mb,
 				@@innodb_buffer_pool_size/POWER(1024,2) mariadb_current_mb,
 				CEILING(CEILING(SUM(data_length+index_length)*${factor}/POWER(1024,2))/128)*128 suggested_mb 
 				FROM information_schema.tables WHERE engine='InnoDB')`;


### PR DESCRIPTION
When we're setting the innodb buffer pool size, it doesn't always need
to be bigger than the database. It just needs to be bigger than the
working set. We'll guess the working set on average is around 50% of the
data + the indexes. We can adjust this if necessary.

Fixes #285