### PR TITLE
Fix permissions issues for Windows

### DIFF
--- a/src/lib/keychain/insecure.js
+++ b/src/lib/keychain/insecure.js
@@ -20,7 +20,7 @@ export default class Insecure implements Keychain {
 		this.passwords = {};
 
 		// only current user has read-write access
-		const rw = fs.constants.S_IRUSR | fs.constants.S_IWUSR;
+		const rw = 0o700;
 
 		let stat;
 		const dir = os.homedir() + path.sep + '.vip';


### PR DESCRIPTION
The fs constants don't seem to work at all and files end up as read-only
which means we can't write any secrets. This solution is not perfect,
but should be OK for now.