### PR TITLE
SQL Validation: Separate import messaging & failure tracking

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -60,7 +60,7 @@ command( {
 		err( 'The type of application you specified does not currently support SQL imports.' );
 	}
 
-	await validate( fileName );
+	await validate( fileName, true );
 
 	/**
 	 * TODO: We should check for various site locks (including importing) prior to the upload.

--- a/src/bin/vip-import-validate-sql.js
+++ b/src/bin/vip-import-validate-sql.js
@@ -22,6 +22,5 @@ command( {
 			process.exit( 1 );
 		}
 
-		const isImport = false;
-		validate( filename, isImport );
+		validate( filename );
 	} );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -211,15 +211,20 @@ export const validate = async ( filename: string, isImport: boolean = true ) => 
 
 		if ( problemsFound > 0 ) {
 			console.error( `Total of ${ chalk.red( problemsFound ) } errors found` );
-			if ( isImport ) {
-				// If we're running this as part of an import command, bail out here
-				process.exit( 1 );
-			}
-		} else {
-			console.log( '✅ Your database file looks good.  You can now submit for import, see here for more details: ' +
-            'https://wpvip.com/documentation/vip-go/migrating-and-importing-content/#submitting-the-database' );
+			await trackEvent( 'import_validate_sql_command_failure', { isImport, errorSummary } );
+			process.exit( 1 );
 		}
 
-		await trackEvent( 'import_validate_sql_command_success', { isImport, errorSummary } );
+		console.log( '✅ Your database file looks good.' );
+
+		await trackEvent( 'import_validate_sql_command_success', { isImport } );
+
+		if ( isImport ) {
+			console.log( '\n🎉 Continuing to the import process.' );
+			return;
+		}
+
+		console.log( '\n🎉 You can now submit for import, see here for more details: ' +
+			'https://wpvip.com/documentation/vip-go/migrating-and-importing-content/#submitting-the-database' );
 	} );
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -167,7 +167,7 @@ function checkTablePrefixes( tables ) {
 	}
 }
 
-export const validate = async ( filename: string, isImport: boolean = true ) => {
+export const validate = async ( filename: string, isImport: boolean = false ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { isImport } );
 
 	const readInterface = readline.createInterface( {


### PR DESCRIPTION
## Description

More clearly differentiate the messaging and event tracking when validating SQL for an Import and otherwise.

Currently, we output the line:
`You can now submit for import, see here for more details:` With a link to a [support doc to request an import from Support](https://wpvip.com/documentation/vip-go/migrating-and-importing-content/#submitting-the-database).

That makes sense when manually running a validation, but not in the case of an import that calls out to the validation command behind the scenes.

This changes that copy to: `Continuing to the import process.`

Additionally, this splits out the tracking event `import_validate_sql_command_success`, into a separate event when validation fails called `import_validate_sql_command_failure`.  Currently, we're just calling the former with an `errorSummary` prop. 

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-validate-sql.js /path/to/some/invalid/dbfile.sql`
    1. Confirm the script accurately declares the file as invalid as before
1. Run `./dist/bin/vip-import-validate-sql.js /path/to/some/valid/dbfile.sql`
    1. Confirm the script accurately declares the file as valid as before
1. Run GOOP & Parker Locally
1. Run `API_HOST=http://localhost:4000 ./dist/bin/vip-import-sql.js @5000.production /path/to/some/valid/dbfile.sql`
    1. Confirm the script accurately declares the file as valid and uses the correct Import-specific messaging
1. Repeat the above with debug output enabled (`DEBUG=*` env var)
    1. Confirm the tracking events are appropriate