### PR TITLE
Fix wp subshell cursor

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -126,7 +126,7 @@ commandWrapper( {
 				input: process.stdin,
 				output: process.stdout,
 				terminal: true,
-				prompt: chalk`{bold.yellowBright ${ promptIdentifier }:}{blue ~}$ `,
+				prompt: chalk`{bold.yellowBright ${ promptIdentifier }:}{blue ~}$` + ' ', // Must pad with plain string (non-chalk template literal), otherwise cursor doesn't work
 				// TODO make history persistent across sessions for same env
 				historySize: 200,
 			} );


### PR DESCRIPTION
`chalk` was interferring with the display of the cursor - moving the trailing whitespace to outside the template literal fixes it.