### PR TITLE
Add user agent for all API requests

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -15,6 +15,7 @@ import ProxyAgent from 'socks-proxy-agent';
  * Internal dependencies
  */
 import Token from './token';
+import env from './env';
 
 // Config
 export const PRODUCTION_API_HOST = 'https://api.wpvip.com';
@@ -29,7 +30,9 @@ export function disableGlobalGraphQLErrorHandling() {
 
 export default async function API(): Promise<ApolloClient> {
 	const token = await Token.get();
-	const headers = {};
+	const headers = {
+		'User-Agent': env.userAgent,
+	};
 
 	if ( token ) {
 		headers.Authorization = `Bearer ${ token.raw }`;
@@ -50,7 +53,7 @@ export default async function API(): Promise<ApolloClient> {
 		}
 	} );
 
-	const httpLink = new HttpLink( { uri: API_URL, headers: headers, fetchOptions: {
+	const httpLink = new HttpLink( { uri: API_URL, headers, fetchOptions: {
 		agent: process.env.hasOwnProperty( 'VIP_PROXY' ) ? new ProxyAgent( process.env.VIP_PROXY ) : null,
 	} } );
 

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -24,6 +24,6 @@ const env = {
 	},
 };
 
-env.userAgent = `vip-cli/${ pkg.version } (node/${ env.node.version }; ${ env.os.name }/${ env.os.version }; +https://vip.wordpress.com)`;
+env.userAgent = `vip-cli/${ pkg.version } (node/${ env.node.version }; ${ env.os.name }/${ env.os.version }; +https://wpvip.com)`;
 
 export default env;


### PR DESCRIPTION
Since sending the generic node-fetch header is not very helpful for debugging.

## To Test

- `npm run build`
- `node dist/bin/vip-app-list.js`
- Check logs to make sure request has a UA matching something like `vip-cli/1.10.0 (node/v12.18.0; darwin/19.5.0; +https://wpvip.com)`