### PR TITLE
Trim whitespace from tokens

### DIFF
--- a/__tests__/lib/token.js
+++ b/__tests__/lib/token.js
@@ -12,11 +12,13 @@ describe( 'token tests', () => {
 		expect( token.valid() ).toEqual( true );
 		expect( token.expired() ).toEqual( false );
 	} );
+
 	test( 'should correctly validate token missing an id', () => {
 		const t = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTYxMzUyNzYsImV4cCI6MjUyNDYwODAwMCwiYXVkIjoiIiwic3ViIjoiIn0.seD8rBKJS0usjYApigqizitlNcmzcrYlGt9DyCm3I4c';
 		const token = new Token( t );
 		expect( token.valid() ).toEqual( false );
 	} );
+
 	test( 'should error for invalid token', () => {
 		const t = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImp0aSI6IjRhM2RmYjE5LTBhMWQtNDE3YS05ODM2LTdjZWIwZTBkM2Q4NSIsImlhdCI6MTUxNjEyMzU1NywiZXhwIjoxNTE2MTI3zM4fQ.atx1YhxB6SQoW99aL97tXNlyJlXWEPZ3Cf1zyfxizvs';
 		let token;
@@ -27,11 +29,26 @@ describe( 'token tests', () => {
 
 		expect( token ).toEqual( undefined );
 	} );
+
 	test( 'should not validate expired token', () => {
 		const t = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiaWF0IjoxNTE1NzExMDY5LCJleHAiOjE1MTU3OTc0Njl9.hZ-mAeoFAahak9WXqAVTOKEU7R_f1VsZfS5HqZOm-a4';
 		const token = new Token( t );
 		expect( token.valid() ).toEqual( false );
 		expect( token.expired() ).toEqual( true );
+	} );
+
+	test( 'should correctly validate token with invalid whitespace', () => {
+		const leadingWhitespace = ' eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWQiOjcsImlhdCI6MTUxNjIzOTAyMn0.RTJMXHhhiaCxQberZ5Pre7SBU3Ci8EvCyaOXoqG3pNA';
+		let token = new Token( leadingWhitespace );
+		expect( token.valid() ).toEqual( true );
+
+		const trailingWhitespace = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWQiOjcsImlhdCI6MTUxNjIzOTAyMn0.RTJMXHhhiaCxQberZ5Pre7SBU3Ci8EvCyaOXoqG3pNA ';
+		token = new Token( trailingWhitespace );
+		expect( token.valid() ).toEqual( true );
+
+		const justWhitespace = ' ';
+		token = new Token( justWhitespace );
+		expect( token.valid() ).toEqual( false );
 	} );
 
 	test( 'should consistently return uuid', () => {

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -21,7 +21,12 @@ export default class Token {
 	exp: Date;
 
 	constructor( token: string ): void {
-		if ( ! token || ! token.length ) {
+		if ( ! token ) {
+			return;
+		}
+
+		token = token.trim();
+		if ( ! token.length ) {
 			return;
 		}
 


### PR DESCRIPTION
As tokens are copy/pasted, it's easy to include extra whitespace. We can
just ignore that whitespace since there shouldn't be any whitespace in
the token anyway.

Fixes #141