### PR TITLE
Ignore an empty VIP_PROXY arg

### DIFF
--- a/src/lib/http/socks-proxy-agent.js
+++ b/src/lib/http/socks-proxy-agent.js
@@ -8,7 +8,7 @@ import ProxyAgent from 'socks-proxy-agent';
  */
 
 export default function createSocksProxyAgent() {
-	if ( ! process.env.hasOwnProperty( 'VIP_PROXY' ) ) {
+	if ( ! process.env.VIP_PROXY ) {
 		return null;
 	}
 


### PR DESCRIPTION
Because it's awkward to have to unset the env var to not use it.

`VIP_PROXY="" vip` should ignore proxy but currently doesn't.