### PR TITLE
Fix logged out help

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -21,7 +21,8 @@ const tokenURL = 'https://dashboard.wpvip.com/me/cli/token';
 const rootCmd = async function() {
 	let token = await Token.get();
 
-	if ( token && token.valid() ) {
+	const helpCommand = process.argv.some( arg => arg === 'help' || arg === '-h' || arg === '--help' );
+	if ( helpCommand || ( token && token.valid() ) ) {
 		command()
 			.command( 'logout', 'Logout from your current session', async () => {
 				await Token.purge();


### PR DESCRIPTION
Since we only register subcommands when you're logged in, you couldn't
see any help text before logging in. This registers subcommands even
when you're logged out if you call the `help` command. Either `vip
help`, `vip -h`, or `vip --help` should work.

Testing:

1. Download the CLI from this PR
1. npm link
1. Run `vip help` `vip -h` `vip --help`

Note: There's a related, known issue (#162) where help for subcommands
shows the help for the root command. This PR allows help to be shown
for subcommands when you're logged out, but it will still be for the
root command until that other issue is fixed.

Fixes #211