### PR TITLE
Add Tracks events for validation commands

### DIFF
--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -182,3 +182,4 @@ command( { requiredArgs: 1, format: true } )
 
 		await trackEvent( 'import_validate_files_command_success', allErrors );
 	} );
+	

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -25,6 +25,7 @@ import {
 	logErrorsForInvalidFilenames,
 	summaryLogs,
 } from '../lib/vip-import-validate-files';
+import { trackEvent } from 'lib/tracker';
 
 // Promisify to use async/await
 const syncStat = promisify( fs.statSync );
@@ -34,6 +35,7 @@ const readDir = promisify( fs.readdir );
 command( { requiredArgs: 1, format: true } )
 	.example( 'vip import validate files <file>', 'Run the import validation against the file' )
 	.argv( process.argv, async ( arg, options ) => {
+		await trackEvent( 'import_validate_files_command_execute' );
 		/**
 		 * File manipulation
 		 *
@@ -159,6 +161,15 @@ command( { requiredArgs: 1, format: true } )
 
 		// Log a summary of all errors
 		summaryLogs( {
+			folderErrorsLength: folderValidation.length,
+			intImagesErrorsLength: intermediateImagesTotal,
+			fileTypeErrorsLength: errorFileTypes.length,
+			filenameErrorsLength: errorFileNames.length,
+			totalFiles: files.length,
+			totalFolders: nestedDirectories.length,
+		} );
+
+		await trackEvent( 'import_validate_files_command_success', {
 			folderErrorsLength: folderValidation.length,
 			intImagesErrorsLength: intermediateImagesTotal,
 			fileTypeErrorsLength: errorFileTypes.length,

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -182,4 +182,3 @@ command( { requiredArgs: 1, format: true } )
 
 		await trackEvent( 'import_validate_files_command_success', allErrors );
 	} );
-	

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -159,17 +159,26 @@ command( { requiredArgs: 1, format: true } )
 			logErrorsForIntermediateImages( intermediateImages );
 		}
 
-		const allErrors = {
+		// Log a summary of all errors
+		summaryLogs( {
 			folderErrorsLength: folderValidation.length,
 			intImagesErrorsLength: intermediateImagesTotal,
 			fileTypeErrorsLength: errorFileTypes.length,
 			filenameErrorsLength: errorFileNames.length,
 			totalFiles: files.length,
 			totalFolders: nestedDirectories.length,
-		};
+		} );
 
-		// Log a summary of all errors
-		summaryLogs( allErrors );
+		// Tracks events to track activity
+		// Props (object keys) need to be in Snake case vs. camelCase
+		const allErrors = {
+			folder_errors_length: folderValidation.length,
+			int_images_errors_length: intermediateImagesTotal,
+			file_type_errors_length: errorFileTypes.length,
+			filename_errors_length: errorFileNames.length,
+			total_files: files.length,
+			total_folders: nestedDirectories.length,
+		};
 
 		await trackEvent( 'import_validate_files_command_success', allErrors );
 	} );

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -159,22 +159,17 @@ command( { requiredArgs: 1, format: true } )
 			logErrorsForIntermediateImages( intermediateImages );
 		}
 
-		// Log a summary of all errors
-		summaryLogs( {
+		const allErrors = {
 			folderErrorsLength: folderValidation.length,
 			intImagesErrorsLength: intermediateImagesTotal,
 			fileTypeErrorsLength: errorFileTypes.length,
 			filenameErrorsLength: errorFileNames.length,
 			totalFiles: files.length,
 			totalFolders: nestedDirectories.length,
-		} );
+		};
 
-		await trackEvent( 'import_validate_files_command_success', {
-			folderErrorsLength: folderValidation.length,
-			intImagesErrorsLength: intermediateImagesTotal,
-			fileTypeErrorsLength: errorFileTypes.length,
-			filenameErrorsLength: errorFileNames.length,
-			totalFiles: files.length,
-			totalFolders: nestedDirectories.length,
-		} );
+		// Log a summary of all errors
+		summaryLogs( allErrors );
+
+		await trackEvent( 'import_validate_files_command_success', allErrors );
 	} );

--- a/src/bin/vip-import-validate-sql.js
+++ b/src/bin/vip-import-validate-sql.js
@@ -175,9 +175,13 @@ command( {
 			for ( const [ type, check ] of Object.entries( checks ) ) {
 				check.outputFormatter( check, type );
 				console.log( '' );
-				errorSummary[ type ] = check.results.length;
+
+				// Change `type` to snake_case for Tracks events
+				const typeToSnakeCase = type.replace( /([A-Z])/, '_$1' ).toLowerCase();
+
+				errorSummary[ typeToSnakeCase ] = check.results.length;
 			}
-			errorSummary.problemsFound = problemsFound;
+			errorSummary.problems_found = problemsFound;
 
 			if ( problemsFound > 0 ) {
 				console.error( `Total of ${ chalk.red( problemsFound ) } errors found` );


### PR DESCRIPTION
## Description
This sends Tracks event for the media and SQL import validation commands. This will give us better insight into the issues that clients encounter with importing data and media.

## Steps to Test


1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-validate-sql.js import.sql `
1. Verify the event as sent to Tracks
1. Alternatively, run the command with `DEBUG=*` in front of it to confirm the track request was sent

