### PR TITLE
Pass data sync errors back from internal API

### DIFF
--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -56,8 +56,22 @@ command( {
 					}
 				} );
 		} catch ( e ) {
-			syncing = true;
+			if ( e.graphQLErrors ) {
+				let bail = false;
 
+				for ( const err of e.graphQLErrors ) {
+					if ( err.message !== 'Site is already syncing' ) {
+						bail = true;
+						console.log( chalk.red( 'Error:' ), err.message );
+					}
+				}
+
+				if ( bail ) {
+					return;
+				}
+			}
+
+			syncing = true;
 			await trackEvent( 'sync_command_execute_error', {
 				error: `Already syncing: ${ e.message }`,
 			} );


### PR DESCRIPTION
We'll output all the errors and then bail if there were issues other
than the site is already syncing. In that case, we can continue polling
for the sync status.

Fixes #100
Fixes #115