### PR TITLE
WP CLI: Missing quotes in wp cli commands

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -115,13 +115,13 @@ commandWrapper( {
 	envContext: true,
 	appQuery,
 } )
-	.argv( process.argv, async ( arg, opts ) => {
-		const isShellMode = 'shell' === arg[ 0 ];
-		const isSubShell = 0 === arg.length;
-		const cmd = arg.join( ' ' );
+	.argv( process.argv, async ( args, opts ) => {
+		const isShellMode = 'shell' === args[ 0 ];
+		const isSubShell = 0 === args.length;
+		const cmd = args.join( ' ' );
 
 		// Store only the first 2 parts of command to avoid recording secrets. Can be tweaked
-		const commandForAnalytics = arg.slice( 0, 2 ).join( ' ' );
+		const commandForAnalytics = quotedArgs.slice( 0, 2 ).join( ' ' );
 
 		const { id: appId, name: appName } = opts.app;
 		const { id: envId, type: envName } = opts.env;

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -16,7 +16,7 @@ import readline from 'readline';
  */
 import API, { API_HOST } from 'lib/api';
 import commandWrapper, { getEnvIdentifier } from 'lib/cli/command';
-import { formatEnvironment } from 'lib/cli/format';
+import { formatEnvironment, requoteArgs } from 'lib/cli/format';
 import { confirm } from 'lib/cli/prompt';
 import { trackEvent } from 'lib/tracker';
 import Token from '../lib/token';
@@ -118,7 +118,11 @@ commandWrapper( {
 	.argv( process.argv, async ( args, opts ) => {
 		const isShellMode = 'shell' === args[ 0 ];
 		const isSubShell = 0 === args.length;
-		const cmd = args.join( ' ' );
+
+		// Have to re-quote anything that needs it before we pass it on
+		const quotedArgs = requoteArgs( args );
+
+		const cmd = quotedArgs.join( ' ' );
 
 		// Store only the first 2 parts of command to avoid recording secrets. Can be tweaked
 		const commandForAnalytics = quotedArgs.slice( 0, 2 ).join( ' ' );

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -108,3 +108,17 @@ export function keyValue( values: Array<Tuple> ): string {
 
 	return lines.join( '\n' );
 }
+
+export function requoteArgs( args: Array<string> ): Array<string> {
+	return args.map( arg => {
+		if ( arg.includes( '--' ) && arg.includes( '=' ) && arg.includes( ' ' ) ) {
+			return arg.replace( /^--(.*)=(.*)$/, '--$1="$2"' );
+		}
+
+		if ( arg.includes( ' ' ) ) {
+			return `"${ arg }"`;
+		}
+
+		return arg;
+	} );
+}


### PR DESCRIPTION
We need to re-quote certain parameters before sending them to the API, as double quotes are removed in on the command line when parsed for `process.argv` in Node.

See #309 