### PR TITLE
Remove mock-local-storage from devDependencies

### DIFF
--- a/__tests__/lib/keychain.js
+++ b/__tests__/lib/keychain.js
@@ -89,9 +89,19 @@ describe( 'token tests (insecure)', () => {
 } );
 
 describe( 'token tests (browser)', () => {
-	global.window = {};
-	const localStorage = require( 'mock-local-storage' );
-	window.localStorage = global.localStorage;
+	// mock localStorage
+	global.localStorage = {
+		data: {},
+		getItem( key ) {
+			return this.data[ key ];
+		},
+		setItem( key, value ) {
+			this.data[ key ] = value;
+		},
+		removeItem( key ) {
+			delete this.data[ key ];
+		},
+	};
 
 	keychain = new Browser();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3385,12 +3385,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -5465,16 +5459,6 @@
             "is-extglob": "^2.1.0"
           }
         }
-      }
-    },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dev": true,
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
       }
     },
     "global-dirs": {
@@ -7611,15 +7595,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7697,24 +7672,6 @@
           "version": "0.0.8",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
-      }
-    },
-    "mock-local-storage": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/mock-local-storage/-/mock-local-storage-1.0.5.tgz",
-      "integrity": "sha1-iZ/zAAJ87+1HgW5txTm7BZ/M5Ik=",
-      "dev": true,
-      "requires": {
-        "core-js": "^0.8.3",
-        "global": "^4.3.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.8.4.tgz",
-          "integrity": "sha1-wiZl8eDRucPF4bCNq9HxCGleT88=",
-          "dev": true
         }
       }
     },
@@ -8881,12 +8838,6 @@
           "dev": true
         }
       }
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "eslint-plugin-wpcalypso": "4.1.0",
     "flow-bin": "0.103.0",
     "jest": "24.8.0",
-    "mock-local-storage": "1.0.5",
     "nock": "10.0.6",
     "publish-please": "5.5.0"
   },


### PR DESCRIPTION
The latest mock-local-storage update was breaking tests, so we're going
to mock localStorage ourselves. It's a simple CRUD API.

Fixes tests and removes a dependency.

Related: https://github.com/Automattic/vip/pull/431