### PR TITLE
Add SOCKS proxy support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1424,6 +1424,14 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
@@ -6791,6 +6799,11 @@
         }
       }
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
     "ip-regex": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
@@ -10937,6 +10950,11 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -11122,6 +11140,25 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
+      }
+    },
+    "socks": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4",
+        "socks": "^2.3.3"
       }
     },
     "source-list-map": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "single-line-log": "1.1.2",
     "socket.io-client": "2.3.0",
     "socket.io-stream": "0.9.1",
+    "socks-proxy-agent": "^5.0.0",
     "update-notifier": "4.1.0",
     "uuid": "3.4.0"
   },

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -51,11 +51,9 @@ export default async function API(): Promise<ApolloClient> {
 		}
 	} );
 
-	const httpLink = new HttpLink( { uri: API_URL, headers: headers } );
-
-	// const httpLink = new HttpLink( { uri: API_URL, headers: headers, fetchOptions: {
-	// 	agent: process.env.hasOwnProperty( 'VIP_PROXY' ) ? ProxyAgent( process.env.VIP_PROXY ) : null,
-	// } } );
+	const httpLink = new HttpLink( { uri: API_URL, headers: headers, fetchOptions: {
+		agent: process.env.hasOwnProperty( 'VIP_PROXY' ) ? ProxyAgent( process.env.VIP_PROXY ) : null,
+	} } );
 
 	return new ApolloClient( {
 		link: errorLink.concat( httpLink ),

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -11,7 +11,6 @@ import { onError } from 'apollo-link-error';
 import chalk from 'chalk';
 import ProxyAgent from 'socks-proxy-agent';
 
-
 /**
  * Internal dependencies
  */

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -9,6 +9,8 @@ import { HttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { onError } from 'apollo-link-error';
 import chalk from 'chalk';
+import ProxyAgent from 'socks-proxy-agent';
+
 
 /**
  * Internal dependencies
@@ -50,6 +52,10 @@ export default async function API(): Promise<ApolloClient> {
 	} );
 
 	const httpLink = new HttpLink( { uri: API_URL, headers: headers } );
+
+	// const httpLink = new HttpLink( { uri: API_URL, headers: headers, fetchOptions: {
+	// 	agent: process.env.hasOwnProperty( 'VIP_PROXY' ) ? ProxyAgent( process.env.VIP_PROXY ) : null,
+	// } } );
 
 	return new ApolloClient( {
 		link: errorLink.concat( httpLink ),

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -51,7 +51,7 @@ export default async function API(): Promise<ApolloClient> {
 	} );
 
 	const httpLink = new HttpLink( { uri: API_URL, headers: headers, fetchOptions: {
-		agent: process.env.hasOwnProperty( 'VIP_PROXY' ) ? ProxyAgent( process.env.VIP_PROXY ) : null,
+		agent: process.env.hasOwnProperty( 'VIP_PROXY' ) ? new ProxyAgent( process.env.VIP_PROXY ) : null,
 	} } );
 
 	return new ApolloClient( {


### PR DESCRIPTION
## Description

Adds the ability to tell the CLI to use a SOCKS proxy when connecting to the API. 

The CLI will look for a `VIP_PROXY` environment variable. If found, it will use its value to add the proxy on the connection. 

## Steps to Test

TBD
