### PR TITLE
sync: clearInterval immediately

### DIFF
--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -173,22 +173,24 @@ command( {
 					break;
 
 				case 'failed':
+					clearInterval( progress );
+
 					await trackEvent( 'sync_command_error', {
 						error: 'API returned `failed` status',
 					} );
 
 					out.push( `${ marks.failed } Data Sync is finished for ${ opts.app.name }` );
 					out.push( '' );
-					clearInterval( progress );
 					break;
 
 				case 'success':
 				default:
+					clearInterval( progress );
+
 					await trackEvent( 'sync_command_success' );
 
 					out.push( `${ marks.success } Data Sync is finished for ${ opts.app.name }` );
 					out.push( '' );
-					clearInterval( progress );
 					break;
 			}
 


### PR DESCRIPTION
Instead of waiting till the end. If the intermediary code until we get to `clearInterval` takes too long it will fire and, in this particular case, we can end up with repeated calls to `trackEvent` and inflated counts.

## To Test

- Run a sync with `DEBUG=*`
- Verify that you only see one `@automattic/vip:analytics:clients:tracks send()` call with `sync_command_success`

Fixes #153 