### PR TITLE
Fix EPIPE error when hitting quit

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -22,6 +22,9 @@ import { trackEvent } from 'lib/tracker';
 import pager from 'lib/cli/pager';
 
 function uncaughtError( err ) {
+	// Error raised when trying to write to an already closed stream
+	if ( err.code === 'EPIPE' ) return;
+
 	console.log();
 	console.log( ' ', chalk.red( '✕' ), ' Unexpected error: Please contact VIP Support with the following error:' );
 	console.log( ' ', chalk.dim( err.stack ) );

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -23,7 +23,9 @@ import pager from 'lib/cli/pager';
 
 function uncaughtError( err ) {
 	// Error raised when trying to write to an already closed stream
-	if ( err.code === 'EPIPE' ) return;
+	if ( err.code === 'EPIPE' ) {
+		return;
+	}
 
 	console.log();
 	console.log( ' ', chalk.red( '✕' ), ' Unexpected error: Please contact VIP Support with the following error:' );


### PR DESCRIPTION
This error is raised when trying to write to a closed stream. Node doesn't get rid of those extra messages and raises an error as per https://github.com/nodejs/node/issues/947

From the same issue, it's supposed to be fixed in 8 and up. I tested in node 8 and 10 and I get the error.

This checks if the error code is `EPIPE` and return.

fixes #175