### PR TITLE
Truncate the git commit hash to 7 characters

### DIFF
--- a/src/bin/vip-app.js
+++ b/src/bin/vip-app.js
@@ -47,5 +47,16 @@ command( { requiredArgs: 1, format: true } )
 
 		await trackEvent( 'app_command_success' );
 
-		return res.environments;
+		// Clone the read-only response object so we can modify it
+		const r = Object.assign( {}, res );
+		r.environments = r.environments.map( env => {
+			const e = Object.assign( {}, env );
+
+			// Use the short version of git commit hash
+			e.currentCommit = e.currentCommit.substring( 0, 7 );
+
+			return e;
+		} );
+
+		return r.environments;
 	} );


### PR DESCRIPTION
Github uses the first 7 characters of the commit hash to uniquely
identify a given commit. This is much nicer for our UI since the full
hash makes each line quite long.

We have to clone the response and environment objects since Apollo
creates them as read-only.

Fixes #132