### PR TITLE
Fix .toLowerCase error on app/env picker

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -285,7 +285,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		}
 
 		if ( options.env ) {
-			info.push( { key: 'environment', value: getEnvIdentifier( options.env.type ) } );
+			info.push( { key: 'environment', value: getEnvIdentifier( options.env ) } );
 		}
 
 		let message = 'Are you sure?';

--- a/src/lib/cli/prompt.js
+++ b/src/lib/cli/prompt.js
@@ -8,7 +8,7 @@ import { prompt } from 'enquirer';
 /**
  * Internal dependencies
  */
-import { formatEnvironment, keyValue, Tuple } from './format';
+import { keyValue, Tuple } from './format';
 
 export async function confirm( values: Array<Tuple>, message: string ): Promise<boolean> {
 	console.log( keyValue( values ) );


### PR DESCRIPTION
Passes in the right object to `getEnvIdentifier()` (full object rather than `type` only).

Fixes #302 