### PR TITLE
Fix login bug when trying to logout

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -22,7 +22,9 @@ const rootCmd = async function() {
 	let token = await Token.get();
 
 	const helpCommand = process.argv.some( arg => arg === 'help' || arg === '-h' || arg === '--help' );
-	if ( helpCommand || ( token && token.valid() ) ) {
+	const logoutCommand = process.argv.some( arg => arg === 'logout' );
+
+	if ( logoutCommand || helpCommand || ( token && token.valid() ) ) {
 		command()
 			.command( 'logout', 'Logout from your current session', async () => {
 				await Token.purge();

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -21,10 +21,10 @@ const tokenURL = 'https://dashboard.wpvip.com/me/cli/token';
 const rootCmd = async function() {
 	let token = await Token.get();
 
-	const helpCommand = process.argv.some( arg => arg === 'help' || arg === '-h' || arg === '--help' );
-	const logoutCommand = process.argv.some( arg => arg === 'logout' );
+	const isHelpCommand = process.argv.some( arg => arg === 'help' || arg === '-h' || arg === '--help' );
+	const isLogoutCommand = process.argv.some( arg => arg === 'logout' );
 
-	if ( logoutCommand || helpCommand || ( token && token.valid() ) ) {
+	if ( isLogoutCommand || isHelpCommand || ( token && token.valid() ) ) {
 		command()
 			.command( 'logout', 'Logout from your current session', async () => {
 				await Token.purge();


### PR DESCRIPTION
Currently if a user wants to logout and the user isn't logged in, a login prompt will be displayed.

This fixes that behavior by skipping the `login` if the command is `logout`