### PR TITLE
Import files: Add multiple nested folders validation

### DIFF
--- a/__tests__/lib/vip-import-validate-files.js
+++ b/__tests__/lib/vip-import-validate-files.js
@@ -16,8 +16,8 @@ describe( 'lib/vip-import-validate-files', () => {
 			const folderStructureObj = {
 				'uploads/2020/06': true,
 				'uploads/2019/01': true,
-				'uploads/2018/03': true
-			}
+				'uploads/2018/03': true,
+			};
 
 			// Mock console.log()
 			console.log = jest.fn();

--- a/__tests__/lib/vip-import-validate-files.js
+++ b/__tests__/lib/vip-import-validate-files.js
@@ -13,20 +13,28 @@ import {
 describe( 'lib/vip-import-validate-files', () => {
 	describe( 'folderStructureValidation', () => {
 		it( 'should correctly validate a recommended folder structure', async () => {
-			const path = 'uploads/2020/06';
+			const folderStructureObj = {
+				'uploads/2020/06': true,
+				'uploads/2019/01': true,
+				'uploads/2018/03': true
+			}
 
+			// Mock console.log()
 			console.log = jest.fn();
 
-			const folderStructure = folderStructureValidation( path );
+			// Call function
+			folderStructureValidation( Object.keys( folderStructureObj ) );
 
-			expect( console.log ).toHaveBeenCalledWith( '✅ File structure: Uploads directory exists' );
+			expect( console.log ).toHaveBeenCalled();
+			expect( console.log.mock.calls[ 0 ][ 0 ] ).toEqual( expect.stringContaining( 'Folder:' ) );
+			expect( console.log.mock.calls[ 0 ][ 1 ] ).toEqual( expect.stringContaining( 'uploads/2020/06' ) );
 		} );
 		it( 'should log recommendations for a non-recommended folder structure', async () => {
 			const path = 'folder/structure/not-recommended';
 
 			console.log = jest.fn();
 
-			const folderStructure = folderStructureValidation( path );
+			folderStructureValidation( path );
 
 			expect( console.log ).toHaveBeenCalled();
 		} );

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -63,7 +63,7 @@ command( { requiredArgs: 1, format: true } )
 		 * - Filename validation
 		 * - Intermediate image validation
 		 */
-		let files = nestedDirectories;
+		let { files, structureObj } = nestedDirectories;
 
 		if ( ! files || ! files.length || files.length <= 0 ) {
 			console.error( chalk.red( '✕ Error:' ), 'Media files directory cannot be empty' );
@@ -119,7 +119,7 @@ command( { requiredArgs: 1, format: true } )
 			 * Intermediate images are copies of images that are resized, so you may have multiples of the same image.
 			 * You can resize an image directly on VIP so intermediate images are not necessary.
 			 */
-			const original = doesImageHaveExistingSource( file, nestedDirectories );
+			const original = doesImageHaveExistingSource( file );
 
 			// If an image is an intermediate image, populate key/value pairs of the original image and intermediate image(s)
 			if ( original ) {

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -26,6 +26,7 @@ import {
 } from '../lib/vip-import-validate-files';
 
 // Promisify to use async/await
+const syncStat = promisify( fs.statSync );
 const stat = promisify( fs.stat );
 const readDir = promisify( fs.readdir );
 
@@ -49,10 +50,10 @@ command( { requiredArgs: 1, format: true } )
 		 *
 		 * Recommended structure: `uploads/year/month` (Single sites)
 		 */
-		const nestedDirectories = await findNestedDirectories( filePath );
+		const nestedDirectories = findNestedDirectories( filePath );
 
 		if ( nestedDirectories ) {
-			folderStructureValidation( nestedDirectories );
+			nestedDirectories.forEach( dir => folderStructureValidation( dir ));
 		}
 
 		/**
@@ -62,16 +63,10 @@ command( { requiredArgs: 1, format: true } )
 		 * - Filename validation
 		 * - Intermediate image validation
 		 */
-		let files;
+		let files = nestedDirectories;
 
-		try {
-			files = await readDir( nestedDirectories );
-
-			if ( ! files || ! files.length || files.length <= 0 ) {
-				console.error( chalk.red( '✕ Error:' ), 'Media files directory cannot be empty' );
-			}
-		} catch ( error ) {
-			console.error( chalk.red( '✕ Error:' ), `Unable to read directory ${ filePath }: ${ error.message }` );
+		if ( ! files || ! files.length || files.length <= 0 ) {
+			console.error( chalk.red( '✕ Error:' ), 'Media files directory cannot be empty' );
 		}
 
 		/**

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -85,7 +85,7 @@ command( { requiredArgs: 1, format: true } )
 		const errorFileTypes = [];
 		const errorFileNames = [];
 		const intermediateImages = {
-			"tally": 0
+			tally: 0,
 		};
 
 		// Iterate through each file to isolate the extension name

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -164,6 +164,6 @@ command( { requiredArgs: 1, format: true } )
 			fileTypeErrorsLength: errorFileTypes.length,
 			filenameErrorsLength: errorFileNames.length,
 			totalFiles: files.length,
-			totalFolders: nestedDirectories.length
+			totalFolders: nestedDirectories.length,
 		} );
 	} );

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -23,6 +23,7 @@ import {
 	logErrorsForIntermediateImages,
 	logErrorsForInvalidFileTypes,
 	logErrorsForInvalidFilenames,
+	summaryLogs,
 } from '../lib/vip-import-validate-files';
 
 // Promisify to use async/await
@@ -156,4 +157,7 @@ command( { requiredArgs: 1, format: true } )
 		if ( Object.keys( intermediateImages ).length > 0 ) {
 			logErrorsForIntermediateImages( intermediateImages );
 		}
+
+		// Log a summary of all errors
+		summaryLogs( folderValidation.length, intermediateImages.tally, errorFileTypes.length, errorFileNames.length, files.length, nestedDirectories.length );
 	} );

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -83,7 +83,7 @@ command( { requiredArgs: 1, format: true } )
 		// Iterate through each file to isolate the extension name
 		for ( const file of files ) {
 			// Check if file is a directory
-			const stats = await stat( nestedDirectories + '/' + file );
+			const stats = await stat( file );
 			const isFolder = stats.isDirectory();
 
 			const extension = path.extname( file ); // Extract the extension of the file

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -46,14 +46,19 @@ command( { requiredArgs: 1, format: true } )
 		/**
 		 * Folder structure validation
 		 *
-		 * Find nested directories to see if media files follow the WordPress recommended folder structure
+		 * Find nested directories and files to see if media files follow the WordPress recommended folder structure
 		 *
 		 * Recommended structure: `uploads/year/month` (Single sites)
 		 */
-		const nestedDirectories = findNestedDirectories( filePath );
+		const nestedFiles = findNestedDirectories( filePath );
+		
+		let { files, folderStructureObj } = nestedFiles; // Destructure
+		
+		// Check if there are any nested directories within the given folder
+		const nestedDirectories = Object.keys( folderStructureObj );
 
-		if ( nestedDirectories ) {
-			nestedDirectories.forEach( dir => folderStructureValidation( dir ));
+		if ( nestedDirectories && nestedDirectories.length > 0 ) {
+			folderStructureValidation( nestedDirectories );
 		}
 
 		/**
@@ -63,8 +68,6 @@ command( { requiredArgs: 1, format: true } )
 		 * - Filename validation
 		 * - Intermediate image validation
 		 */
-		let { files, structureObj } = nestedDirectories;
-
 		if ( ! files || ! files.length || files.length <= 0 ) {
 			console.error( chalk.red( '✕ Error:' ), 'Media files directory cannot be empty' );
 		}

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -51,9 +51,9 @@ command( { requiredArgs: 1, format: true } )
 		 * Recommended structure: `uploads/year/month` (Single sites)
 		 */
 		const nestedFiles = findNestedDirectories( filePath );
-		
-		let { files, folderStructureObj } = nestedFiles; // Destructure
-		
+
+		const { files, folderStructureObj } = nestedFiles; // Destructure
+
 		// Check if there are any nested directories within the given folder
 		const nestedDirectories = Object.keys( folderStructureObj );
 

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -158,5 +158,12 @@ command( { requiredArgs: 1, format: true } )
 		}
 
 		// Log a summary of all errors
-		summaryLogs( folderValidation.length, intermediateImages.tally, errorFileTypes.length, errorFileNames.length, files.length, nestedDirectories.length );
+		summaryLogs( {
+			folderErrorsLength: folderValidation.length,
+			intImagesErrorsLength: intermediateImages.tally,
+			fileTypeErrorsLength: errorFileTypes.length,
+			filenameErrorsLength: errorFileNames.length,
+			totalFiles: files.length,
+			totalFolders: nestedDirectories.length
+		} );
 	} );

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -43,6 +43,8 @@ command( { requiredArgs: 1, format: true } )
 		arg = url.parse( folder ); // Then parse the file to its URL parts
 		const filePath = arg.path; // Extract the path of the file
 
+		let folderValidation;
+
 		/**
 		 * Folder structure validation
 		 *
@@ -58,7 +60,7 @@ command( { requiredArgs: 1, format: true } )
 		const nestedDirectories = Object.keys( folderStructureObj );
 
 		if ( nestedDirectories && nestedDirectories.length > 0 ) {
-			folderStructureValidation( nestedDirectories );
+			folderValidation = folderStructureValidation( nestedDirectories );
 		}
 
 		/**
@@ -81,7 +83,9 @@ command( { requiredArgs: 1, format: true } )
 		// Collect invalid files for error logging
 		const errorFileTypes = [];
 		const errorFileNames = [];
-		const intImagesObject = {};
+		const intermediateImages = {
+			"tally": 0
+		};
 
 		// Iterate through each file to isolate the extension name
 		for ( const file of files ) {
@@ -124,13 +128,16 @@ command( { requiredArgs: 1, format: true } )
 			 */
 			const original = doesImageHaveExistingSource( file );
 
-			// If an image is an intermediate image, populate key/value pairs of the original image and intermediate image(s)
+			// If an image is an intermediate image, increment the total number and
+			// populate key/value pairs of the original image and intermediate image(s)
 			if ( original ) {
-				if ( intImagesObject[ original ] ) {
+				intermediateImages.tally++;
+
+				if ( intermediateImages[ original ] ) {
 					// Key: original image, value: intermediate image(s)
-					intImagesObject[ original ] = `${ intImagesObject[ original ] }, ${ file }`;
+					intermediateImages[ original ] = `${ intermediateImages[ original ] }, ${ file }`;
 				} else {
-					intImagesObject[ original ] = file;
+					intermediateImages[ original ] = file;
 				}
 			}
 		}
@@ -146,7 +153,7 @@ command( { requiredArgs: 1, format: true } )
 			logErrorsForInvalidFilenames( errorFileNames );
 		}
 
-		if ( Object.keys( intImagesObject ).length > 0 ) {
-			logErrorsForIntermediateImages( intImagesObject );
+		if ( Object.keys( intermediateImages ).length > 0 ) {
+			logErrorsForIntermediateImages( intermediateImages );
 		}
 	} );

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -153,6 +153,7 @@ const recommendAcceptableFileNames = () => {
  * @param {string} directory Root directory, or the given (current) directory
  */
 let files = [];
+let folderStructureObj = {};
 
 export const findNestedDirectories = directory => {
 	let nestedDirectories;
@@ -173,7 +174,10 @@ export const findNestedDirectories = directory => {
 			if ( statSync.isDirectory() ) {
 				return findNestedDirectories( filePath );
 			} else {
-				// Once we hit media files, push them to an array to do individual file validations later on
+				// Once we hit media files, add the path of all existing folders
+				// as object keys to validate folder structure later on
+				folderStructureObj[ directory ] = true;
+				// Also, push individual files to an array to do individual file validations later on
 				return files.push( filePath ); 
 			}
 		} );

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -203,7 +203,7 @@ export const findNestedDirectories = directory => {
  */
 export const folderStructureValidation = folderStructureKeys => {
 	// Collect all the folder paths that have errors
-	let allErrors = [];
+	const allErrors = [];
 
 	// Loop through each key (path) to validate the folder structure format
 	for ( const folderPath of folderStructureKeys ) {
@@ -420,29 +420,29 @@ export const logErrorsForIntermediateImages = obj => {
 };
 
 export const summaryLogs = ( folderErrorsLength, intImagesErrorsLength, fileTypeErrorsLength, filenameErrorsLength, totalFiles, totalFolders ) => {
- if ( folderErrorsLength > 0 ) {
-  folderErrorsLength = chalk.bgYellow( ' RECOMMENDED ') + chalk.bold.yellow( ` ${ folderErrorsLength } folders, ` ) + `${ totalFolders } folders total`;
- } else {
-  folderErrorsLength = chalk.bgGreen( '    PASS     ') + chalk.bold.green( ` ${ totalFolders } folders, ` ) + `${ totalFolders } folders total`;
- }
- 
- if( intImagesErrorsLength > 0 ) {
-  intImagesErrorsLength = chalk.white.bgRed( '   ERROR     ') + chalk.red( ` ${ intImagesErrorsLength } intermediate images` ) + `, ${ totalFiles } files total`;
- } else {
-  intImagesErrorsLength = chalk.white.bgGreen( '    PASS     ') + chalk.green( ` ${ intImagesErrorsLength } intermediate images` ) + `, ${ totalFiles } files total`;
- }
+	if ( folderErrorsLength > 0 ) {
+		folderErrorsLength = chalk.bgYellow( ' RECOMMENDED ' ) + chalk.bold.yellow( ` ${ folderErrorsLength } folders, ` ) + `${ totalFolders } folders total`;
+	} else {
+		folderErrorsLength = chalk.bgGreen( '    PASS     ' ) + chalk.bold.green( ` ${ totalFolders } folders, ` ) + `${ totalFolders } folders total`;
+	}
 
- if( fileTypeErrorsLength > 0 ) {
-  fileTypeErrorsLength = chalk.white.bgRed( '   ERROR     ') + chalk.red( ` ${ fileTypeErrorsLength } invalid file extensions` ) + `, ${ totalFiles } files total`;
- } else {
-  fileTypeErrorsLength = chalk.white.bgGreen( '    PASS     ') + chalk.green( ` ${ fileTypeErrorsLength } invalid file extensions` ) + `, ${ totalFiles } files total`;
- }
+	if ( intImagesErrorsLength > 0 ) {
+		intImagesErrorsLength = chalk.white.bgRed( '   ERROR     ' ) + chalk.red( ` ${ intImagesErrorsLength } intermediate images` ) + `, ${ totalFiles } files total`;
+	} else {
+		intImagesErrorsLength = chalk.white.bgGreen( '    PASS     ' ) + chalk.green( ` ${ intImagesErrorsLength } intermediate images` ) + `, ${ totalFiles } files total`;
+	}
 
- if ( filenameErrorsLength ) {
-  filenameErrorsLength = chalk.white.bgRed( '   ERROR     ') + chalk.red( ` ${ filenameErrorsLength } invalid filenames` ) + `, ${ totalFiles } files total`;
- } else {
-  filenameErrorsLength = chalk.bgGreen( '    PASS     ') + chalk.green( ` ${ filenameErrorsLength } invalid filenames` ) + `, ${ totalFiles } files total`;
- }
+	if ( fileTypeErrorsLength > 0 ) {
+		fileTypeErrorsLength = chalk.white.bgRed( '   ERROR     ' ) + chalk.red( ` ${ fileTypeErrorsLength } invalid file extensions` ) + `, ${ totalFiles } files total`;
+	} else {
+		fileTypeErrorsLength = chalk.white.bgGreen( '    PASS     ' ) + chalk.green( ` ${ fileTypeErrorsLength } invalid file extensions` ) + `, ${ totalFiles } files total`;
+	}
 
- console.log(`\n${ folderErrorsLength }\n${ intImagesErrorsLength }\n${ fileTypeErrorsLength }\n${ filenameErrorsLength }\n`);
-}
+	if ( filenameErrorsLength ) {
+		filenameErrorsLength = chalk.white.bgRed( '   ERROR     ' ) + chalk.red( ` ${ filenameErrorsLength } invalid filenames` ) + `, ${ totalFiles } files total`;
+	} else {
+		filenameErrorsLength = chalk.bgGreen( '    PASS     ' ) + chalk.green( ` ${ filenameErrorsLength } invalid filenames` ) + `, ${ totalFiles } files total`;
+	}
+
+	console.log( `\n${ folderErrorsLength }\n${ intImagesErrorsLength }\n${ fileTypeErrorsLength }\n${ filenameErrorsLength }\n` );
+};

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -159,7 +159,7 @@ export const findNestedDirectories = directory => {
 
 	try {
 		// Read nested directories within the given directory
-		nestedDirectories = fs.readdir( directory );
+		nestedDirectories = fs.readdirSync( directory );
 
 		// Filter out hidden files such as .DS_Store
 		nestedDirectories = nestedDirectories.filter( file => ! ( /(^|\/)\.[^\/\.]/g ).test( file ) );
@@ -167,7 +167,7 @@ export const findNestedDirectories = directory => {
 		nestedDirectories.forEach( dir => {
 			// Concatenate the file path of the parent directory with the nested directory
 			const filePath = path.join( directory, dir );
-			const statSync = fs.stat( filePath ); // Get stats on the file/folder
+			const statSync = fs.statSync( filePath ); // Get stats on the file/folder
 
 			// Keep looking for nested directories until we hit individual files
 			if ( statSync.isDirectory() ) {

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -418,3 +418,31 @@ export const logErrorsForIntermediateImages = obj => {
 	}
 	console.log( '------------------------------------------------------------' );
 };
+
+export const summaryLogs = ( folderErrorsLength, intImagesErrorsLength, fileTypeErrorsLength, filenameErrorsLength, totalFiles, totalFolders ) => {
+ if ( folderErrorsLength > 0 ) {
+  folderErrorsLength = chalk.bgYellow( ' RECOMMENDED ') + chalk.bold.yellow( ` ${ folderErrorsLength } folders, ` ) + `${ totalFolders } folders total`;
+ } else {
+  folderErrorsLength = chalk.bgGreen( '    PASS     ') + chalk.bold.green( ` ${ totalFolders } folders, ` ) + `${ totalFolders } folders total`;
+ }
+ 
+ if( intImagesErrorsLength > 0 ) {
+  intImagesErrorsLength = chalk.white.bgRed( '   ERROR     ') + chalk.red( ` ${ intImagesErrorsLength } intermediate images` ) + `, ${ totalFiles } files total`;
+ } else {
+  intImagesErrorsLength = chalk.white.bgGreen( '    PASS     ') + chalk.green( ` ${ intImagesErrorsLength } intermediate images` ) + `, ${ totalFiles } files total`;
+ }
+
+ if( fileTypeErrorsLength > 0 ) {
+  fileTypeErrorsLength = chalk.white.bgRed( '   ERROR     ') + chalk.red( ` ${ fileTypeErrorsLength } invalid file extensions` ) + `, ${ totalFiles } files total`;
+ } else {
+  fileTypeErrorsLength = chalk.white.bgGreen( '    PASS     ') + chalk.green( ` ${ fileTypeErrorsLength } invalid file extensions` ) + `, ${ totalFiles } files total`;
+ }
+
+ if ( filenameErrorsLength ) {
+  filenameErrorsLength = chalk.white.bgRed( '   ERROR     ') + chalk.red( ` ${ filenameErrorsLength } invalid filenames` ) + `, ${ totalFiles } files total`;
+ } else {
+  filenameErrorsLength = chalk.bgGreen( '    PASS     ') + chalk.green( ` ${ filenameErrorsLength } invalid filenames` ) + `, ${ totalFiles } files total`;
+ }
+
+ console.log(`\n${ folderErrorsLength }\n${ intImagesErrorsLength }\n${ fileTypeErrorsLength }\n${ filenameErrorsLength }\n`);
+}

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -177,6 +177,7 @@ export const findNestedDirectories = directory => {
 				// Once we hit media files, add the path of all existing folders
 				// as object keys to validate folder structure later on
 				folderStructureObj[ directory ] = true;
+
 				// Also, push individual files to an array to do individual file validations later on
 				return files.push( filePath ); 
 			}
@@ -186,7 +187,7 @@ export const findNestedDirectories = directory => {
 		return;
 	}
 
-	return files;
+	return { files, folderStructureObj };
 };
 
 /**

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -143,17 +143,17 @@ const recommendAcceptableFileNames = () => {
 	* Nested Directory Search
  *
  * Use recursion to identify the nested tree structure of the given media file
-	* 
+	*
 	* Example media file:
 	*  - Given directory: uploads
 	*   - Nested directories: 2020, 2019, 2018, 2017
 	*    - Nested directories: 01, 02, 03, 04, 05, 06
-	*     - Individual files: image.jpg, image2.jpg, etc. 
+	*     - Individual files: image.jpg, image2.jpg, etc.
  *
  * @param {string} directory Root directory, or the given (current) directory
  */
-let files = [];
-let folderStructureObj = {};
+const files = [];
+const folderStructureObj = {};
 
 export const findNestedDirectories = directory => {
 	let nestedDirectories;
@@ -172,14 +172,14 @@ export const findNestedDirectories = directory => {
 
 			// Keep looking for nested directories until we hit individual files
 			if ( statSync.isDirectory() ) {
-				return findNestedDirectories( filePath );
+				findNestedDirectories( filePath );
 			} else {
 				// Once we hit media files, add the path of all existing folders
 				// as object keys to validate folder structure later on
 				folderStructureObj[ directory ] = true;
 
 				// Also, push individual files to an array to do individual file validations later on
-				return files.push( filePath ); 
+				return files.push( filePath );
 			}
 		} );
 	} catch ( error ) {
@@ -205,7 +205,7 @@ export const folderStructureValidation = folderStructureKeys => {
 	let errors = 0;
 
 	// Loop through each key (path) to validate the folder structure format
-	for( const folderPath of folderStructureKeys) {
+	for ( const folderPath of folderStructureKeys ) {
 		let yearIndex, monthIndex;
 
 		console.log( chalk.bold( 'Folder:' ), chalk.cyan( `${ folderPath }` ) );
@@ -277,7 +277,7 @@ export const folderStructureValidation = folderStructureKeys => {
 			console.log();
 			errors++;
 		}
- }
+	}
 
 	if ( errors ) {
 		recommendedFileStructure();
@@ -297,7 +297,7 @@ export const folderStructureValidation = folderStructureKeys => {
  */
 export const isFileSanitized = file => {
 	const filename = path.basename( file );
-	
+
 	let sanitizedFile = filename;
 
 	// Prohibited characters:
@@ -353,11 +353,11 @@ export const doesImageHaveExistingSource = file => {
 		// Filename manipulation: if an image is an intermediate image, strip away the image sizing
 		// e.g.- `panda4000x6000.png` -> `panda.png`
 		const baseFileName = filename.replace( imageSizing, '' ) + '.' + extension;
-		
-		const splitFolder = file.split('/');
+
+		const splitFolder = file.split( '/' );
 
 		// Remove the last element (intermediate image filename) and replace it with the original image filename
-		splitFolder.splice( splitFolder.length -1, 1, baseFileName );
+		splitFolder.splice( splitFolder.length - 1, 1, baseFileName );
 
 		const originalImage = splitFolder.join( '/' );
 

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -199,81 +199,85 @@ export const findNestedDirectories = directory => {
  * Check if the folder structure follows the WordPress recommended `uploads/year/month`
  * folder path structure for media files
  *
- * @param {string} folderStructure Path of the entire folder structure
+ * @param {Array} folderStructureKeys Path of the entire folder structure
  */
-export const folderStructureValidation = folderStructure => {
+export const folderStructureValidation = folderStructureKeys => {
 	let errors = 0;
-	let yearIndex, monthIndex;
 
-	// Turn the path into an array to determine index position
-	const directories = folderStructure.split( '/' );
+	// Loop through each key (path) to validate the folder structure format
+	for( const folderPath of folderStructureKeys) {
+		let yearIndex, monthIndex;
 
-	/**
-	 * Upload folder validation
-	 *
-	 * Find if an `uploads` folder exists and return its index position
-	 */
-	const uploadsIndex = directories.indexOf( 'uploads' );
+		// Turn the path into an array to determine index position
+		const directories = folderPath.split( '/' );
 
-	/**
-	 * Year folder validation
-	 *
-	 * Find if a year folder exists via a four digit regex matching pattern,
-	 * then obtain that value
-	 */
-	const regexYear = /\b\d{4}\b/g;
-	const year = regexYear.exec( folderStructure ); // Returns an array with the regex-matching value
+		/**
+			* Upload folder validation
+			*
+			* Find if an `uploads` folder exists and return its index position
+			*/
+		const uploadsIndex = directories.indexOf( 'uploads' );
 
-	if ( year ) {
-		yearIndex = directories.indexOf( year[ 0 ] );
-	}
+		/**
+			* Year folder validation
+			*
+			* Find if a year folder exists via a four digit regex matching pattern,
+			* then obtain that value
+			*/
+		const regexYear = /\b\d{4}\b/g;
+		const year = regexYear.exec( folderPath ); // Returns an array with the regex-matching value
 
-	/**
-	 * Month folder validation
-	 *
-	 * Find if a month folder exists via a two digit regex matching pattern,
-	 * then obtain that value
-	 */
-	const regexMonth = /\b\d{2}\b/g;
-	const month = regexMonth.exec( folderStructure ); // Returns an array with the regex-matching value
+		if ( year ) {
+			yearIndex = directories.indexOf( year[ 0 ] );
+		}
 
-	if ( month ) {
-		monthIndex = directories.indexOf( month[ 0 ] );
-	}
+		/**
+			* Month folder validation
+			*
+			* Find if a month folder exists via a two digit regex matching pattern,
+			* then obtain that value
+			*/
+		const regexMonth = /\b\d{2}\b/g;
+		const month = regexMonth.exec( folderPath ); // Returns an array with the regex-matching value
 
-	/**
-	 * Logging
-	 */
+		if ( month ) {
+			monthIndex = directories.indexOf( month[ 0 ] );
+		}
 
-	// Uploads folder
-	if ( uploadsIndex === 0 ) {
-		console.log();
-		console.log( '✅ File structure: Uploads directory exists' );
-		console.log();
-	} else {
-		console.log();
-		console.log( chalk.yellow( '✕' ), 'Recommended: Media files should reside in an', chalk.magenta( '`uploads`' ), 'directory' );
-		errors++;
-	}
+		/**
+			* Logging
+			*/
 
-	// Year folder
-	if ( yearIndex && yearIndex === 1 ) {
-		console.log( '✅ File structure: Year directory exists (format: YYYY)' );
-		console.log();
-	} else {
-		console.log( chalk.yellow( '✕' ), 'Recommended: Structure your WordPress media files into', chalk.magenta( '`uploads/YYYY`' ), 'directories' );
-		errors++;
-	}
+		// Uploads folder
+		if ( uploadsIndex === 0 ) {
+			console.log();
+			console.log( '✅ File structure: Uploads directory exists' );
+			console.log();
+		} else {
+			console.log();
+			console.log( chalk.yellow( '✕' ), 'Recommended: Media files should reside in an', chalk.magenta( '`uploads`' ), 'directory' );
+			errors++;
+		}
 
-	// Month folder
-	if ( monthIndex && monthIndex === 2 ) {
-		console.log( '✅ File structure: Month directory exists (format: MM)' );
-		console.log();
-	} else {
-		console.log( chalk.yellow( '✕' ), 'Recommended: Structure your WordPress media files into', chalk.magenta( '`uploads/YYYY/MM`' ), 'directories' );
-		console.log();
-		errors++;
-	}
+		// Year folder
+		if ( yearIndex && yearIndex === 1 ) {
+			console.log( '✅ File structure: Year directory exists (format: YYYY)' );
+			console.log();
+		} else {
+			console.log( chalk.yellow( '✕' ), 'Recommended: Structure your WordPress media files into', chalk.magenta( '`uploads/YYYY`' ), 'directories' );
+			errors++;
+		}
+
+		// Month folder
+		if ( monthIndex && monthIndex === 2 ) {
+			console.log( '✅ File structure: Month directory exists (format: MM)' );
+			console.log();
+		} else {
+			console.log( chalk.yellow( '✕' ), 'Recommended: Structure your WordPress media files into', chalk.magenta( '`uploads/YYYY/MM`' ), 'directories' );
+			console.log();
+			errors++;
+		}
+ }
 
 	if ( errors ) {
 		recommendedFileStructure();

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -202,11 +202,13 @@ export const findNestedDirectories = directory => {
  * @param {Array} folderStructureKeys Path of the entire folder structure
  */
 export const folderStructureValidation = folderStructureKeys => {
-	let errors = 0;
+	// Collect all the folder paths that have errors
+	let allErrors = [];
 
 	// Loop through each key (path) to validate the folder structure format
 	for ( const folderPath of folderStructureKeys ) {
 		let yearIndex, monthIndex;
+		let error = 0; // Tally individual folder errors
 
 		console.log( chalk.bold( 'Folder:' ), chalk.cyan( `${ folderPath }` ) );
 
@@ -257,7 +259,7 @@ export const folderStructureValidation = folderStructureKeys => {
 		} else {
 			console.log();
 			console.log( chalk.yellow( '✕' ), 'Recommended: Media files should reside in an', chalk.magenta( '`uploads`' ), 'directory' );
-			errors++;
+			error++;
 		}
 
 		// Year folder
@@ -265,7 +267,7 @@ export const folderStructureValidation = folderStructureKeys => {
 			console.log( '✅ File structure: Year directory exists (format: YYYY)' );
 		} else {
 			console.log( chalk.yellow( '✕' ), 'Recommended: Structure your WordPress media files into', chalk.magenta( '`uploads/YYYY`' ), 'directories' );
-			errors++;
+			error++;
 		}
 
 		// Month folder
@@ -275,15 +277,20 @@ export const folderStructureValidation = folderStructureKeys => {
 		} else {
 			console.log( chalk.yellow( '✕' ), 'Recommended: Structure your WordPress media files into', chalk.magenta( '`uploads/YYYY/MM`' ), 'directories' );
 			console.log();
-			errors++;
+			error++;
+		}
+
+		// Push individual folder errors to the collective array of errors
+		if ( error > 0 ) {
+			allErrors.push( folderPath );
 		}
 	}
 
-	if ( errors ) {
+	if ( allErrors.length > 0 ) {
 		recommendedFileStructure();
 	}
 
-	return;
+	return allErrors;
 };
 
 /**

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -285,7 +285,9 @@ export const folderStructureValidation = folderStructure => {
  * @param {string} filename - The current file being validated
  * @returns {Boolean} - Checks if the filename has been sanitized
  */
-export const isFileSanitized = filename => {
+export const isFileSanitized = file => {
+	const filename = path.basename( file );
+	
 	let sanitizedFile = filename;
 
 	// Prohibited characters:

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -208,6 +208,8 @@ export const folderStructureValidation = folderStructureKeys => {
 	for( const folderPath of folderStructureKeys) {
 		let yearIndex, monthIndex;
 
+		console.log( chalk.bold( 'Folder:' ), chalk.cyan( `${ folderPath }` ) );
+
 		// Turn the path into an array to determine index position
 		const directories = folderPath.split( '/' );
 
@@ -252,7 +254,6 @@ export const folderStructureValidation = folderStructureKeys => {
 		if ( uploadsIndex === 0 ) {
 			console.log();
 			console.log( '✅ File structure: Uploads directory exists' );
-			console.log();
 		} else {
 			console.log();
 			console.log( chalk.yellow( '✕' ), 'Recommended: Media files should reside in an', chalk.magenta( '`uploads`' ), 'directory' );
@@ -262,7 +263,6 @@ export const folderStructureValidation = folderStructureKeys => {
 		// Year folder
 		if ( yearIndex && yearIndex === 1 ) {
 			console.log( '✅ File structure: Year directory exists (format: YYYY)' );
-			console.log();
 		} else {
 			console.log( chalk.yellow( '✕' ), 'Recommended: Structure your WordPress media files into', chalk.magenta( '`uploads/YYYY`' ), 'directories' );
 			errors++;
@@ -377,9 +377,6 @@ export const doesImageHaveExistingSource = file => {
 
 // Log errors for files with invalid file extensions and recommend accepted file types
 export const logErrorsForInvalidFileTypes = invalidFiles => {
-	console.log( '------------------------------------------------------------' );
-	console.log();
-
 	invalidFiles.map( file => {
 		console.error( chalk.red( '✕' ), 'File extensions: Invalid file type for file: ', chalk.cyan( `${ file }` ) );
 	} );

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -419,7 +419,14 @@ export const logErrorsForIntermediateImages = obj => {
 	console.log( '------------------------------------------------------------' );
 };
 
-export const summaryLogs = ( folderErrorsLength, intImagesErrorsLength, fileTypeErrorsLength, filenameErrorsLength, totalFiles, totalFolders ) => {
+export const summaryLogs = ( {
+	folderErrorsLength,
+	intImagesErrorsLength,
+	fileTypeErrorsLength,
+	filenameErrorsLength,
+	totalFiles,
+	totalFolders
+} ) => {
 	if ( folderErrorsLength > 0 ) {
 		folderErrorsLength = chalk.bgYellow( ' RECOMMENDED ' ) + chalk.bold.yellow( ` ${ folderErrorsLength } folders, ` ) + `${ totalFolders } folders total`;
 	} else {

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -152,7 +152,7 @@ const recommendAcceptableFileNames = () => {
  *
  * @param {string} directory Root directory, or the given (current) directory
  */
-let individualFiles = [];
+let files = [];
 
 export const findNestedDirectories = directory => {
 	let nestedDirectories;
@@ -173,15 +173,16 @@ export const findNestedDirectories = directory => {
 			if ( statSync.isDirectory() ) {
 				return findNestedDirectories( filePath );
 			} else {
-				// Once we hit media files, push them to an array to do invidual file validations later on
-				return individualFiles.push( filePath ); 
+				// Once we hit media files, push them to an array to do individual file validations later on
+				return files.push( filePath ); 
 			}
 		} );
 	} catch ( error ) {
 		console.error( chalk.red( '✕' ), ` Error: Cannot read nested directory: ${ directory }. Reason: ${ error.message }` );
 		return;
 	}
-	return individualFiles;
+
+	return files;
 };
 
 /**

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -425,7 +425,7 @@ export const summaryLogs = ( {
 	fileTypeErrorsLength,
 	filenameErrorsLength,
 	totalFiles,
-	totalFolders
+	totalFolders,
 } ) => {
 	if ( folderErrorsLength > 0 ) {
 		folderErrorsLength = chalk.bgYellow( ' RECOMMENDED ' ) + chalk.bold.yellow( ` ${ folderErrorsLength } folders, ` ) + `${ totalFolders } folders total`;

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -330,7 +330,7 @@ const identifyIntermediateImage = filename => {
 };
 
 // Check if an intermediate image has an existing original (source) image
-export const doesImageHaveExistingSource = ( file, folder ) => {
+export const doesImageHaveExistingSource = file => {
 	const filename = path.basename( file );
 
 	// Intermediate image regex check
@@ -343,7 +343,13 @@ export const doesImageHaveExistingSource = ( file, folder ) => {
 		// Filename manipulation: if an image is an intermediate image, strip away the image sizing
 		// e.g.- `panda4000x6000.png` -> `panda.png`
 		const baseFileName = filename.replace( imageSizing, '' ) + '.' + extension;
-		const originalImage = path.join( folder, baseFileName );
+		
+		const splitFolder = file.split('/');
+
+		// Remove the last element (intermediate image filename) and replace it with the original image filename
+		splitFolder.splice( splitFolder.length -1, 1, baseFileName );
+
+		const originalImage = splitFolder.join( '/' );
 
 		// Check if an image with the same path + name (the original) already exists
 		if ( fs.existsSync( originalImage ) ) {

--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -142,7 +142,13 @@ const recommendAcceptableFileNames = () => {
 /**
 	* Nested Directory Search
  *
- * Use recursion to identify the nested tree structure of the folders
+ * Use recursion to identify the nested tree structure of the given media file
+	* 
+	* Example media file:
+	*  - Given directory: uploads
+	*   - Nested directories: 2020, 2019, 2018, 2017
+	*    - Nested directories: 01, 02, 03, 04, 05, 06
+	*     - Individual files: image.jpg, image2.jpg, etc. 
  *
  * @param {string} directory Root directory, or the given (current) directory
  */
@@ -158,8 +164,8 @@ export const findNestedDirectories = directory => {
 		// Filter out hidden files such as .DS_Store
 		nestedDirectories = nestedDirectories.filter( file => ! ( /(^|\/)\.[^\/\.]/g ).test( file ) );
 
-		// For each directory
 		nestedDirectories.forEach( dir => {
+			// Concatenate the file path of the parent directory with the nested directory
 			const filePath = path.join( directory, dir );
 			const statSync = fs.stat( filePath ); // Get stats on the file/folder
 


### PR DESCRIPTION
## Description

Building on top of the validation from #575.

This adds validation for multiple subdirectories in the same level in a nested directory tree structure such as:

- Given directory: `uploads`
 - Nested directories: `2020`, `2019`, `2018`, `2017`
  - Nested directories: `01`, `02`, `03`, `04`, `05`, `06`
   - Individual files: `image.jpg`, `image2.jpg, etc.`

## Steps to Test

1. Check out PR.
1. Download this sample `uploads` directory and unzip:
[uploads.zip](https://github.com/Automattic/vip/files/5030577/uploads.zip)

1. Run `npm install`
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-validate-files.js uploads`
1. Verify messages:

- Folder structure validation
- File extension validation
- Filename character validation
- Intermediate images validation

----------------------------------------

<img width="1792" alt="log1" src="https://user-images.githubusercontent.com/29221840/89454171-2e579c00-d715-11ea-87ce-b13263d166f2.png">
<img width="1792" alt="log 2" src="https://user-images.githubusercontent.com/29221840/89454196-37486d80-d715-11ea-8064-4bdea0dac5c6.png">
<img width="1792" alt="log 3" src="https://user-images.githubusercontent.com/29221840/89454361-72e33780-d715-11ea-91a2-0c72b6dd80ff.png">
<img width="1792" alt="log 4" src="https://user-images.githubusercontent.com/29221840/89454377-7a0a4580-d715-11ea-868c-7b716a82fae1.png">


