### PR TITLE
Use separate tokens per host

### DIFF
--- a/__tests__/lib/token.js
+++ b/__tests__/lib/token.js
@@ -2,7 +2,7 @@
 /**
  * Internal dependencies
  */
-import Token from 'lib/token';
+import Token, { SERVICE } from 'lib/token';
 
 describe( 'token tests', () => {
 	it( 'should correctly validate token', () => {
@@ -56,6 +56,29 @@ describe( 'token tests', () => {
 			Token.uuid().then( uuid2 => {
 				expect( uuid1 ).toBe( uuid2 );
 			} );
+		} );
+	} );
+
+	describe( 'getServiceName()', () => {
+		// TODO how do we test this when it comes from env var, which we've already overridden?
+		it.todo( 'should return default service name for default API_HOST' );
+
+		it( 'should add the API_HOST to the service name if overridden', () => {
+			const name = Token.getServiceName();
+
+			const sanitizedHost = 'http---localhost-4000'; // Sanitized version of process.env.API_HOST
+
+			expect( name ).toBe( `${ SERVICE }:${ sanitizedHost }` );
+		} );
+
+		it( 'should append an optional modifier to the final service name', () => {
+			const modifier = '-foo';
+
+			const name = Token.getServiceName( modifier );
+
+			const sanitizedHost = 'http---localhost-4000'; // Sanitized version of process.env.API_HOST
+
+			expect( name ).toBe( `${ SERVICE }:${ sanitizedHost }${ modifier }` );
 		} );
 	} );
 } );

--- a/__tests__/lib/token.js
+++ b/__tests__/lib/token.js
@@ -5,7 +5,7 @@
 import Token from 'lib/token';
 
 describe( 'token tests', () => {
-	test( 'should correctly validate token', () => {
+	it( 'should correctly validate token', () => {
 		// Does not expire
 		const t = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWQiOjcsImlhdCI6MTUxNjIzOTAyMn0.RTJMXHhhiaCxQberZ5Pre7SBU3Ci8EvCyaOXoqG3pNA';
 		const token = new Token( t );
@@ -13,13 +13,13 @@ describe( 'token tests', () => {
 		expect( token.expired() ).toEqual( false );
 	} );
 
-	test( 'should correctly validate token missing an id', () => {
+	it( 'should correctly validate token missing an id', () => {
 		const t = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1MTYxMzUyNzYsImV4cCI6MjUyNDYwODAwMCwiYXVkIjoiIiwic3ViIjoiIn0.seD8rBKJS0usjYApigqizitlNcmzcrYlGt9DyCm3I4c';
 		const token = new Token( t );
 		expect( token.valid() ).toEqual( false );
 	} );
 
-	test( 'should error for invalid token', () => {
+	it( 'should error for invalid token', () => {
 		const t = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImp0aSI6IjRhM2RmYjE5LTBhMWQtNDE3YS05ODM2LTdjZWIwZTBkM2Q4NSIsImlhdCI6MTUxNjEyMzU1NywiZXhwIjoxNTE2MTI3zM4fQ.atx1YhxB6SQoW99aL97tXNlyJlXWEPZ3Cf1zyfxizvs';
 		let token;
 		try {
@@ -30,14 +30,14 @@ describe( 'token tests', () => {
 		expect( token ).toEqual( undefined );
 	} );
 
-	test( 'should not validate expired token', () => {
+	it( 'should not validate expired token', () => {
 		const t = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiaWF0IjoxNTE1NzExMDY5LCJleHAiOjE1MTU3OTc0Njl9.hZ-mAeoFAahak9WXqAVTOKEU7R_f1VsZfS5HqZOm-a4';
 		const token = new Token( t );
 		expect( token.valid() ).toEqual( false );
 		expect( token.expired() ).toEqual( true );
 	} );
 
-	test( 'should correctly validate token with invalid whitespace', () => {
+	it( 'should correctly validate token with invalid whitespace', () => {
 		const leadingWhitespace = ' eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWQiOjcsImlhdCI6MTUxNjIzOTAyMn0.RTJMXHhhiaCxQberZ5Pre7SBU3Ci8EvCyaOXoqG3pNA';
 		let token = new Token( leadingWhitespace );
 		expect( token.valid() ).toEqual( true );
@@ -51,7 +51,7 @@ describe( 'token tests', () => {
 		expect( token.valid() ).toEqual( false );
 	} );
 
-	test( 'should consistently return uuid', () => {
+	it( 'should consistently return uuid', () => {
 		Token.uuid().then( uuid1 => {
 			Token.uuid().then( uuid2 => {
 				expect( uuid1 ).toBe( uuid2 );

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -3,5 +3,7 @@
  */
 import nock from 'nock';
 
+process.env.API_HOST = 'http://localhost:4000';
+
 // Don't let tests talk to the outside world
 nock.disableNetConnect();

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -14,7 +14,8 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import Token from './token';
 
 // Config
-export const API_HOST = process.env.API_HOST || 'https://api.wpvip.com';
+export const PRODUCTION_API_HOST = 'https://api.wpvip.com';
+export const API_HOST = process.env.API_HOST || PRODUCTION_API_HOST;
 export const API_URL = `${ API_HOST }/graphql`;
 
 export default async function API(): Promise<ApolloClient> {

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -13,6 +13,10 @@ import keychain from './keychain';
 
 // Config
 const SERVICE = 'vip-go-cli';
+import {
+	API_HOST,
+	PRODUCTION_API_HOST,
+} from './api';
 
 export default class Token {
 	raw: string;
@@ -93,5 +97,16 @@ export default class Token {
 
 	static async purge(): Promise<boolean> {
 		return keychain.deletePassword( SERVICE );
+
+	static getServiceName( modifier: string = '' ): string {
+		let service = SERVICE;
+
+		if ( PRODUCTION_API_HOST !== API_HOST ) {
+			const sanitized = API_HOST.replace( /[^a-z0-9]/gi, '-' );
+
+			service = `${ SERVICE }:${ sanitized }`;
+		}
+
+		return `${ service }${ modifier }`;
 	}
 }

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -77,26 +77,35 @@ export default class Token {
 	}
 
 	static async uuid(): string {
-		let _uuid = await keychain.getPassword( SERVICE + '-uuid' );
+		const service = Token.getServiceName( '-uuid' );
+
+		let _uuid = await keychain.getPassword( service );
 		if ( ! _uuid ) {
 			_uuid = uuid();
-			await keychain.setPassword( SERVICE + '-uuid', _uuid );
+			await keychain.setPassword( service, _uuid );
 		}
 
 		return _uuid;
 	}
 
 	static async set( token: string ): Promise<boolean> {
-		return keychain.setPassword( SERVICE, token );
+		const service = Token.getServiceName();
+
+		return keychain.setPassword( service, token );
 	}
 
 	static async get(): Promise<Token> {
-		const token = await keychain.getPassword( SERVICE );
+		const service = Token.getServiceName();
+
+		const token = await keychain.getPassword( service );
 		return new Token( token );
 	}
 
 	static async purge(): Promise<boolean> {
-		return keychain.deletePassword( SERVICE );
+		const service = Token.getServiceName();
+
+		return keychain.deletePassword( service );
+	}
 
 	static getServiceName( modifier: string = '' ): string {
 		let service = SERVICE;

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -11,13 +11,13 @@ import uuid from 'uuid/v4';
  */
 import keychain from './keychain';
 
-// Config
-const SERVICE = 'vip-go-cli';
 import {
 	API_HOST,
 	PRODUCTION_API_HOST,
 } from './api';
 
+// Config
+export const SERVICE = 'vip-go-cli';
 export default class Token {
 	raw: string;
 	id: number;


### PR DESCRIPTION
To make local dev easier, we should key tokens by API host, so that we can be logged in to both production and a local instance at the same time.

This means we no longer need to logout / login when switching between environments, which will make development faster and easier.

NOTE - this is designed to be backwards compatible with existing token saving - it will behave the same as before unless `API_HOST=<some-other-host>` is set in the env vars.

Fixes #262

## Testing

1. Be already logged into production
1. Start Parker API locally
1. Pull PR - `update/262-separate-tokens-per-host`
1. `npm run build`
1. (Optionally `npm link`)
1. Test production request again (should still be logged in and should work normally) - `./dist/bin/vip-app-list.js`
1. Test local request - `API_HOST=http://localhost:4000 ./dist/bin/vip-app-list.js`
1. Should be logged out - token is invalid
1. Logout on local dev - `API_HOST=http://localhost:4000 ./dist/bin/vip.js logout`
1. Login on local dev - `API_HOST=http://localhost:4000 ./dist/bin/vip.js` (use token for local API instance)
1. Try local request again (should succeed) - `API_HOST=http://localhost:4000 ./dist/bin/vip-app-list.js`
1. Test production request again (should succeed normally) - `./dist/bin/vip-app-list.js`