### PR TITLE
Add functionality to retreive output logs for completed commands

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -290,6 +290,7 @@ commandWrapper( {
 			commands.forEach( c => {
 				console.log( new Date( c.startedAt ), c.command, c.guid );
 			} );
+			process.exit();
 		}
 
 		trackEvent( 'wpcli_command_execute', commonTrackingParams );


### PR DESCRIPTION
## Description
Adds a `--log` flag to allow retrieving log output for completed commands. Dependant on changes to the API to be deployed first.

## Steps to Test

This is dependant on https://github.com/Automattic/vip-go-api-public/pull/821 being deployed

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-wp.js @app.env --log`
1. Select a command from the list
1. Confirm the entire output for the command is returned

Example output:
```
$./dist/bin/vip-wp.js @1163 --log
2020-01-14T22:20:45.000Z 'vip-test-command long' 'f72025c7-cc2e-400e-b4c6-10d42d436e06'
2020-01-14T22:20:45.000Z 'vip-test-command long' '9c5f0968-66ee-4708-a347-acc199f45bce'
2019-12-02T20:58:00.000Z 'option set home https://daryl-abracadabra-ca.go-vip.co' 'a514abb4-8dc3-4c64-987d-9d2d91a77f8f'
2019-11-29T18:31:45.000Z 'option get home' 'f539bc0f-003b-425c-8568-ecdc9cf82a23'
2019-11-29T18:31:36.000Z 'option set siteurl https://daryl-abracadabra-ca.go-vip.co' '645a3eea-1ee1-45a6-bb15-edcfad0b5f4a'

$./dist/bin/vip-wp.js @1163 --log f539bc0f-003b-425c-8568-ecdc9cf82a23
https://daryl-abracadabra-ca.go-vip.co

```
