### PR TITLE
Add is_vip flag

### DIFF
--- a/src/lib/analytics/index.js
+++ b/src/lib/analytics/index.js
@@ -3,6 +3,7 @@
  */
 import AnalyticsClientStub from './clients/stub';
 import env from '../env';
+import currentUser from 'lib/api/user';
 
 const client_info = {
 	cli_version: env.app.version,
@@ -19,8 +20,10 @@ export default class Analytics {
 	}
 
 	async trackEvent( name, props = {} ): Promise {
+		const user = await currentUser();
+
 		return await Promise.all( [
-			this.tracks.trackEvent( name, Object.assign( {}, client_info, props ) ),
+			this.tracks.trackEvent( name, Object.assign( { is_vip: user.me && user.me.isVIP }, client_info, props ) ),
 		] );
 	}
 }

--- a/src/lib/analytics/index.js
+++ b/src/lib/analytics/index.js
@@ -23,7 +23,7 @@ export default class Analytics {
 		const user = await currentUser();
 
 		return await Promise.all( [
-			this.tracks.trackEvent( name, Object.assign( { is_vip: user.me && user.me.isVIP }, client_info, props ) ),
+			this.tracks.trackEvent( name, Object.assign( { is_vip: user.isVIP }, client_info, props ) ),
 		] );
 	}
 }

--- a/src/lib/api/user.js
+++ b/src/lib/api/user.js
@@ -24,9 +24,9 @@ export default async function(): Promise<any> {
 			}`,
 		} );
 
-	if ( ! res || ! res.data ) {
+	if ( ! res || ! res.data || ! res.data.me ) {
 		return {};
 	}
 
-	return res.data;
+	return res.data.me;
 }

--- a/src/lib/api/user.js
+++ b/src/lib/api/user.js
@@ -1,0 +1,32 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+
+export default async function(): Promise<any> {
+	const api = await API();
+
+	const res = await api
+		.query( {
+			// $FlowFixMe: gql template is not supported by flow
+			query: gql`query Me {
+				me {
+					id
+					isVIP
+				}
+			}`,
+		} );
+
+	if ( ! res || ! res.data ) {
+		return {};
+	}
+
+	return res.data;
+}


### PR DESCRIPTION
## Description

This adds the `is_vip` flag to all tracked events. Apollo will cache the user request so calling it multiple time shouldn't be a problem *in theory*.

However, I think we can leverage other options if we can:
1. Can we get the `is_vip` flag or user information part of the Token class? If yes, we may use it instead of this
2. Do we have a way to call the API and pass the result to the underlying commands? With this we may call the API once, but the problem is we need to add `is_vip` flag to all events in each sub command.