### PR TITLE
Make wp shell impossible in sub-shell mode

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -141,9 +141,15 @@ commandWrapper( {
 
 				const startsWithWp = line.startsWith( 'wp ' );
 				const empty = 0 === line.length;
+				const isShellCommand = 'wp shell' === line;
 
 				if ( empty || ! startsWithWp ) {
 					console.log( chalk.red( 'Error:' ), 'invalid command, please pass a valid WP CLI command.' );
+					return;
+				}
+
+				if ( isShellCommand ) {
+					console.log( chalk.red( 'Error:' ), 'you can not run \'wp shell\' in the subshell mode.' );
 					return;
 				}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -141,7 +141,7 @@ commandWrapper( {
 
 				const startsWithWp = line.startsWith( 'wp ' );
 				const empty = 0 === line.length;
-				const isShellCommand = 'wp shell' === line;
+				const isShellCommand = line.startsWith( 'wp shell ' );
 
 				if ( empty || ! startsWithWp ) {
 					console.log( chalk.red( 'Error:' ), 'invalid command, please pass a valid WP CLI command.' );


### PR DESCRIPTION
This makes running `wp shell` impossible in the sub-shell mode