### PR TITLE
WP CLI - More comprehensive subshell cursor fix

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -117,6 +117,9 @@ commandWrapper( {
 		let rl;
 		let subShellRl;
 
+		// Reset the cursor (can get messed up with enquirer)
+		process.stdout.write( '\u001b[?25h' );
+
 		if ( isSubShell ) {
 			console.log( `Welcome to the WP CLI shell for the ${ formatEnvironment( envName ) } environment of ${ chalk.green( appName ) } (${ opts.env.primaryDomain.name })!` );
 
@@ -126,7 +129,7 @@ commandWrapper( {
 				input: process.stdin,
 				output: process.stdout,
 				terminal: true,
-				prompt: chalk`{bold.yellowBright ${ promptIdentifier }:}{blue ~}$` + ' ', // Must pad with plain string (non-chalk template literal), otherwise cursor doesn't work
+				prompt: chalk`{bold.yellowBright ${ promptIdentifier }:}{blue ~}$ `,
 				// TODO make history persistent across sessions for same env
 				historySize: 200,
 			} );


### PR DESCRIPTION
Resets the cursor at the beginning by sending a control code. This prevents instances where the cursor disappears, usually after `enquirer` prompts.