### PR TITLE
WP-CLI Add event handler for wp-cli cancel events

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -175,7 +175,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken, offset = 0 } ) =>
 	socket.on( 'cancel', message => {
 		console.log( `Cancel received from server: ${ message }` );
 		socket.close();
-		process.exit();
+		process.exit( 1 );
 	} );
 
 	IOStream( socket ).on( 'error', err => {

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -172,6 +172,12 @@ const launchCommandAndGetStreams = async ( { guid, inputToken, offset = 0 } ) =>
 		console.log( 'There was an error with the authentication:', err.message );
 	} );
 
+	socket.on( 'cancel', message => {
+		console.log( `Cancel received from server: ${ message }` );
+		socket.close();
+		process.exit();
+	} );
+
 	IOStream( socket ).on( 'error', err => {
 		// This returns the error so it can be catched by the socket.on('error')
 		rollbar.error( err );


### PR DESCRIPTION
## Description
Adds an event handler to gracefully handle remote wp-cli command cancel events.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
2. Run `npm run build`
3. Run `./dist/bin/vip-wp.js --yes  @appid -- shell`
4. Cancel the command remotely
5. Verify that the cancel message displays and the process exits.

