### PR TITLE
Analytics: Prevent tracks calls when DO_NOT_TRACK is truthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ vip
 
 If you need more information, check out our [VIP CLI documentation](https://vip.wordpress.com/documentation/vip-go/vip-cli/).
 
+## Analytics
+
+By default, we record information about the usage of this tool using an in-house analytics sytem. If you would prefer to opt-out of this data collection, you can do so via the `DO_NOT_TRACK` environment variable. You may either export it in your shell configuration or specify it on the command line (e.g. `DO_NOT_TRACK=1 vip app list`).
+
 ## Changelog
 
 ### 1.8.0

--- a/src/lib/analytics/clients/tracks.js
+++ b/src/lib/analytics/clients/tracks.js
@@ -85,6 +85,10 @@ export default class Tracks implements AnalyticsClient {
 	}
 
 	send( extraParams: {} ): Promise<Response> {
+		if ( process.env.DO_NOT_TRACK ) {
+			return Promise.resolve( 'tracks disabled per DO_NOT_TRACK variable' );
+		}
+
 		const params = Object.assign( {}, this.baseParams, extraParams );
 
 		const method = 'POST';

--- a/src/lib/analytics/clients/tracks.js
+++ b/src/lib/analytics/clients/tracks.js
@@ -44,7 +44,7 @@ export default class Tracks implements AnalyticsClient {
 		};
 	}
 
-	trackEvent( name: string, eventProps = {} ): Promise<Response> {
+	trackEvent( name: string, eventProps = {} ): Promise<any> {
 		if ( ! name.startsWith( this.eventPrefix ) ) {
 			name = this.eventPrefix + name;
 		}
@@ -84,7 +84,7 @@ export default class Tracks implements AnalyticsClient {
 		return this.send( params );
 	}
 
-	send( extraParams: {} ): Promise<Response> {
+	send( extraParams: {} ): Promise<any> {
 		if ( process.env.DO_NOT_TRACK ) {
 			debug( 'send() => skipping per DO_NOT_TRACK variable' );
 

--- a/src/lib/analytics/clients/tracks.js
+++ b/src/lib/analytics/clients/tracks.js
@@ -86,6 +86,8 @@ export default class Tracks implements AnalyticsClient {
 
 	send( extraParams: {} ): Promise<Response> {
 		if ( process.env.DO_NOT_TRACK ) {
+			debug( 'send() => skipping per DO_NOT_TRACK variable' );
+
 			return Promise.resolve( 'tracks disabled per DO_NOT_TRACK variable' );
 		}
 


### PR DESCRIPTION
## Description

Provide a mechanism to opt-out of telemetry / usage tracking. If the `DO_NOT_TRACK` environment variable is truthy, prevent the sending of data to the "tracks" system.

See: https://consoledonottrack.com/

PLAT-1054

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run the automated tests (`npm run test __tests__/lib/analytics/clients/tracks.js`)
    1. The added test logic should run & be logically-sound
    1. All tests should pass
1. Apply [this patch](https://gist.github.com/jblz/dd87fb4ca0f9f4cde43e0125bc998099) to manually test
1. Run `npm run build`
1. Run `DO_NOT_TRACK=1 ./dist/bin/vip-app-list.js`
    1. Verify your available apps are listed
    1. Verify all events are labeled `wouldNotTrack`
1. Run `./dist/bin/vip-app-list.js` (NOTE: this assumes you do not have the env var set system-wide.  If you do, override it like `DO_NOT_TRACK=0 ./dist/bin/vip-app-list.js` here.)
    1. Verify your available apps are listed
    1. Verify all events are labeled `wouldTrack`

