### PR TITLE
Use socks-proxy-agent for socket requests

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -22,6 +22,7 @@ import { confirm } from 'lib/cli/prompt';
 import { trackEvent } from 'lib/tracker';
 import Token from '../lib/token';
 import { rollbar } from 'lib/rollbar';
+import createSocksProxyAgent from 'lib/http/socks-proxy-agent';
 
 const appQuery = `id, name,
 	organization {
@@ -145,6 +146,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken, offset = 0 } ) =>
 				},
 			},
 		},
+		agent: createSocksProxyAgent(),
 	} );
 
 	const stdoutStream = IOStream.createStream();

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -9,13 +9,13 @@ import { HttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { onError } from 'apollo-link-error';
 import chalk from 'chalk';
-import ProxyAgent from 'socks-proxy-agent';
 
 /**
  * Internal dependencies
  */
 import Token from './token';
 import env from './env';
+import createSocksProxyAgent from 'lib/http/socks-proxy-agent';
 
 // Config
 export const PRODUCTION_API_HOST = 'https://api.wpvip.com';
@@ -54,7 +54,7 @@ export default async function API(): Promise<ApolloClient> {
 	} );
 
 	const httpLink = new HttpLink( { uri: API_URL, headers, fetchOptions: {
-		agent: process.env.hasOwnProperty( 'VIP_PROXY' ) ? new ProxyAgent( process.env.VIP_PROXY ) : null,
+		agent: createSocksProxyAgent(),
 	} } );
 
 	return new ApolloClient( {

--- a/src/lib/http/socks-proxy-agent.js
+++ b/src/lib/http/socks-proxy-agent.js
@@ -1,7 +1,11 @@
-/** External dependencies **/
+/**
+ * External dependencies
+ */
 import ProxyAgent from 'socks-proxy-agent';
 
-/** Internal dependencies **/
+/**
+ * Internal dependencies
+ */
 
 export default function createSocksProxyAgent() {
 	if ( ! process.env.hasOwnProperty( 'VIP_PROXY' ) ) {

--- a/src/lib/http/socks-proxy-agent.js
+++ b/src/lib/http/socks-proxy-agent.js
@@ -1,0 +1,13 @@
+/** External dependencies **/
+import ProxyAgent from 'socks-proxy-agent';
+
+/** Internal dependencies **/
+
+export default function createSocksProxyAgent() {
+	if ( ! process.env.hasOwnProperty( 'VIP_PROXY' ) ) {
+		return null;
+	}
+
+	return new ProxyAgent( process.env.VIP_PROXY );
+}
+


### PR DESCRIPTION
Will allow us to secure the socket requests as well.

Move the initialization of the proxyagent to a shared lib to avoid duplicate code.

```
## With VIP_PROXY set and proxy active

# GraphQL request:
❯ node ./dist/bin/vip app 123
===================================
+ id: 123
+ name: example
+ repo: wpcomvip/example
===================================

node ./dist/bin/vip wp @123 option get home
https://example.com

# With proxy not active
node ./dist/bin/vip wp @123 option get home
App 123 does not exist
```

## Steps to Test

Use the following commands to verify things:

```
./dist/bin/vip @309 wp option get home
./dist/bin/vip app 309
```

- Start with `VIP_PROXY` not defined: commands should work (if you have superadmin)
- Set `VIP_PROXY` but do not start proxy: commands should error out
- Set `VIP_PROXY` and also start proxy: commands should work.