### PR TITLE
Show an error when a user can't run a sync

### DIFF
--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -20,7 +20,7 @@ import { trackEvent } from 'lib/tracker';
 const appQuery = `id,name,environments{
 	id,name,defaultDomain,branch,datacenter,syncProgress{
 		status,sync,steps{name,status}
-	},syncPreview { backup { createdAt }, replacements { from, to } }
+	},syncPreview { canSync, errors { message }, backup { createdAt }, replacements { from, to } }
 }`;
 
 command( {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -282,7 +282,15 @@ args.argv = async function( argv, cb ): Promise<any> {
 			message = _opts.requireConfirm;
 		}
 
-		const { backup } = options.env.syncPreview;
+		const { backup, canSync, errors } = options.env.syncPreview;
+
+		if( ! canSync ) {
+			// User can not sync due to some error(s)
+			// Shows the first error in the array
+			console.log( `${ chalk.red( 'Error:' ) } Could not sync to this environment: ${ errors[ 0 ].message }` );
+			return {};
+		}
+
 		// remove __typename from replacements.
 		// can not be deleted afterwards if deconstructed
 		const replacements = options.env.syncPreview.replacements.map( rep => {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -284,7 +284,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 		const { backup, canSync, errors } = options.env.syncPreview;
 
-		if( ! canSync ) {
+		if ( ! canSync ) {
 			// User can not sync due to some error(s)
 			// Shows the first error in the array
 			console.log( `${ chalk.red( 'Error:' ) } Could not sync to this environment: ${ errors[ 0 ].message }` );


### PR DESCRIPTION
This shows an error if the user can not sync to an environment:

```
Error: Could not sync to this environment: Data sync requires a .vip.yml config when multiple domains are mapped. See <redacted link>
```

Before this it was an unhandled error

### How to test
0. Select an app having an environment with missing config
1. Get this branch
2. Run `npm link`
3. Run `npm sync` with the desired app and environment
4. You should get an error

Fix #226 