### PR TITLE
Add login subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "vip": "dist/bin/vip.js",
     "vip-app": "dist/bin/vip-app.js",
     "vip-app-list": "dist/bin/vip-app-list.js",
-    "vip-sync": "dist/bin/vip-sync.js"
+    "vip-sync": "dist/bin/vip-sync.js",
+    "vip-login": "dist/bin/vip-login.js"
   },
   "scripts": {
     "test": "npm run lint && npm run flow && jest --coverage",

--- a/src/bin/vip-login.js
+++ b/src/bin/vip-login.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// @flow
+
+/**
+ * External dependencies
+ */
+import opn from 'opn';
+import inquirer from 'inquirer';
+
+/**
+ * Internal dependencies
+ */
+import command from 'lib/cli/command';
+import Token from 'lib/token';
+
+command( { format: true } )
+	.argv( process.argv, async ( arg, options ) => {
+		let token = await Token.get();
+
+		// double check if user is already logged in
+		if ( token && token.valid() ) {
+			return console.log( 'You are already logged in' );
+		}
+
+		console.log();
+		console.log( '  Welcome to' );
+		console.log( '   _    __________     ______' );
+		console.log( '  | |  / /  _/ __ \\   / ____/___' );
+		console.log( '  | | / // // /_/ /  / / __/ __ \\' );
+		console.log( '  | |/ // // ____/  / /_/ / /_/ /' );
+		console.log( '  |___/___/_/       \\____/\\____/' );
+		console.log();
+		console.log( '  VIP CLI is your tool for interacting with and managing your VIP Go applications.' );
+		console.log();
+
+		console.log( `  To get started, we need an access token for your VIP account. We'll open ${ tokenURL } in your web browser; follow the instructions there to continue.` );
+		console.log();
+
+		await trackEvent( 'login_command_execute' );
+
+		const c = await inquirer.prompt( {
+			type: 'confirm',
+			name: 'continue',
+			message: 'Ready?',
+			prefix: '',
+		} );
+
+		if ( ! c.continue ) {
+			await trackEvent( 'login_command_browser_cancelled' );
+
+			return;
+		}
+
+		opn( tokenURL, { wait: false } );
+
+		await trackEvent( 'login_command_browser_opened' );
+
+		let t = await inquirer.prompt( {
+			type: 'password',
+			name: 'token',
+			message: 'Access Token:',
+			prefix: '',
+		} );
+
+		t = t.token;
+
+		try {
+			token = new Token( t );
+		} catch ( e ) {
+			console.log( 'The token provided is malformed. Please check the token and try again.' );
+
+			await trackEvent( 'login_command_token_submit_error', { error: e.message } );
+
+			return;
+		}
+
+		if ( token.expired() ) {
+			console.log( 'The token provided is expired. Please log in again to refresh the token.' );
+
+			await trackEvent( 'login_command_token_submit_error', { error: 'expired' } );
+
+			return;
+		}
+
+		if ( ! token.valid() ) {
+			console.log( 'The provided token is not valid. Please log in again to refresh the token.' );
+
+			await trackEvent( 'login_command_token_submit_error', { error: 'invalid' } );
+
+			return;
+		}
+
+		try {
+			Token.set( token.raw );
+		} catch ( e ) {
+			await trackEvent( 'login_command_token_submit_error', {
+				error: e.message,
+			} );
+
+			throw e;
+		}
+
+		await trackEvent( 'login_command_token_submit_success' );
+
+	} );

--- a/src/bin/vip-login.js
+++ b/src/bin/vip-login.js
@@ -22,7 +22,7 @@ command( { format: true } )
 
 		// double check if user is already logged in
 		if ( token && token.valid() ) {
-			return console.log( 'You are already logged in' );
+			return console.log( 'You are already logged in!' );
 		}
 
 		console.log();
@@ -103,6 +103,7 @@ command( { format: true } )
 			throw e;
 		}
 
+		console.log( 'You are now logged in!' );
 		await trackEvent( 'login_command_token_submit_success' );
 
 	} );

--- a/src/bin/vip-login.js
+++ b/src/bin/vip-login.js
@@ -12,6 +12,9 @@ import inquirer from 'inquirer';
  */
 import command from 'lib/cli/command';
 import Token from 'lib/token';
+import { trackEvent } from 'lib/tracker';
+
+const tokenURL = 'https://dashboard.wpvip.com/me/cli/token';
 
 command( { format: true } )
 	.argv( process.argv, async ( arg, options ) => {

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -28,6 +28,7 @@ const rootCmd = async function() {
 				await trackEvent( 'logout_command_execute' );
 			} )
 			.command( 'app', 'List and modify your VIP Go apps' )
+			.command( 'login', 'Login to the vip cli' )
 			.command( 'sync', 'Sync production to a development environment' )
 			.argv( process.argv );
 	} else {

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -5,8 +5,6 @@
  * External dependencies
  */
 import args from 'args';
-import opn from 'opn';
-import inquirer from 'inquirer';
 
 /**
  * Internal dependencies
@@ -34,86 +32,6 @@ const rootCmd = async function() {
 	} else {
 		// Bypass helper function
 		args.parse( process.argv );
-
-		console.log();
-		console.log( '  Welcome to' );
-		console.log( '   _    __________     ______' );
-		console.log( '  | |  / /  _/ __ \\   / ____/___' );
-		console.log( '  | | / // // /_/ /  / / __/ __ \\' );
-		console.log( '  | |/ // // ____/  / /_/ / /_/ /' );
-		console.log( '  |___/___/_/       \\____/\\____/' );
-		console.log();
-		console.log( '  VIP CLI is your tool for interacting with and managing your VIP Go applications.' );
-		console.log();
-
-		console.log( `  To get started, we need an access token for your VIP account. We'll open ${ tokenURL } in your web browser; follow the instructions there to continue.` );
-		console.log();
-
-		await trackEvent( 'login_command_execute' );
-
-		const c = await inquirer.prompt( {
-			type: 'confirm',
-			name: 'continue',
-			message: 'Ready?',
-			prefix: '',
-		} );
-
-		if ( ! c.continue ) {
-			await trackEvent( 'login_command_browser_cancelled' );
-
-			return;
-		}
-
-		opn( tokenURL, { wait: false } );
-
-		await trackEvent( 'login_command_browser_opened' );
-
-		let t = await inquirer.prompt( {
-			type: 'password',
-			name: 'token',
-			message: 'Access Token:',
-			prefix: '',
-		} );
-
-		t = t.token;
-
-		try {
-			token = new Token( t );
-		} catch ( e ) {
-			console.log( 'The token provided is malformed. Please check the token and try again.' );
-
-			await trackEvent( 'login_command_token_submit_error', { error: e.message } );
-
-			return;
-		}
-
-		if ( token.expired() ) {
-			console.log( 'The token provided is expired. Please log in again to refresh the token.' );
-
-			await trackEvent( 'login_command_token_submit_error', { error: 'expired' } );
-
-			return;
-		}
-
-		if ( ! token.valid() ) {
-			console.log( 'The provided token is not valid. Please log in again to refresh the token.' );
-
-			await trackEvent( 'login_command_token_submit_error', { error: 'invalid' } );
-
-			return;
-		}
-
-		try {
-			Token.set( token.raw );
-		} catch ( e ) {
-			await trackEvent( 'login_command_token_submit_error', {
-				error: e.message,
-			} );
-
-			throw e;
-		}
-
-		await trackEvent( 'login_command_token_submit_success' );
 
 		// Exec the command we originally  wanted
 		const argv = process.argv.slice( 2 );

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -11,6 +11,7 @@ import args from 'args';
  */
 import command from 'lib/cli/command';
 import Token from 'lib/token';
+import { trackEvent } from 'lib/tracker';
 
 // Config
 const rootCmd = async function() {

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -27,6 +27,9 @@ const rootCmd = async function() {
 			.command( 'sync', 'Sync production to a development environment' )
 			.argv( process.argv );
 	} else {
+		// parse arguments in case it's a general subcommand (help, version...)
+		args.parse( process.argv );
+
 		const { spawn } = require('child_process');
 
 		// run login first

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -11,11 +11,8 @@ import args from 'args';
  */
 import command from 'lib/cli/command';
 import Token from 'lib/token';
-import { trackEvent } from 'lib/tracker';
 
 // Config
-const tokenURL = 'https://dashboard.wpvip.com/me/cli/token';
-
 const rootCmd = async function() {
 	let token = await Token.get();
 

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -52,7 +52,7 @@ const rootCmd = async function() {
 		loginSpawn.on( 'exit', async ( code, signal ) => {
 			let token = await Token.get();
 
-			if ( token && token.valid() ) {
+			if ( token && token.valid() && ! 'login' === currentCommand ) {
 				// user is logged in now, run desired command:
 				return spawn( process.argv[ 0 ], process.argv.slice( 1 ), { stdio: 'inherit' } );
 			}

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -13,6 +13,12 @@ import command from 'lib/cli/command';
 import Token from 'lib/token';
 import { trackEvent } from 'lib/tracker';
 
+// By default, we'll log the user if he's logged out
+// Define commands to ignore from this behavior
+const IGNORE_LOGIN = [
+	'logout',
+];
+
 // Config
 const rootCmd = async function() {
 	let token = await Token.get();
@@ -30,6 +36,12 @@ const rootCmd = async function() {
 	} else {
 		// parse arguments in case it's a general subcommand (help, version...)
 		args.parse( process.argv );
+
+		const currentCommand = process.argv[ 2 ];
+
+		if ( IGNORE_LOGIN.includes( currentCommand ) ) {
+			return;
+		}
 
 		const { spawn } = require('child_process');
 

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -22,8 +22,8 @@ const rootCmd = async function() {
 				await Token.purge();
 				await trackEvent( 'logout_command_execute' );
 			} )
-			.command( 'app', 'List and modify your VIP Go apps' )
 			.command( 'login', 'Login to the vip cli' )
+			.command( 'app', 'List and modify your VIP Go apps' )
 			.command( 'sync', 'Sync production to a development environment' )
 			.argv( process.argv );
 	} else {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -22,6 +22,11 @@ import { trackEvent } from 'lib/tracker';
 import pager from 'lib/cli/pager';
 
 function uncaughtError( err ) {
+	// If it's a non existant subcommand, do not log the unexpected error message
+	if ( 'ENOENT' === err.code && err.syscall.startsWith( 'spawn' ) ) {
+		return;
+	}
+
 	console.log();
 	console.log( ' ', chalk.red( '✕' ), ' Unexpected error: Please contact VIP Support with the following error:' );
 	console.log( ' ', chalk.dim( err.stack ) );


### PR DESCRIPTION
This adds the login subcommand to the `cli`.

It also fixes these types of errors: (https://github.com/Automattic/vip/commit/6c26502a92e0501524283ad4e9b5ed7fcc30a2ab)
```
✕  Unexpected error: Please contact VIP Support with the following error:
  Error: spawn vip-login ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:238:19)
    at onErrorNT (internal/child_process.js:413:16)
    at process.internalTickCallback (internal/process/next_tick.js:72:19)
```

### How to test:
1. clone this branch
2. execute `vip logout`
3. execute `npm link`

#### First test:
4. execute `vip aaa`, **you should be redirected** to the `login` flow
5. when prompted with `Ready? (Y, n)`, respond with `n`. You **should quit the command**.

#### Second test:
4. execute `vip aaa`, and complete the `login` workflow
5. when the `login` workflow is done, your `aaa` command **should execute after**. and you should **get an error that the subcommand isn't defined**

fixes #196 
