### PR TITLE
Remove help and version in favor of -h/--help and -v/--version

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -410,8 +410,8 @@ export default function( opts: any ): args {
 	}
 
 	// Add help and version to all subcommands
-	a.option( 'help', 'Output the help for the (sub)command', false );
-	a.option( 'version', 'Output the version number', false );
+	a.option( 'help', 'Output the help for the (sub)command' );
+	a.option( 'version', 'Output the version number' );
 
 	return a;
 }

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -401,6 +401,10 @@ export default function( opts: any ): args {
 		a.option( 'format', 'Format results', 'table' );
 	}
 
+	// Add help and version to all subcommands
+	a.option( 'help', 'Output the help for the (sub)command', false );
+	a.option( 'version', 'Output the version number', false );
+
 	return a;
 }
 

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -36,7 +36,15 @@ process.on( 'unhandledRejection', uncaughtError );
 
 let _opts = {};
 args.argv = async function( argv, cb ): Promise<any> {
-	const options = this.parse( argv );
+	const options = this.parse( argv, { help: false, version: false } );
+
+	if ( options.h || options.help ) {
+		this.showHelp();
+	}
+
+	if ( options.v || options.version ) {
+		this.showVersion();
+	}
 
 	const validationError = validateOpts( options );
 	if ( validationError ) {


### PR DESCRIPTION
_This is a PR to see how the help and version will look like if we remove `help`/`version` and replace it with `-h`/`-v` and `--help`/`--version` flags instead._

This will make the help displays only if `-h` or `--help` are passed, which is the correct behavior. Before this, in order for the help to be shown, you need `-h`, `--help` or `help` but that causes some problems with subcommands see #162.

This fix #162 and #293 

### How to test:

1. Get current branch
2. Run `npm link`
3. Run `vip -h` you should get the help for vip
4. Run `vip app -h` or any subcommand, you should get the help for that subcommand