### PR TITLE
Imports: Properly reference child environments

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -42,7 +42,7 @@ command( {
 	appContext: true,
 	appQuery,
 	requiredArgs: 1, // TODO print proper usage example
-	childEnvContext: true,
+	envContext: true,
 	// TODO: `requireConfirm=` with something like, 'Are you sure you want to replace your database with the contents of the provided file?',
 	// Looks like requireConfirm does not work here... ("Cannot destructure property `backup` of 'undefined' or 'null'")
 } ).argv( process.argv, async ( arg, opts ) => {


### PR DESCRIPTION
## Description

We are currently adding the `childEnvContext` option preventing us from selecting a `production` environment.

This change switches it to `envContext` instead.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js @2909`
    1. You should be prompted for an environment. **IMPORTANT!!! Choose: `production`** (for now) & hit enter.
    1. It should show: `PRODUCTION`
    1. Note: you'll see a `ValidationError` until https://github.com/Automattic/vip-go-api/pull/2685 lands when it tries to get an upload URL.
1. Run `./dist/bin/vip-import-sql.js @2909.production`
    1. You should **NOT** be prompted for an environment.
    1. It should show: `PRODUCTION`
    1. Note: you'll see a `ValidationError` until https://github.com/Automattic/vip-go-api/pull/2685 lands when it tries to get an 