### PR TITLE
await tracking events

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -338,11 +338,11 @@ commandWrapper( {
 				subShellRl.resume();
 			} );
 
-			currentJob.stdoutStream.on( 'end', () => {
+			currentJob.stdoutStream.on( 'end', async () => {
 				subShellRl.clearLine();
 				commandRunning = false;
 
-				trackEvent( 'wpcli_command_end', commonTrackingParams );
+				await trackEvent( 'wpcli_command_end', commonTrackingParams );
 
 				// Tell socket.io to stop trying to connect
 				currentJob.socket.close();
@@ -371,7 +371,7 @@ commandWrapper( {
 
 			//write out CTRL-C/SIGINT
 			process.stdin.write( cancelCommandChar );
-			trackEvent( 'wpcli_cancel_command', commonTrackingParams );
+			await trackEvent( 'wpcli_cancel_command', commonTrackingParams );
 			console.log( 'Command cancelled by user' );
 		} );
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -62,11 +62,11 @@ const bindStreamEvents = ( { subShellRl, commandRunning, commonTrackingParams, i
 		console.log( 'Error: ' + err.message );
 	} );
 
-	stdoutStream.on( 'end', () => {
+	stdoutStream.on( 'end', async () => {
 		subShellRl.clearLine();
 		commandRunning = false;
 
-		trackEvent( 'wpcli_command_end', commonTrackingParams );
+		await trackEvent( 'wpcli_command_end', commonTrackingParams );
 
 		// Tell socket.io to stop trying to connect
 		currentJob.socket.close();

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -188,6 +188,8 @@ commandWrapper( {
 			method: isSubShell ? 'subshell' : 'normal',
 		};
 
+		trackEvent( 'wpcli_command_execute', commonTrackingParams );
+
 		let cmdGuid;
 
 		if ( isSubShell ) {

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -388,7 +388,7 @@ commandWrapper( {
 			currentJob.stdoutStream.end();
 
 			await trackEvent( 'wpcli_cancel_command', commonTrackingParams );
-      
+
 			console.log( 'Command cancelled by user' );
 		} );
 

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -340,9 +340,7 @@ commandWrapper( {
 
 			commandRunning = true;
 
-			
-      
-      ( { subShellRl, commandRunning, commonTrackingParams, isSubShell, stdoutStream: currentJob.stdoutStream } );
+			bindStreamEvents( { subShellRl, commandRunning, commonTrackingParams, isSubShell, stdoutStream: currentJob.stdoutStream } );
 
 			currentJob.socket.on( 'reconnect', async () => {
 				// Close old streams


### PR DESCRIPTION
## Description

We used the fire and forget approach for those tracking events. However, some aren't recorded as the process is already closed with no time to send the events