### PR TITLE
Allow publishing from either `master` or `release`

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -4,7 +4,7 @@
     "uncommittedChanges": true,
     "untrackedFiles": true,
     "sensitiveData": true,
-    "branch": "master",
+    "branch": /(master|release)/,
     "gitTag": true
   },
   "confirm": true,

--- a/.publishrc
+++ b/.publishrc
@@ -4,7 +4,7 @@
     "uncommittedChanges": true,
     "untrackedFiles": true,
     "sensitiveData": true,
-    "branch": /(master|release)/,
+    "branch": /^(master|(release\/\d\.\d\.\d))$/,
     "gitTag": true
   },
   "confirm": true,


### PR DESCRIPTION
Tweaks our `.publishrc` config to allow publishing from either the `master` or `release*` branches.

Sometimes we need to release patches without committing them directly to master, this will allow us to do that.

Without this, `npm publish-please` will fail when validating the branch.