### PR TITLE
Run version check on `postinstall`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:watch": "babel src -d dist --watch",
     "flow": "flow",
     "jest": "jest",
-    "preinstall": "node ./scripts/check-version.js"
+    "postinstall": "node ./scripts/check-version.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We can't use dependencies during preinstall (i.e. `semver`) since they have not been added yet. Moving to `postinstall` means that dependencies are available for use (the downside is that it takes a lot longer to report the node version error).

See https://github.com/Automattic/vip/pull/93#discussion_r186253444