### PR TITLE
Only reset the cursor in subshell mode

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -135,10 +135,10 @@ commandWrapper( {
 		let rl;
 		let subShellRl;
 
-		// Reset the cursor (can get messed up with enquirer)
-		process.stdout.write( '\u001b[?25h' );
-
 		if ( isSubShell ) {
+			// Reset the cursor (can get messed up with enquirer)
+			process.stdout.write( '\u001b[?25h' );
+
 			console.log( `Welcome to the WP CLI shell for the ${ formatEnvironment( envName ) } environment of ${ chalk.green( appName ) } (${ opts.env.primaryDomain.name })!` );
 
 			// We'll handle our own errors, thank you


### PR DESCRIPTION
In subshell mode, we need to reset the cursor as it can get messed
up by the environment prompts. It shouldn't be necessary outside
the subshell mode though. And, in fact, if you're using the output
in other commands, it can cause unexpected behavior.

Fixes: #342

Previously: #303