### PR TITLE
Add sub shell experience to WP CLI

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -127,7 +127,6 @@ commandWrapper( {
 			} );
 
 			subShellRl.on( 'line', async line => {
-				console.log( 'received line:', line );
 				subShellRl.pause();
 
 				try {

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -121,7 +121,7 @@ commandWrapper( {
 				input: process.stdin,
 				output: process.stdout,
 				terminal: true,
-				prompt: `${ appName }.${ getEnvIdentifier( opts.env ) }> `,
+				prompt: `${ appName }.${ getEnvIdentifier( opts.env ) }$ `,
 				// TODO make history persistent across sessions for same env
 				historySize: 200,
 			} );

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -91,7 +91,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken } ) => {
 	} );
 
 	return { stdinStream, stdoutStream };
-}
+};
 
 commandWrapper( {
 	wildcardCommand: true,
@@ -130,7 +130,7 @@ commandWrapper( {
 				const startsWithWp = line.startsWith( 'wp ' );
 				const empty = 0 === line.length;
 
-				if( empty || ! startsWithWp ) {
+				if ( empty || ! startsWithWp ) {
 					console.log( chalk.red( 'Error:' ), 'invalid command, please pass a valid WP CLI command.' );
 					return;
 				}

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -156,14 +156,7 @@ commandWrapper( {
 				} );
 
 				subShellRl.on( 'SIGINT', () => {
-					subShellRl.question( 'Are you sure you want to exit the subshell mode? ', answer => {
-						if ( answer.match( /^y(es)?$/i ) ) {
-							commandStreams.stdinStream.write( 'exit();\n' );
-							process.exit();
-						} else {
-							subShellRl.prompt();
-						}
-					} );
+					commandStreams.stdinStream.write( 'exit();\n' );
 				} );
 			} );
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -26,6 +26,9 @@ const appQuery = `id, name, environments {
 	appId
 	type
 	name
+	primaryDomain {
+		name
+	}
 }`;
 
 const getTokenForCommand = async ( appId, envId, command ) => {
@@ -115,7 +118,7 @@ commandWrapper( {
 		let subShellRl;
 
 		if ( isSubShell ) {
-			console.log( `Entering WP-CLI subshell mode for ${ formatEnvironment( envName ) } on ${ appName } (${ appId })` );
+			console.log( `Welcome to the WP CLI shell for the ${ formatEnvironment( envName ) } environment of ${ chalk.green( appName ) } (${ opts.env.primaryDomain.name })!` );
 
 			subShellRl = readline.createInterface( {
 				input: process.stdin,

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -120,11 +120,13 @@ commandWrapper( {
 		if ( isSubShell ) {
 			console.log( `Welcome to the WP CLI shell for the ${ formatEnvironment( envName ) } environment of ${ chalk.green( appName ) } (${ opts.env.primaryDomain.name })!` );
 
+			const promptIdentifier = `${ appName }.${ getEnvIdentifier( opts.env ) }`;
+
 			subShellRl = readline.createInterface( {
 				input: process.stdin,
 				output: process.stdout,
 				terminal: true,
-				prompt: `${ appName }.${ getEnvIdentifier( opts.env ) }> `,
+				prompt: chalk`{bold.yellowBright ${ promptIdentifier }:}{blue ~}$ `,
 				// TODO make history persistent across sessions for same env
 				historySize: 200,
 			} );

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -175,6 +175,7 @@ commandWrapper( {
 				rl.question( 'Are you sure you want to exit? ', answer => {
 					if ( answer.match( /^y(es)?$/i ) ) {
 						commandStreams.stdinStream.write( 'exit();\n' );
+						process.exit();
 					} else {
 						rl.prompt();
 					}

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -28,7 +28,7 @@ const appQuery = `id, name, environments {
 	name
 }`;
 
-const launchCommandOnEnv = async ( appId, envId, command ) => {
+const getTokenForCommand = async ( appId, envId, command ) => {
 	const api = await API();
 
 	return api
@@ -147,7 +147,7 @@ commandWrapper( {
 		}
 
 		try {
-			result = await launchCommandOnEnv( appId, envId, cmd );
+			result = await getTokenForCommand( appId, envId, cmd );
 		} catch ( e ) {
 			console.log( e );
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -149,8 +149,6 @@ commandWrapper( {
 				commandStreams.stdoutStream.on( 'error', err => {
 					// TODO handle this better
 					console.log( err );
-
-					process.exit( 1 );
 				} );
 
 				commandStreams.stdoutStream.on( 'end', () => {

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -127,6 +127,13 @@ commandWrapper( {
 			} );
 
 			subShellRl.on( 'line', async line => {
+				// Check for exit, like SSH (handles both `exit` and `exit;`)
+				if ( line.startsWith( 'exit' ) ) {
+					subShellRl.close();
+
+					process.exit();
+				}
+
 				const startsWithWp = line.startsWith( 'wp ' );
 				const empty = 0 === line.length;
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -161,13 +161,17 @@ commandWrapper( {
 
 				commandStreams.stdoutStream.on( 'end', () => {
 					subShellRl.resume();
-				} );
 
-				subShellRl.on( 'SIGINT', () => {
-					subShellRl.close();
-
-					process.exit();
+					subShellRl.prompt();
 				} );
+			} );
+
+			subShellRl.prompt();
+
+			subShellRl.on( 'SIGINT', () => {
+				subShellRl.close();
+
+				process.exit();
 			} );
 
 			return;

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -164,7 +164,9 @@ commandWrapper( {
 				} );
 
 				subShellRl.on( 'SIGINT', () => {
-					commandStreams.stdinStream.write( 'exit();\n' );
+					subShellRl.close();
+
+					process.exit();
 				} );
 			} );
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -127,6 +127,14 @@ commandWrapper( {
 			} );
 
 			subShellRl.on( 'line', async line => {
+				const startsWithWp = line.startsWith( 'wp ' );
+				const empty = 0 === line.length;
+
+				if( empty || ! startsWithWp ) {
+					console.log( chalk.red( 'Error:' ), 'invalid command, please pass a valid WP CLI command.' );
+					return;
+				}
+
 				subShellRl.pause();
 
 				try {

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -121,7 +121,7 @@ commandWrapper( {
 				input: process.stdin,
 				output: process.stdout,
 				terminal: true,
-				prompt: `${ appName }.${ getEnvIdentifier( envName ) }> `,
+				prompt: `${ appName }.${ getEnvIdentifier( opts.env ) }> `,
 				// TODO make history persistent across sessions for same env
 				historySize: 200,
 			} );

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -15,7 +15,7 @@ import readline from 'readline';
  * Internal dependencies
  */
 import API, { API_HOST } from 'lib/api';
-import commandWrapper from 'lib/cli/command';
+import commandWrapper, { getEnvIdentifier } from 'lib/cli/command';
 import { formatEnvironment } from 'lib/cli/format';
 import { confirm } from 'lib/cli/prompt';
 import { trackEvent } from 'lib/tracker';
@@ -121,7 +121,7 @@ commandWrapper( {
 				input: process.stdin,
 				output: process.stdout,
 				terminal: true,
-				prompt: `${ appName }.${ envName }> `,
+				prompt: `${ appName }.${ getEnvIdentifier( envName ) }> `,
 				// TODO make history persistent across sessions for same env
 				historySize: 200,
 			} );


### PR DESCRIPTION
This adds the sub shell experience to the WP CLI commands.

How to test:
1. Get this branch
2. Run `npm link`
3. Run `vip wp --app=XXX --env=YYY`
4. Welcome to sub shell mode
5. Run whatever commands you want
6. When finishing hit Ctrl + C
7. Respond `yes`
8. 💰 

There is some copy paste there, but couldn't find a better way of doing it. Ideas are always welcome :)