### PR TITLE
Repo detection: search all git remotes

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -69,7 +69,6 @@ args.argv = async function( argv, cb ): Promise<any> {
 	// Set the site in options.app
 	let res;
 	if ( _opts.appContext ) {
-
 		// If --app is not set, try to infer the app context
 		if ( ! options.app ) {
 			const repo = await Repo();

--- a/src/lib/cli/repo.js
+++ b/src/lib/cli/repo.js
@@ -16,12 +16,29 @@ export default async function getRepoFromGitConfig(): Promise<string> {
 
 	const config = ini.parse( fs.readFileSync( file, 'utf-8' ) );
 
-	let url = config[ 'remote "origin"' ].url;
-	url = url.replace( /.git$/, '' );
-	url = url.replace( 'https://github.com/', '' );
-	url = url.replace( 'git@github.com:', '' );
+	// Find the first 'wpcomvip' remote
+	for ( const key in config ) {
+		if ( 'remote' !== key.substring( 0, 6 ) ) {
+			continue;
+		}
 
-	return url;
+		if ( ! config[ key ].url ) {
+			continue;
+		}
+
+		if ( 0 > config[ key ].url.indexOf( 'wpcomvip/' ) ) {
+			continue;
+		}
+
+		let repo = config[ key ].url;
+		repo = repo.replace( /.git$/, '' );
+		repo = repo.replace( 'https://github.com/', '' );
+		repo = repo.replace( 'git@github.com:', '' );
+
+		return repo;
+	}
+
+	return;
 }
 
 async function find( dir ): Promise<string> {


### PR DESCRIPTION
Rather than require the wpcomvip repo to be the "origin", we can use the
first remote that pushes to wpcomvip.

Fixes #92