### PR TITLE
Add clarity to uncaught exception message

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -22,7 +22,7 @@ import pkg from 'root/package.json';
 
 function uncaughtError( err ) {
 	console.log();
-	console.log( ' ', colors.red( '✕' ), ' Please contact VIP Support with the following error:' );
+	console.log( ' ', colors.red( '✕' ), ' Unexpected error: Please contact VIP Support with the following error:' );
 	console.log( ' ', colors.dim( err.stack ) );
 }
 process.on( 'uncaughtException', uncaughtError );


### PR DESCRIPTION
If there's an uncaught exception, clarify for the the user that this shouldn't have happened. We already direct them to contact support with the error message.