### PR TITLE
WP-CLI: Close underlying socket.io connection to prevent reconnects

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -107,7 +107,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken } ) => {
 		console.log( err );
 	} );
 
-	return { stdinStream, stdoutStream };
+	return { stdinStream, stdoutStream, socket };
 };
 
 commandWrapper( {
@@ -229,12 +229,18 @@ commandWrapper( {
 				commandStreams.stdoutStream.on( 'error', err => {
 					commandRunning = false;
 
+					// Tell socket.io to stop trying to connect
+					commandStreams.socket.close();
+
 					// TODO handle this better
 					console.log( err );
 				} );
 
 				commandStreams.stdoutStream.on( 'end', () => {
 					commandRunning = false;
+
+					// Tell socket.io to stop trying to connect
+					commandStreams.socket.close();
 
 					process.stdin.unpipe( commandStreams.stdinStream );
 


### PR DESCRIPTION
We're currently not properly closing the connection when commands end in subshell, so they keep trying to reconnect after the command is complete.

This can manifest as several "rate limit exceeded" errors if a user has run several commands in the subshell and their internet connection drops/reconnects - all the orphaned socket.io connections attempt to reconnect at the same time, causing the rate limit error message.