### PR TITLE
Don't fork PAGER unless we have data to output

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -296,10 +296,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 	}
 
 	if ( cb ) {
-		const p = pager();
-
 		res = await cb( this.sub, options );
-
 		if ( _opts.format && res ) {
 			res = res.map( row => {
 				const out = Object.assign( {}, row );
@@ -317,6 +314,8 @@ args.argv = async function( argv, cb ): Promise<any> {
 			} );
 
 			const formattedOut = formatData( res, options.format );
+
+			const p = pager();
 			p.write( formattedOut + '\n' );
 			p.end();
 			return {};


### PR DESCRIPTION
We were forking `less` before even making the API request for data.
If there was an error (for example, if the network was disconnected)
less would eat the error and fail to exit because p.end() was only
called if there was data returned.

Fixes #145