### PR TITLE
Fix error handling

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -29,7 +29,7 @@ export default async function API(): Promise<ApolloClient> {
 	}
 
 	const unauthorizedLink = onError( ( { networkError } ) => {
-		if ( networkError.statusCode === 401 ) {
+		if ( networkError && networkError.statusCode === 401 ) {
 			console.error( chalk.red( 'Unauthorized:' ), 'You are unauthorized to perform this request, please logout with `vip logout` then try again.' );
 			process.exit();
 		}


### PR DESCRIPTION
Fixes the `unauthorizedLink` to first check `networkError` (because it can be `null`).

Then adds generic GraphQL error handling to the network link, to abort the CLI if an error is encountered. NOTE - at some point it may be necessary or expected to receive _some_ errors (not all GraphQL errors are fatal) - we can revisit this and maybe add some exceptions in that case.

Fixes #277