### PR TITLE
SQL Validation: Catch invalid / unreadable file

### DIFF
--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -184,7 +184,7 @@ export const validate = async ( filename: string, isImport: boolean = true ) => 
 	try {
 		fd = await openFile( filename );
 	} catch ( e ) {
-		console.log( chalk.red( 'Error: The file at the provided path is either missing or not readable.' ) );
+		console.log( chalk.red( 'Error: ' ) + 'The file at the provided path is either missing or not readable.' );
 		console.log( 'Please check the input and try again.' );
 		process.exit( 1 );
 	}

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -167,11 +167,30 @@ function checkTablePrefixes( tables ) {
 	}
 }
 
+const openFile = ( filename, flags = 'r', mode = 666 ) => new Promise( ( resolve, reject ) => {
+	fs.open( filename, flags, mode, ( err, fd ) => {
+		if ( err ) {
+			return reject( err );
+		}
+		resolve( fd );
+	} );
+} );
+
 export const validate = async ( filename: string, isImport: boolean = true ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { isImport } );
 
+	let fd;
+
+	try {
+		fd = await openFile( filename );
+	} catch ( e ) {
+		console.log( chalk.red( 'Error: The file at the provided path is either missing or not readable.' ) );
+		console.log( 'Please check the input and try again.' );
+		process.exit( 1 );
+	}
+
 	const readInterface = readline.createInterface( {
-		input: fs.createReadStream( filename ),
+		input: fs.createReadStream( '', { fd } ),
 		output: null,
 		console: false,
 	} );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -167,14 +167,16 @@ function checkTablePrefixes( tables ) {
 	}
 }
 
-const openFile = ( filename, flags = 'r', mode = 666 ) => new Promise( ( resolve, reject ) => {
-	fs.open( filename, flags, mode, ( err, fd ) => {
-		if ( err ) {
-			return reject( err );
-		}
-		resolve( fd );
+function openFile( filename, flags = 'r', mode = 666 ) {
+	return new Promise( ( resolve, reject ) => {
+		fs.open( filename, flags, mode, ( err, fd ) => {
+			if ( err ) {
+				return reject( err );
+			}
+			resolve( fd );
+		} );
 	} );
-} );
+}
 
 export const validate = async ( filename: string, isImport: boolean = true ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { isImport } );


### PR DESCRIPTION
## Description

Currently, if a file name is passed to the SQL validation command that does not exist or is not readable on the user's local system, we display the standard catch-all error message with the unhandled exception:

```
  ❌  Unexpected error: Please contact VIP Support with the following error:
  Error: ENOENT: no such file or directory, open 'foo'
```

The error message is mildly cryptic & accurate, but we don't want to direct this situation to VIP Support.  It's most likely just a typo.

This change wraps the file opening process in a Promise / try/catch, so we can display a more meaningful error:

![Screen Shot 2020-12-03 at 2 20 53 PM](https://user-images.githubusercontent.com/1587282/101077470-e20d5300-3572-11eb-997b-2eaa1c285484.png)

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-validate-sql.js foo` (where `foo` is a file that does not exist)
    1. Confirm the new messaging is an improved UX
1. Run `./dist/bin/vip-import-validate-sql.js /path/to/some/invalid/dbfile.sql`
    1. Confirm the script accurately declares the file as invalid as before
1. Run `./dist/bin/vip-import-validate-sql.js /path/to/some/valid/dbfile.sql`
    1. Confirm the script accurately declares the file as valid as before
