### PR TITLE
Catch app/environment prompt errors on SIGINT

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -190,7 +190,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 					process.exit();
 				}
 
-				if ( ! err.message ){
+				if ( ! err.message ) {
 					console.log( err );
 				} else {
 					console.log( chalk.red( 'Error:' ), err.message );
@@ -296,7 +296,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 					process.exit();
 				}
 
-				if ( ! err.message ){
+				if ( ! err.message ) {
 					console.log( err );
 				} else {
 					console.log( chalk.red( 'Error:' ), err.message );

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -190,7 +190,12 @@ args.argv = async function( argv, cb ): Promise<any> {
 					process.exit();
 				}
 
-				console.log( err );
+				if ( ! err.message ){
+					console.log( err );
+				} else {
+					console.log( chalk.red( 'Error:' ), err.message );
+				}
+
 				process.exit( 1 );
 			}
 
@@ -291,7 +296,12 @@ args.argv = async function( argv, cb ): Promise<any> {
 					process.exit();
 				}
 
-				console.log( err );
+				if ( ! err.message ){
+					console.log( err );
+				} else {
+					console.log( chalk.red( 'Error:' ), err.message );
+				}
+
 				process.exit( 1 );
 			}
 

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -176,13 +176,23 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 			const appNames = res.data.apps.edges.map( cur => cur.name );
 
-			const a = await prompt( {
-				type: 'autocomplete',
-				name: 'app',
-				message: 'Which app?',
-				limit: 10,
-				choices: appNames,
-			} );
+			let a;
+			try {
+				a = await prompt( {
+					type: 'autocomplete',
+					name: 'app',
+					message: 'Which app?',
+					limit: 10,
+					choices: appNames,
+				} );
+			} catch ( err ) {
+				if ( ! err ) {
+					process.exit();
+				}
+
+				console.log( err );
+				process.exit( 1 );
+			}
 
 			// Copy all app information
 			a.app = res.data.apps.edges.find( cur => cur.name === a.app );
@@ -267,12 +277,23 @@ args.argv = async function( argv, cb ): Promise<any> {
 			options.env = options.app.environments[ 0 ];
 		} else if ( options.app.environments.length > 1 ) {
 			const environmentNames = options.app.environments.map( envObject => getEnvIdentifier( envObject ) );
-			const e = await prompt( {
-				type: 'select',
-				name: 'env',
-				message: 'Which environment?',
-				choices: environmentNames,
-			} );
+
+			let e;
+			try {
+				e = await prompt( {
+					type: 'select',
+					name: 'env',
+					message: 'Which environment?',
+					choices: environmentNames,
+				} );
+			} catch ( err ) {
+				if ( ! err ) {
+					process.exit();
+				}
+
+				console.log( err );
+				process.exit( 1 );
+			}
 
 			// Get full environment info after user selection
 			e.env = options.app.environments.find( envObject => getEnvIdentifier( envObject ) === e.env );


### PR DESCRIPTION
If you SIGINT in an app or environment list, the prompt throws an error.
We need to catch that error or else our uncaught error handler kicks in.

Fixes an uncaught error:

```
  ✕  Unexpected error: Please contact VIP Support with the following error:
  undefined
```

Alternatively, we could update the uncaught error handler to silently exit if the
error is undefined.

## Testing

1. Checkout this PR
1. npm run build
1. `vip wp`
1. CTRL-C
1. Observe there is no error