### PR TITLE
Add $PAGER support

### DIFF
--- a/src/bin/vip-app-list.js
+++ b/src/bin/vip-app-list.js
@@ -36,7 +36,7 @@ command( { format: true } )
 						}
 					}`,
 					variables: {
-						first: 10,
+						first: 100,
 						after: null, // TODO make dynamic
 					},
 				} );

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -19,6 +19,7 @@ import { formatData } from './format';
 import { confirm } from './prompt';
 import pkg from 'root/package.json';
 import { trackEvent } from 'lib/tracker';
+import pager from 'lib/cli/pager';
 
 function uncaughtError( err ) {
 	console.log();
@@ -295,6 +296,8 @@ args.argv = async function( argv, cb ): Promise<any> {
 	}
 
 	if ( cb ) {
+		const p = pager();
+
 		res = await cb( this.sub, options );
 
 		if ( _opts.format && res ) {
@@ -313,7 +316,9 @@ args.argv = async function( argv, cb ): Promise<any> {
 				format: options.format,
 			} );
 
-			console.log( formatData( res, options.format ) );
+			const formattedOut = formatData( res, options.format );
+			p.write( formattedOut + '\n' );
+			p.end();
 			return {};
 		}
 	}

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -147,7 +147,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 				type: 'list',
 				name: 'app',
 				message: 'Which app?',
-				pageSize: 10,
+				pageSize: 100,
 				prefix: '',
 				choices: res.data.apps.edges.map( cur => {
 					return {

--- a/src/lib/cli/pager.js
+++ b/src/lib/cli/pager.js
@@ -7,6 +7,18 @@ import { spawn } from 'child_process';
 
 let proc;
 export default function pager() {
+	let less;
+	switch ( process.platform ) {
+		case 'win32':
+			// PROGRA~1 is the short name for Program Files
+			// we're using it here to avoid the space which is broken by .split( ' ' )
+			less = 'C:\\PROGRA~1\\Git\\usr\\bin\\less.exe -FRX';
+			break;
+
+		default:
+			less = 'less -FRX';
+	}
+
 	const args = ( process.env.PAGER || 'less -FRX' ).split( ' ' );
 	const bin = args.shift();
 

--- a/src/lib/cli/pager.js
+++ b/src/lib/cli/pager.js
@@ -1,0 +1,23 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+import { spawn } from 'child_process';
+
+let proc;
+export default function pager() {
+	const args = ( process.env.PAGER || 'less -FRX' ).split( ' ' );
+	const bin = args.shift();
+
+	proc = spawn( bin, args, { stdio: [ -1, 1, 2 ] } );
+	proc.on( 'exit', () => {
+		proc.stdin.emit( 'done' );
+	} );
+
+	return proc.stdin;
+}
+
+export function end() {
+	proc.end();
+}

--- a/src/lib/cli/pager.js
+++ b/src/lib/cli/pager.js
@@ -19,7 +19,7 @@ export default function pager() {
 			less = 'less -FRX';
 	}
 
-	const args = ( process.env.PAGER || 'less -FRX' ).split( ' ' );
+	const args = ( process.env.PAGER || less ).split( ' ' );
 	const bin = args.shift();
 
 	proc = spawn( bin, args, { stdio: [ 'pipe', process.stdout, process.stderr ] } );

--- a/src/lib/cli/pager.js
+++ b/src/lib/cli/pager.js
@@ -10,7 +10,7 @@ export default function pager() {
 	const args = ( process.env.PAGER || 'less -FRX' ).split( ' ' );
 	const bin = args.shift();
 
-	proc = spawn( bin, args, { stdio: [ -1, 1, 2 ] } );
+	proc = spawn( bin, args, { stdio: [ 'pipe', process.stdout, process.stderr ] } );
 	proc.on( 'exit', () => {
 		proc.stdin.emit( 'done' );
 	} );


### PR DESCRIPTION
Adds support to use a pager for long commands. By default we use `less -FRX`
which disables the init step (so the screen doesn't completely clear
when less starts), sends the raw output to less (so colors work), and
exits if less than one full screen is output.

We also honor the $PAGER environment variable, so the program that's
used for paging can be customized per http://manpages.ubuntu.com/manpages/bionic/en/man1/man.1posix.html

An easy way to test this is to change the `vip app list` to output 30
results instead of 10.

This is a good start, but it would be better if we could page over
results and write 10 at a time. It would also be nice if that was
pausable (like stream.pause()) so we could lazy load results (or never
load results) that aren't going to be on screen anyway.

See: #116