### PR TITLE
Fix vip-login

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -126,7 +126,11 @@ const rootCmd = async function() {
 		// Exec the command we originally  wanted
 		const argv = process.argv.slice( 2 );
 		if ( argv.length ) {
-			return args.runCommand( { usage: process.argv.slice( 2 ) } );
+			if ( ! args.isDefined( argv, 'commands' ) ) {
+				return args.showHelp();
+			}
+
+			return args.runCommand( { usage: argv } );
 		}
 
 		const { spawn } = require( 'child_process' );


### PR DESCRIPTION
If you try to run a command that doesn't exist, such as `vip login`,
show a more helpful error

```
$ vip login                                                                                                                                                                                                                                                              master@23216e6c *

  Welcome to
   _    __ ________         ________    ____
  | |  / //  _/ __        / ____/ /   /  _/
  | | / / / // /_/ /______/ /   / /    / /
  | |/ /_/ // ____//_____/ /___/ /____/ /
  |___//___/_/           ____/_____/___/

  VIP CLI is your tool for interacting with and managing your VIP applications.

  To get started, we need an access token for your VIP account. We'll open https://dashboard.wpvip.com/me/cli/token in your web browser; follow the instructions there to continue.

✔ Ready? (y/N) · true
✔ Access Token: · <redacted>
  Usage: vip [options] [command]

  Commands:
    help     Display help
    version  Display version

  Options:
    -h, --help     Output usage information
    -v, --version  Output the version number
```