### PR TITLE
Updates to Insecure keychain

### DIFF
--- a/__tests__/lib/keychain.js
+++ b/__tests__/lib/keychain.js
@@ -72,6 +72,20 @@ describe( 'token tests (insecure)', () => {
 			} );
 		} );
 	} );
+
+	test( 'should correctly delete a single token', () => {
+		return keychain.setPassword( 'first', 'password1' ).then( _ => {
+			return keychain.setPassword( 'second', 'password2' ).then( _ => {
+				return keychain.deletePassword( 'first' ).then( _ => {
+					const p = keychain.getPassword( 'first' );
+					expect( p ).resolves.toBe( null );
+
+					const p2 = keychain.getPassword( 'second' );
+					expect( p2 ).resolves.toBe( 'password2' );
+				} );
+			} );
+		} );
+	} );
 } );
 
 describe( 'token tests (browser)', () => {

--- a/__tests__/lib/keychain.js
+++ b/__tests__/lib/keychain.js
@@ -52,6 +52,18 @@ describe( 'token tests (insecure)', () => {
 		} );
 	} );
 
+	test( 'should correctly set multiple tokens', () => {
+		return keychain.setPassword( 'first', 'password1' ).then( _ => {
+			return keychain.setPassword( 'second', 'password2' ).then( _ => {
+				const p = keychain.getPassword( 'first' );
+				expect( p ).resolves.toBe( 'password1' );
+
+				const p2 = keychain.getPassword( 'second' );
+				expect( p2 ).resolves.toBe( 'password2' );
+			} );
+		} );
+	} );
+
 	test( 'should correctly delete token', () => {
 		return keychain.setPassword( account, password ).then( _ => {
 			return keychain.deletePassword( account ).then( _ => {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+environment:
+  nodejs_version: "8.10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   nodejs_version: "8.10"
 
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version x64
   - npm install
 
 test_script:

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -12,7 +12,7 @@ import path from 'path';
  */
 import type { Keychain } from './keychain';
 
-export default class Secure implements Keychain {
+export default class Insecure implements Keychain {
 	file: string;
 
 	constructor( file: string ) {

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -39,7 +39,7 @@ export default class Insecure implements Keychain {
 
 		// Ensure permissions are what we expect
 		if ( !! ( perms & ~rw ) ) {
-			throw `Invalid permissions (${ perms }, expecting ${ rw }) for keychain file (${ tmpfile })`;
+			throw `Invalid permissions (${ perms.toString( 8 ) }, expecting ${ rw.toString( 8 ) }) for keychain file (${ tmpfile })`;
 		}
 
 		this.file = tmpfile;

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -20,7 +20,10 @@ export default class Insecure implements Keychain {
 		const rw = 0o600;
 
 		let stat;
-		const tmpfile = os.homedir() + path.sep + file;
+		const dir = os.homedir() + path.sep + '.vip';
+		this.mkdirp( dir );
+
+		const tmpfile = dir + path.sep + file;
 		try {
 			// Ensure the file exists
 			stat = fs.statSync( tmpfile );
@@ -63,5 +66,16 @@ export default class Insecure implements Keychain {
 		return new Promise( resolve => {
 			fs.unlink( this.file, err => resolve( ! err ) );
 		} );
+	}
+
+	mkdirp( dir ) {
+		const parent = path.dirname( dir );
+
+		try {
+			fs.statSync( dir );
+		} catch ( e ) {
+			this.mkdirp( parent );
+			fs.mkdirSync( dir );
+		}
 	}
 }

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -18,7 +18,15 @@ export default class Insecure implements Keychain {
 
 	constructor( file: string ) {
 		// only current user has read-write access
-		const rw = 0o600;
+		let rw;
+		switch ( process.platform ) {
+			case 'win32':
+				rw = 0o666;
+				break;
+
+			default:
+				rw = 0o600;
+		}
 
 		let stat;
 		const dir = os.homedir() + path.sep + '.vip';

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -20,7 +20,7 @@ export default class Insecure implements Keychain {
 		const rw = 0o600;
 
 		let stat;
-		const tmpfile = os.tmpdir() + path.sep + file;
+		const tmpfile = os.homedir() + path.sep + file;
 		try {
 			// Ensure the file exists
 			stat = fs.statSync( tmpfile );

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -48,13 +48,17 @@ export default class Insecure implements Keychain {
 			return Promise.resolve( this.passwords[ service ] );
 		}
 
-		return new Promise( resolve => {
+		return new Promise( ( resolve, reject ) => {
 			fs.readFile( this.file, 'utf8', ( err, passwords ) => {
 				if ( err || ! passwords ) {
 					return resolve( null );
 				}
 
-				this.passwords = JSON.parse( passwords );
+				try {
+					this.passwords = JSON.parse( passwords );
+				} catch ( e ) {
+					return reject( e );
+				}
 
 				return resolve( passwords[ service ] );
 			} );
@@ -64,8 +68,15 @@ export default class Insecure implements Keychain {
 	setPassword( service: string, password: string ): Promise<boolean> {
 		this.passwords[ service ] = password;
 
-		return new Promise( resolve => {
-			const json = JSON.stringify( this.passwords );
+		return new Promise( ( resolve, reject ) => {
+			let json;
+
+			try {
+				json = JSON.stringify( this.passwords );
+			} catch ( e ) {
+				return reject( e );
+			}
+
 			fs.writeFile( this.file, json, err => resolve( ! err ) );
 		} );
 	}
@@ -73,8 +84,15 @@ export default class Insecure implements Keychain {
 	deletePassword( service: string ): Promise<boolean> {
 		delete this.passwords[ service ];
 
-		return new Promise( resolve => {
-			const json = JSON.stringify( this.passwords );
+		return new Promise( ( resolve, reject ) => {
+			let json;
+
+			try {
+				json = JSON.stringify( this.passwords );
+			} catch ( e ) {
+				return reject( e );
+			}
+
 			fs.writeFile( this.file, json, err => resolve( ! err ) );
 		} );
 	}

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -35,7 +35,7 @@ export default class Insecure implements Keychain {
 
 		// Ensure permissions are what we expect
 		if ( !! ( perms & ~rw ) ) {
-			throw 'Invalid permissions on access token file: ' + tmpfile;
+			throw `Invalid permissions (${ perms }) for keychain file (${ tmpfile })`;
 		}
 
 		this.file = tmpfile;

--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -39,7 +39,7 @@ export default class Insecure implements Keychain {
 
 		// Ensure permissions are what we expect
 		if ( !! ( perms & ~rw ) ) {
-			throw `Invalid permissions (${ perms }) for keychain file (${ tmpfile })`;
+			throw `Invalid permissions (${ perms }, expecting ${ rw }) for keychain file (${ tmpfile })`;
 		}
 
 		this.file = tmpfile;


### PR DESCRIPTION
- [x] Fix class name
- [x] Better error message for permissions errors
- [x] Move file to `.vip` dir
- [ ] Try to recover from permissions error (and/or at least provide next steps)
- [x] Verify permissions are correct for file (some Windows users reporting `Invalid permissions on access token file` error)
- [x] Support for multiple "service" values (e.g. uuid)
- [x] Switch to `homedir()`