### PR TITLE
Reduce Rennovate bot noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,8 @@
 {
   "extends": [
-    "config:base"
-  ],
-  "packageRules": [{
-    "depTypeList": ["devDependencies"],
-    "automerge": true,
-    "major": {
-        "automerge": false
-    }
-  }]
+    "config:base",
+    ":automergeLinters",
+    "schedule:weekly",
+    "group:allNonMajor"
+  ]
 }


### PR DESCRIPTION
Automatically merges linters, opens PRs on a weekly basis, and skips major updates.

Originally attempted to do something similar in https://github.com/Automattic/vip/pull/395