### PR TITLE
Re-attach outputStream socket events when reconnecting

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -360,6 +360,7 @@ commandWrapper( {
 
 			//write out CTRL-C/SIGINT
 			process.stdin.write( cancelCommandChar );
+			currentJob.stdoutStream.end();
 			trackEvent( 'wpcli_cancel_command', {
 				command: commandForAnalytics,
 			} );


### PR DESCRIPTION
## Description
We need to re-attach the error and end events to the new output stream when reconnecting so that the command exits when it ends and is cancelled

There are three use cases here:
- [x] Command disconnects, reconnects and then completes but doesn't exit at end
- [x] Command diconnects, doesn't reach timeout before Ctrl-C pressed
- [x] Command disconnect hit timeout and tries to reconnect. Ctrl-C pressed after his happens

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Run `./dist/bin/vip-wp.js --app=<testSiteId> --yes -- vip test-command long`
4. Disconnect network and wait for connection to timeout.
5. Ctrl-C should end and exit back to the command prompt
6. Repeat but but hit Ctrl-C after the command starts but before the reconnect attempt is made
7. Repeat but wait for the command to complete. Should return to the command prompt.


