### PR TITLE
Include --help for unknown command (fixes #348 )

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -120,7 +120,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 			error: `Invalid subcommand: ${ subcommand }`,
 		} );
 
-		console.error( chalk.red( 'Error:' ), `\`${ subcommand }\` is not a valid subcommand. See \`vip help\`` );
+		console.error( chalk.red( 'Error:' ), `\`${ subcommand }\` is not a valid subcommand. See \`vip --help\`` );
 		return {};
 	}
 


### PR DESCRIPTION
Provides a more verbose message when an unknown command is run. Instead of `see vip help` the message will now read `vip --help`.

fixes #348