### PR TITLE
Always use readline to parse input

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -262,7 +262,8 @@ commandWrapper( {
 
 		if ( ! isSubShell ) {
 			subShellRl.write( 'wp ' + cmd + '\n' );
-		} else {
-			subShellRl.prompt();
+			return;
 		}
+
+		subShellRl.prompt();
 	} );

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -215,8 +215,12 @@ commandWrapper( {
 					console.log( e );
 				}
 
-				subShellRl.prompt();
+				if ( ! isSubShell ) {
+					subShellRl.close();
+					process.exit( 1 );
+				}
 
+				subShellRl.prompt();
 				return;
 			}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -245,6 +245,7 @@ commandWrapper( {
 				}
 
 				if ( ! isSubShell ) {
+					subShellRl.close();
 					process.exit();
 					return;
 				}

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -134,6 +134,22 @@ commandWrapper( {
 			// Reset the cursor (can get messed up with enquirer)
 			process.stdout.write( '\u001b[?25h' );
 			console.log( `Welcome to the WP CLI shell for the ${ formatEnvironment( envName ) } environment of ${ chalk.green( appName ) } (${ opts.env.primaryDomain.name })!` );
+		} else if ( envName === 'production' ) {
+			const yes = opts.yes || await confirm( [
+				{
+					key: 'command',
+					value: `wp ${ cmd }`,
+				},
+			], `Are you sure you want to run this command on ${ formatEnvironment( envName ) } for site ${ appName }?` );
+
+			if ( ! yes ) {
+				await trackEvent( 'wpcli_confirm_cancel', {
+					command: commandForAnalytics,
+				} );
+
+				console.log( 'Command cancelled' );
+				process.exit();
+			}
 		}
 
 		// We'll handle our own errors, thank you

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -277,7 +277,7 @@ commandWrapper( {
 		} );
 
 		if ( ! isSubShell ) {
-			subShellRl.write( 'wp ' + cmd + '\n' );
+			subShellRl.write( `wp ${ cmd }\n` );
 			return;
 		}
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -255,8 +255,6 @@ commandWrapper( {
 			} );
 		} );
 
-		subShellRl.prompt();
-
 		subShellRl.on( 'SIGINT', () => {
 			subShellRl.close();
 			process.exit();
@@ -264,5 +262,7 @@ commandWrapper( {
 
 		if ( ! isSubShell ) {
 			subShellRl.write( 'wp ' + cmd + '\n' );
+		} else {
+			subShellRl.prompt();
 		}
 	} );

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -259,6 +259,7 @@ commandWrapper( {
 			} );
 
 			commandStreams.stdoutStream.on( 'end', () => {
+				subShellRl.clearLine();
 				commandRunning = false;
 
 				// Tell socket.io to stop trying to connect


### PR DESCRIPTION
This ensures we always use readline to parse input and therefore
don't rely on bash to decide when input is worthy of being sent
to stdin (i.e. on return).

This effectively makes everything subshell mode, though if you run a
specific command, we return to your system shell as soon as the command
finishes.

Noting that this also removes the special "wp shell" mode as well, since the
normal mode is now able to support all input. We could add that back
if there are other reasons to have it.

The primary thing this fixes is `wp help` or other similar long running
commands that expect input over time. Previously input was only sent
when the user pressed return, but now we're able to capture all input.

Fixes #363

## Testing

Some simple test cases:

* Run `wp help`, verify scrolling works correctly
* Run `wp shell`, verify shell works correctly
* Run `wp`, verify subshell mode still works
* Test invalid commands