### PR TITLE
Move `dev` prefix later

### DIFF
--- a/config/config.local.json
+++ b/config/config.local.json
@@ -1,5 +1,5 @@
 {
   "tracksUserType": "vip:user_id",
   "tracksAnonUserType": "anon",
-  "tracksEventPrefix": "vip_dev_cli_"
+  "tracksEventPrefix": "vip_cli_dev_"
 }


### PR DESCRIPTION
For consistency with the Dashboard. From `vip_dev_cli_`  to `vip_cli_dev_`