### PR TITLE
SQL Import: Extend command wrapper's requireConfirm functionality

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -17,7 +17,6 @@ import gql from 'graphql-tag';
 import command from 'lib/cli/command';
 import { currentUserCanImportForApp, isSupportedApp } from 'lib/site-import/db-file-import';
 import { uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
-import { formatData } from '../lib/cli/format';
 import { validate } from 'lib/validations/sql';
 import API from 'lib/api';
 
@@ -43,11 +42,10 @@ command( {
 	appQuery,
 	requiredArgs: 1, // TODO print proper usage example
 	envContext: true,
-	// TODO: `requireConfirm=` with something like, 'Are you sure you want to replace your database with the contents of the provided file?',
-	// Looks like requireConfirm does not work here... ("Cannot destructure property `backup` of 'undefined' or 'null'")
+	module: 'import-sql',
+	requireConfirm: 'Are you sure you want to import the contents of the provided SQL file?',
 } ).argv( process.argv, async ( arg, opts ) => {
 	const { app, env } = opts;
-	const primaryDomainName = env.primaryDomain.name;
 	const [ fileName ] = arg;
 
 	console.log( '** Welcome to the WPVIP Site SQL Importer! **\n' );
@@ -65,16 +63,6 @@ command( {
 	/**
 	 * TODO: We should check for various site locks (including importing) prior to the upload.
 	 */
-
-	console.log( 'You are about to import a SQL file to site:' );
-
-	console.log( formatData( [
-		{ key: 'appId', value: app.id },
-		{ key: 'appName', value: app.name },
-		{ key: 'environment ID', value: env.id },
-		{ key: 'environment', value: env.type },
-		{ key: 'Primary Domain Name', value: primaryDomainName },
-	], 'keyValue' ) );
 
 	const api = await API();
 

--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -27,6 +27,7 @@ command( {
 	appContext: true,
 	appQuery: appQuery,
 	childEnvContext: true,
+	module: 'sync',
 	requireConfirm: 'Are you sure you want to sync from production?',
 } )
 	.argv( process.argv, async ( arg, opts ) => {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -7,6 +7,7 @@ import args from 'args';
 import { prompt } from 'enquirer';
 import chalk from 'chalk';
 import gql from 'graphql-tag';
+import path from 'path';
 import updateNotifier from 'update-notifier';
 
 /**
@@ -346,24 +347,36 @@ args.argv = async function( argv, cb ): Promise<any> {
 			message = _opts.requireConfirm;
 		}
 
-		const { backup, canSync, errors } = options.env.syncPreview;
+		switch ( _opts.module ) {
+			case 'import-sql':
+				if ( options.env && options.env.primaryDomain ) {
+					const primaryDomainName = options.env.primaryDomain.name;
+					info.push( { key: 'Primary Domain Name', value: primaryDomainName } );
+				}
+				this.sub && info.push( { key: 'SQL File', value: this.sub } );
+				break;
+			case 'sync':
+				const { backup, canSync, errors } = options.env.syncPreview;
 
-		if ( ! canSync ) {
-			// User can not sync due to some error(s)
-			// Shows the first error in the array
-			console.log( `${ chalk.red( 'Error:' ) } Could not sync to this environment: ${ errors[ 0 ].message }` );
-			return {};
+				if ( ! canSync ) {
+					// User can not sync due to some error(s)
+					// Shows the first error in the array
+					console.log( `${ chalk.red( 'Error:' ) } Could not sync to this environment: ${ errors[ 0 ].message }` );
+					return {};
+				}
+
+				// remove __typename from replacements.
+				// can not be deleted afterwards if deconstructed
+				const replacements = options.env.syncPreview.replacements.map( rep => {
+					const { from, to } = rep;
+					return { from, to };
+				} );
+
+				info.push( { key: 'From backup', value: new Date( backup.createdAt ).toUTCString() } );
+				info.push( { key: 'Replacements', value: '\n' + formatData( replacements, 'table' ) } );
+				break;
+			default:
 		}
-
-		// remove __typename from replacements.
-		// can not be deleted afterwards if deconstructed
-		const replacements = options.env.syncPreview.replacements.map( rep => {
-			const { from, to } = rep;
-			return { from, to };
-		} );
-
-		info.push( { key: 'From backup', value: new Date( backup.createdAt ).toUTCString() } );
-		info.push( { key: 'Replacements', value: '\n' + formatData( replacements, 'table' ) } );
 
 		const yes = await confirm( info, message );
 		if ( ! yes ) {


### PR DESCRIPTION
## Description

Currently, passing the `requireConfirm` option to the `command` function for anything outside the `sync` command fails:

```
✕  Unexpected error: Please contact VIP Support with the following error:
TypeError: Cannot destructure property 'backup' of 'options.env.syncPreview' as it is undefined.
at Args._args.default.argv (/Users/jeff/Documents/gitRepos/vip/dist/lib/cli/command.js:382:11)
```

In order to use it for the sql import, it needs to be enhanced to only check for appropriate inputs and to display only appropriate output.

This is accomplished here by passing a `module` slug to `command` so we can differentiate the `requireConfirm` handling depending on which command invoked it (but sill maintain a standardized API and tracking).

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `API_HOST=http://localhost:4000 ./dist/bin/vip-import-sql.js @5000.production /path/to/a/dbdump.sql`
    1. Verify you are prompted with an "are you sure" message
    1. Verify your sql file is shown in the prompt
1. The `sync` command should be unaffected & display the output as it currently does

