### PR TITLE
Fix postinstall prompt

### DIFF
--- a/scripts/postuninstall
+++ b/scripts/postuninstall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 read -p "Do you want to delete the VIP CLI configuration? [n] " delete
-if [[ ! $delete =~ ^[Yy]([Ee][Ss])?$ ]]; then
+if [[ $delete =~ ^[Yy]([Ee][Ss])?$ ]]; then
 	rm -r ~/.vip-cli
 fi


### PR DESCRIPTION
The postinstall script was doing the opposite of what we wanted
(deleting the config if we said no).

Fixes #303