### PR TITLE
Remove `vip wp` stdin pipe

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -334,8 +334,6 @@ commandWrapper( {
 			} );
 		}
 
-		process.stdin.pipe( commandStreams.stdinStream );
-
 		commandStreams.stdoutStream.pipe( process.stdout );
 
 		commandStreams.stdoutStream.on( 'error', err => {


### PR DESCRIPTION
This is causing an issue where if you create a stdin pipe, the command
never runs. I suspect it's because we're confusing the command runner
on the CLI container and the command never gets run.

## Testing

1. Download the PR
1. `npm run build`
1. echo "hi" | vip @59 wp user list

You can also test this with regular wp-cli on a sandbox. `echo "hi" | wp user list` works fine.

To understand why this is important, it also effects something like this which can be used to run
CLI commands across many sites:

```
vipgo api get /sites/59 | jq -r '.data[].client_site_id' | xargs -n1 -I{} vip @{} wp user list
```