### PR TITLE
Add error message for rate limit

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -96,7 +96,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken } ) => {
 
 	socket.on( 'error', err => {
 		if ( err === 'Rate limit exceeded' ) {
-			console.log( chalk.red( '\nError:' ), 'Maximum concurrent running commands have been reached, please allow some to finish before starting another.' );
+			console.log( chalk.red( '\nError:' ), 'Rate limit exceeded: Please wait a moment and try again.' );
 			return;
 		}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -89,7 +89,17 @@ const launchCommandAndGetStreams = async ( { guid, inputToken } ) => {
 		console.log( 'There was an error with the authentication:', err.message );
 	} );
 
+	IOStream( socket ).on( 'error', err => {
+		// This returns the error so it can be catched by the socket.on('error')
+		return err;
+	} );
+
 	socket.on( 'error', err => {
+		if ( err = 'Rate limit exceeded' ) {
+			console.log( chalk.red( '\nError:' ), 'you can not run more than two commands in the same time against an environment.' );
+			return;
+		}
+
 		console.log( err );
 	} );
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -96,7 +96,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken } ) => {
 
 	socket.on( 'error', err => {
 		if ( err === 'Rate limit exceeded' ) {
-			console.log( chalk.red( '\nError:' ), 'you can not run more than two commands in the same time against an environment.' );
+			console.log( chalk.red( '\nError:' ), 'you can not run more than two commands simultaneously in the same environment.' );
 			return;
 		}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -96,7 +96,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken } ) => {
 
 	socket.on( 'error', err => {
 		if ( err === 'Rate limit exceeded' ) {
-			console.log( chalk.red( '\nError:' ), 'you can not run more than two commands simultaneously in the same environment.' );
+			console.log( chalk.red( '\nError:' ), 'Maximum concurrent running commands have been reached, please allow some to finish before starting another.' );
 			return;
 		}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -95,7 +95,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken } ) => {
 	} );
 
 	socket.on( 'error', err => {
-		if ( err = 'Rate limit exceeded' ) {
+		if ( err === 'Rate limit exceeded' ) {
 			console.log( chalk.red( '\nError:' ), 'you can not run more than two commands in the same time against an environment.' );
 			return;
 		}


### PR DESCRIPTION
This handles the rate limit error and displays an error message:

`Error: you can not run more than two commands in the same time against an environment.`

Ideally we should check for the `code` of the error object instead of the message, but looks like the error received isn't an object, it's a string containing the error message :/

### Testing
1. Get this branch
2. Run `npm link`
3. Enter the subshell mode for an environment
4. Paste the following
```
wp option get home
wp option get home
wp option get home
```
5. You should see the error message
6. Try with two only
```
wp option get home
wp option get home
```
7. Should work

fix #283 