### PR TITLE
Name the circleci tests for clarity of which is failing/running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,25 @@ workflows:
       - flow
       - test:
           version: 8-stretch
+          name: 8-stretch
           requires:
             - lint
             - flow
       - test:
           version: 10-stretch
+          name: 10-stretch
           requires:
             - lint
             - flow
       - test:
           version: lts-stretch
+          name: lts-stretch
           requires:
             - lint
             - flow
       - test:
           version: current-stretch
+          name: current-stretch
           requires:
             - lint
             - flow


### PR DESCRIPTION
## Description

Adds naming to the circle ci jobs so we can see what version of node may be having an issue.

## Steps to Test

No testing necessary, just witness the naming of the tests that execute for this PR.


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_