### PR TITLE
Remove "Go" reference in welcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vip [![Build Status](https://travis-ci.com/Automattic/vip.svg?token=xWx9qCRAJeRdHxEcWW83&branch=master)](https://travis-ci.com/Automattic/vip)
 
-VIP CLI is your tool for interacting with and managing your VIP Go applications.
+VIP CLI is your tool for interacting with and managing your VIP applications.
 
 ## Getting started
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automattic/vip",
   "version": "1.5.0-0",
-  "description": "The VIP Go Javascript library & CLI",
+  "description": "The VIP Javascript library & CLI",
   "main": "index.js",
   "bin": {
     "vip": "dist/bin/vip.js",

--- a/src/bin/vip-app.js
+++ b/src/bin/vip-app.js
@@ -17,7 +17,7 @@ command( { requiredArgs: 1, format: true } )
 	.example( 'vip app <app>', 'Pass an app name or ID to get details about that app' )
 	.example( 'vip app 123', 'Get details about the app with ID 123' )
 	.example( 'vip app vip-test', 'Get details about the app named vip-test' )
-	.command( 'list', 'List your VIP Go apps' )
+	.command( 'list', 'List your VIP applications' )
 	.argv( process.argv, async ( arg, opts ) => {
 		await trackEvent( 'app_command_execute' );
 

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -47,7 +47,7 @@ const rootCmd = async function() {
 		console.log( '  | |/ /_/ // ____//_____/ /___/ /____/ /   ' );
 		console.log( '  |___//___/_/           \____/_____/___/   ' );
 		console.log();
-		console.log( '  VIP CLI is your tool for interacting with and managing your VIP Go applications.' );
+		console.log( '  VIP CLI is your tool for interacting with and managing your VIP applications.' );
 		console.log();
 
 		console.log( `  To get started, we need an access token for your VIP account. We'll open ${ tokenURL } in your web browser; follow the instructions there to continue.` );

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -41,11 +41,11 @@ const rootCmd = async function() {
 
 		console.log();
 		console.log( '  Welcome to' );
-		console.log( '   _    __________     ______' );
-		console.log( '  | |  / /  _/ __ \\   / ____/___' );
-		console.log( '  | | / // // /_/ /  / / __/ __ \\' );
-		console.log( '  | |/ // // ____/  / /_/ / /_/ /' );
-		console.log( '  |___/___/_/       \\____/\\____/' );
+		console.log( '   _    __ ________         ________    ____' );
+		console.log( '  | |  / //  _/ __ \       / ____/ /   /  _/' );
+		console.log( '  | | / / / // /_/ /______/ /   / /    / /  ' );
+		console.log( '  | |/ /_/ // ____//_____/ /___/ /____/ /   ' );
+		console.log( '  |___//___/_/           \____/_____/___/   ' );
 		console.log();
 		console.log( '  VIP CLI is your tool for interacting with and managing your VIP Go applications.' );
 		console.log();

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -31,7 +31,7 @@ const rootCmd = async function() {
 				await trackEvent( 'logout_command_execute' );
 				console.log( 'You are successfully logged out.' );
 			} )
-			.command( 'app', 'List and modify your VIP Go apps' )
+			.command( 'app', 'List and modify your VIP applications' )
 			.command( 'sync', 'Sync production to a development environment' )
 			.command( 'wp', 'Run WP CLI commands against an environment' )
 			.argv( process.argv );


### PR DESCRIPTION
We shouldn't refer to `VIP Go`, there is only VIP.

Either:

```
 _    __ ________         ________    ____
| |  / //  _/ __ \       / ____/ /   /  _/
| | / / / // /_/ /______/ /   / /    / /  
| |/ /_/ // ____//_____/ /___/ /____/ /   
|___//___/_/           \____/_____/___/   
                                          
```

…or…

```
_    __ ________  
| |  / //  _/ __ \ 
| | / / / // /_/ /
| |/ /_/ // ____/
|___//___/_/       
```