### PR TITLE
Add UUID

### DIFF
--- a/__tests__/lib/token.js
+++ b/__tests__/lib/token.js
@@ -33,4 +33,14 @@ describe( 'token tests', () => {
 		expect( token.valid() ).toEqual( false );
 		expect( token.expired() ).toEqual( true );
 	} );
+	test( 'should consistently return uuid', () => {
+		const t = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWQiOjcsImlhdCI6MTUxNjIzOTAyMn0.RTJMXHhhiaCxQberZ5Pre7SBU3Ci8EvCyaOXoqG3pNA';
+		const token = new Token( t );
+
+		token.uuid().then( uuid1 => {
+			token.uuid().then( uuid2 => {
+				expect( uuid1 ).toBe( uuid2 );
+			} );
+		} );
+	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@automattic/vip",
-  "version": "1.0.0-dev-build8",
+  "version": "1.0.0-dev-build10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
       }
@@ -890,7 +890,7 @@
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
@@ -991,29 +991,34 @@
       }
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "1.9.1"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1077,18 +1082,10 @@
       }
     },
     "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "version": "github:automattic/cli-table#b9ebd7570e20d885b7455c696d8fd2fcaa3c503f",
       "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-        }
+        "chalk": "2.4.1",
+        "wcwidth": "1.0.1"
       }
     },
     "cli-width": {
@@ -1117,6 +1114,11 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1140,11 +1142,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -1348,6 +1345,14 @@
             "is-utf8": "0.2.1"
           }
         }
+      }
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "1.0.4"
       }
     },
     "define-properties": {
@@ -3487,7 +3492,7 @@
       "integrity": "sha512-kn7N70US1MSZHZHSGJLiZ7iCwwncc7b0gc68YtlX29OjI3Mp0tSVV+snVXpZ1G+ONS3Ac9zd1m6hve2ibLDYfA==",
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
@@ -3942,7 +3947,7 @@
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
-            "chalk": "2.3.0",
+            "chalk": "2.4.1",
             "exit": "0.1.2",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
@@ -3993,7 +3998,7 @@
       "integrity": "sha512-imzke/YkKXOQKec5cvprqvfcWKNGccZCs3dDk8wTGaqeFnGsx9A9csZ7zzGMlMG8qjlnl+/urRjIdk8XZEXuUg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "glob": "7.1.2",
         "jest-environment-jsdom": "22.1.0",
         "jest-environment-node": "22.1.0",
@@ -4012,7 +4017,7 @@
       "integrity": "sha512-lowdbU/dzXh+2/MR5QcvU5KPNkO4JdAEYw0PkQCbIQIuy5+g3QZBuVhWh8179Fmpg4CQrz1WgoK/yQHDCHbqqw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "diff": "3.4.0",
         "jest-get-type": "22.1.0",
         "pretty-format": "22.1.0"
@@ -4075,7 +4080,7 @@
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "co": "4.6.0",
         "expect": "22.1.0",
         "graceful-fs": "4.1.11",
@@ -4110,7 +4115,7 @@
       "integrity": "sha512-Zn1OD9wVjILOdvRxgAnqiCN36OX6KJx+P2FHN+3lzQ0omG2N2OAguxE1QXuJJneG2yndlkXjekXFP254c0cSpw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "jest-get-type": "22.1.0",
         "pretty-format": "22.1.0"
       }
@@ -4122,7 +4127,7 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.37",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
         "stack-utils": "1.0.1"
@@ -4134,7 +4139,7 @@
           "integrity": "sha512-LIpcKm+2otOOvOvhCbD6wkNYi8aUwHk73uWR+hxBdW2EFht5D0QX89n4me8nyeNGWr5zC3Pvmjq+9MvUof+jkg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.4.1",
             "esutils": "2.0.2",
             "js-tokens": "3.0.2"
           }
@@ -4160,7 +4165,7 @@
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
-        "chalk": "2.3.0"
+        "chalk": "2.4.1"
       }
     },
     "jest-resolve-dependencies": {
@@ -4200,7 +4205,7 @@
         "babel-core": "6.26.0",
         "babel-jest": "22.1.0",
         "babel-plugin-istanbul": "4.1.5",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "convert-source-map": "1.5.1",
         "exit": "0.1.2",
         "graceful-fs": "4.1.11",
@@ -4224,7 +4229,7 @@
       "integrity": "sha512-g5IqCgAC1TaaocL9xMIE2GLpOPP2li5BPVc2Vsa3ti+e7LMhpooXYcd/ouNqtWDThZD8Tp3jDavyqN0LH6hkPA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "jest-diff": "22.1.0",
         "jest-matcher-utils": "22.1.0",
         "mkdirp": "0.5.1",
@@ -4239,7 +4244,7 @@
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "graceful-fs": "4.1.11",
         "is-ci": "1.1.0",
         "jest-message-util": "22.1.0",
@@ -4261,7 +4266,7 @@
       "integrity": "sha512-v9QKiQksA8e0LXRYBhI6c3vuvYyLAm95kR4SVFGj0l2zgzAG3VNT6qpUAxntna6ERf5jydzzmSpOzLpCJYCUvg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "jest-get-type": "22.1.0",
         "leven": "2.1.0",
         "pretty-format": "22.1.0"
@@ -4393,7 +4398,7 @@
       "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-3.11.5.tgz",
       "integrity": "sha512-ORsw84BuRKMLxfI+HFZuvxRDnsJps53D5fIGr6tLn4ZY+ymcG8XU00E+JJ2wfAiHx5w2QRNmOLE8xHiGAeSfuQ==",
       "requires": {
-        "cli-table": "0.3.1",
+        "cli-table": "github:automattic/cli-table#b9ebd7570e20d885b7455c696d8fd2fcaa3c503f",
         "commander": "2.12.2",
         "debug": "3.1.0",
         "flat": "4.0.0",
@@ -5413,7 +5418,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "request-promise-core": {
@@ -6174,7 +6179,7 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "requires": {
         "boxen": "1.3.0",
-        "chalk": "2.3.0",
+        "chalk": "2.4.1",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
         "is-installed-globally": "0.1.0",
@@ -6218,10 +6223,9 @@
       }
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "v8flags": {
       "version": "2.1.1",
@@ -6286,6 +6290,14 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "1.0.3"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "opn": "^5.2.0",
     "semver": "^5.5.0",
     "single-line-log": "^1.1.2",
-    "update-notifier": "^2.3.0"
+    "update-notifier": "^2.3.0",
+    "uuid": "^3.2.1"
   },
   "eslintConfig": {
     "env": {

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import jwtDecode from 'jwt-decode';
+import uuid from 'uuid/v1';
 
 /**
  * Internal dependencies
@@ -64,6 +65,16 @@ export default class Token {
 
 		const now = new Date();
 		return now > this.exp;
+	}
+
+	async uuid(): string {
+		let _uuid = await keychain.getPassword( SERVICE + '-uuid' );
+		if ( ! _uuid ) {
+			_uuid = uuid();
+			await keychain.setPassword( SERVICE + '-uuid', _uuid );
+		}
+
+		return _uuid;
 	}
 
 	static async set( token: string ): Promise<boolean> {

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import jwtDecode from 'jwt-decode';
-import uuid from 'uuid/v1';
+import uuid from 'uuid/v4';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
We need UUIDs to track usage data. We don't care who the user actually
is, but we need to be able to see problematic flows.

This generates a unique ID that cannot be reversed or
otherwise used to figure out who the user is. The ID is persisted in
whatever keychain is used on that given system.

See #32