### PR TITLE
Revert change that was affecting install of release 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run lint && npm run flow && jest --coverage",
     "prepare": "npm run build",
     "prepack": "npm run prepareConfig:publish",
-    "postinstall": "npm run build && node ./helpers/check-version.js && node ./helpers/postinstall.js",
+    "postinstall": "node ./helpers/check-version.js",
     "build": "npm run prepareConfig:local && babel src -d dist",
     "build:watch": "babel src -d dist --watch",
     "flow": "flow",


### PR DESCRIPTION
## Description
Revert change that was made in #341 that was causing errors on install:
```
prepareConfig: config/config.local.json => config/config.json
module.js:549
    throw err;
    ^

Error: Cannot find module '@babel/core'
    at Function.Module._resolveFilename (module.js:547:15)

```