### PR TITLE
Fix isNaN check

### DIFF
--- a/src/lib/api/app.js
+++ b/src/lib/api/app.js
@@ -16,7 +16,7 @@ export default async function( app: string | number, fields: ?any ): Promise<any
 	}
 
 	const api = await API();
-	if ( isNaN( parseInt( app ) ) ) {
+	if ( isNaN( app ) ) {
 		const res = await api
 			.query( {
 				// $FlowFixMe: gql template is not supported by flow

--- a/src/lib/api/app.js
+++ b/src/lib/api/app.js
@@ -45,6 +45,8 @@ export default async function( app: string | number, fields: ?any ): Promise<any
 		return res.data.apps.edges[ 0 ];
 	}
 
+	app = parseInt( app, 10 );
+
 	const res = await api
 		.query( {
 			// $FlowFixMe: gql template is not supported by flow


### PR DESCRIPTION
parseInt will return an int if the first character is a number. If we pass in a name that starts with a number, we don't want it to be interpreted as a number.