### PR TITLE
Send a newline after results when format is count or ids

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -228,7 +228,12 @@ commandWrapper( {
 
 					// Need a newline - WP CLI doesn't always send one :(
 					// https://github.com/wp-cli/wp-cli/blob/779bdd16025cb718260b35fd2b69ae47ca80cb91/php/WP_CLI/Formatter.php#L129-L141
-					if ( line.includes( '--format=count' ) || line.includes( '--format="count"' ) || line.includes( '--format=ids' ) || line.includes( '--format="ids"' ) ) {
+					if ( line.includes( '--format=count' ) ||
+						line.includes( '--format="count"' ) ||
+						line.includes( '--format=\'count\'' ) ||
+						line.includes( '--format=ids' ) ||
+						line.includes( '--format="ids"' ) ||
+						line.includes( '--format=\'ids\'' ) ) {
 						process.stdout.write( EOL );
 					}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -225,7 +225,7 @@ commandWrapper( {
 					process.stdin.unpipe( commandStreams.stdinStream );
 
 					commandStreams.stdoutStream.unpipe( process.stdout );
-					
+
 					// Need a newline - WP CLI doesn't always send one :(
 					// https://github.com/wp-cli/wp-cli/blob/779bdd16025cb718260b35fd2b69ae47ca80cb91/php/WP_CLI/Formatter.php#L129-L141
 					if ( line.includes( '--format=count' ) || line.includes( '--format=ids' ) ) {

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -228,7 +228,7 @@ commandWrapper( {
 
 					// Need a newline - WP CLI doesn't always send one :(
 					// https://github.com/wp-cli/wp-cli/blob/779bdd16025cb718260b35fd2b69ae47ca80cb91/php/WP_CLI/Formatter.php#L129-L141
-					if ( line.includes( '--format=count' ) || line.includes( '--format=ids' ) ) {
+					if ( line.includes( '--format=count' ) || line.includes( '--format="count"' ) || line.includes( '--format=ids' ) || line.includes( '--format="ids"' ) ) {
 						process.stdout.write( EOL );
 					}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -10,6 +10,7 @@ import { stdout } from 'single-line-log';
 import SocketIO from 'socket.io-client';
 import IOStream from 'socket.io-stream';
 import readline from 'readline';
+import { EOL } from 'os';
 
 /**
  * Internal dependencies
@@ -224,6 +225,12 @@ commandWrapper( {
 					process.stdin.unpipe( commandStreams.stdinStream );
 
 					commandStreams.stdoutStream.unpipe( process.stdout );
+					
+					// Need a newline - WP CLI doesn't always send one :(
+					// https://github.com/wp-cli/wp-cli/blob/779bdd16025cb718260b35fd2b69ae47ca80cb91/php/WP_CLI/Formatter.php#L129-L141
+					if ( line.includes( '--format=count' ) || line.includes( '--format=ids' ) ) {
+						process.stdout.write( EOL );
+					}
 
 					subShellRl.resume();
 


### PR DESCRIPTION
WP-CLI doesn't send a newline on these, so the next prompt() ends up resetting the line.

Fixes #322 