### PR TITLE
Use type instead of name

### DIFF
--- a/src/bin/vip-app.js
+++ b/src/bin/vip-app.js
@@ -9,7 +9,7 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
-import command from 'lib/cli/command';
+import command, { getEnvIdentifier } from 'lib/cli/command';
 import app from 'lib/api/app';
 import { trackEvent } from 'lib/tracker';
 
@@ -25,7 +25,7 @@ command( { requiredArgs: 1, format: true } )
 		try {
 			res = await app(
 				arg[ 0 ],
-				'id,repo,name,environments{name,branch,currentCommit,primaryDomain{name}}'
+				'id,repo,name,environments{id,appId,name,type,branch,currentCommit,primaryDomain{name}}'
 			);
 		} catch ( e ) {
 			await trackEvent( 'app_command_fetch_error', {
@@ -58,6 +58,8 @@ command( { requiredArgs: 1, format: true } )
 
 		r.environments = r.environments.map( env => {
 			const e = Object.assign( {}, env );
+
+			e.name = getEnvIdentifier( env );
 
 			// Use the short version of git commit hash
 			e.currentCommit = e.currentCommit.substring( 0, 7 );

--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -18,7 +18,7 @@ import { formatEnvironment } from 'lib/cli/format';
 import { trackEvent } from 'lib/tracker';
 
 const appQuery = `id,name,environments{
-	id,type,name,defaultDomain,branch,datacenter,syncProgress{
+	id,appId,type,name,defaultDomain,branch,datacenter,syncProgress{
 		status,sync,steps{name,status}
 	},syncPreview { canSync, errors { message }, backup { createdAt }, replacements { from, to } }
 }`;

--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -18,7 +18,7 @@ import { formatEnvironment } from 'lib/cli/format';
 import { trackEvent } from 'lib/tracker';
 
 const appQuery = `id,name,environments{
-	id,name,defaultDomain,branch,datacenter,syncProgress{
+	id,type,name,defaultDomain,branch,datacenter,syncProgress{
 		status,sync,steps{name,status}
 	},syncPreview { canSync, errors { message }, backup { createdAt }, replacements { from, to } }
 }`;

--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -111,7 +111,7 @@ command( {
 		console.log();
 		console.log( `  syncing: ${ chalk.yellow( opts.app.name ) }` );
 		console.log( `     from: ${ formatEnvironment( 'production' ) }` );
-		console.log( `       to: ${ formatEnvironment( opts.env.name ) }` );
+		console.log( `       to: ${ formatEnvironment( opts.env.type ) }` );
 
 		let i = 0;
 		const progress = setInterval( async () => {

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -23,6 +23,7 @@ import Token from '../lib/token';
 
 const appQuery = `id, name, environments {
 	id
+	appId
 	type
 	name
 }`;

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -216,7 +216,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 				return {};
 			}
 
-			const env = options.app.environments.find( cur => cur.name === options.env );
+			const env = options.app.environments.find( cur => cur.type === options.env );
 
 			if ( ! env ) {
 				await trackEvent( 'command_childcontext_param_error', {
@@ -240,7 +240,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		} else if ( options.app.environments.length === 1 ) {
 			options.env = options.app.environments[ 0 ];
 		} else if ( options.app.environments.length > 1 ) {
-			const environmentNames = options.app.environments.map( envObject => envObject.name );
+			const environmentNames = options.app.environments.map( envObject => envObject.type );
 			const e = await prompt( {
 				type: 'select',
 				name: 'env',
@@ -249,14 +249,14 @@ args.argv = async function( argv, cb ): Promise<any> {
 			} );
 
 			// Get full environment info after user selection
-			e.env = options.app.environments.find( envObject => envObject.name === e.env );
+			e.env = options.app.environments.find( envObject => envObject.type === e.env );
 
 			if ( ! e || ! e.env || ! e.env.id ) {
 				await trackEvent( 'command_childcontext_list_select_error', {
 					error: 'Invalid environment selected',
 				} );
 
-				console.log( `Environment ${ chalk.blueBright( e.env.name ) } does not exist` );
+				console.log( `Environment ${ chalk.blueBright( e.env.type ) } does not exist` );
 				return {};
 			}
 
@@ -275,7 +275,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		}
 
 		if ( options.env ) {
-			info.push( { key: 'environment', value: options.env.name } );
+			info.push( { key: 'environment', value: options.env.type } );
 		}
 
 		let message = 'Are you sure?';

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -402,7 +402,7 @@ export default function( opts: any ): args {
 	return a;
 }
 
-function getEnvIdentifier( env ) {
+export function getEnvIdentifier( env ) {
 	let identifier = env.type;
 
 	// If the env has a unique name (happens when site has multiple envs of a type), add on name


### PR DESCRIPTION
fix #266 

This should display `production` for the production environment

### Steps to test
1. Get this PR
2. Run `npm i` & `npm link`
3. Test it on an app, ex `647`