### PR TITLE
Add a validation to check each line for ENGINE!=InnoDB

### DIFF
--- a/__fixtures__/validations/bad-sql-dump.sql
+++ b/__fixtures__/validations/bad-sql-dump.sql
@@ -1,0 +1,32 @@
+CREATE DATABASE automatticians;
+
+USE automatticians;
+
+-- DROP TABLE IF EXISTS `employees`;
+
+-- CREATE TABLE `employees` (
+--     id INT(10) UNSIGNED NOT NULL AUTO_INCREMENTS,
+--     employeeNumber VARCHAR(255) NOT NULL,
+--     firstName VARCHAR(255) NOT NULL,
+--     lastName VARCHAR(255) NOT NULL,
+--     PRIMARY KEY (id),
+--     UNIQUE KEY (employeeNumber)
+-- ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+CREATE TRIGGER before_employee_update
+        BEFORE UPDATE ON employees
+        FOR EACH ROW
+    INSERT INTO employee_audit
+    SET action = 'update',
+        employeeNumber = OLD.employeeNumber,
+        lastname = OLD.lastname,
+        changedat = NOW();
+
+ALTER USER USER() IDENTIFIED BY 'auth_string';
+
+DROP DATABASE countrycodes;
+
+INSERT INTO wp_options (option_name, option_value, autoload) 
+    VALUES 
+        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
+        ('home', 'https://super-empoyees.com', 'yes');

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -45,31 +45,31 @@ describe( 'lib/validations/sql', () => {
 		it( 'an error, and exits with code 1', () => {
 			expect( mockExit ).toHaveBeenCalledWith( ERROR_CODE );
 		} );
-		it( 'USE statements', () => {
+		it( 'instances of USE statements', () => {
 			expect( output ).toContain( 'USE statement on line(s) 3' );
 		} );
-		it( 'CREATE DATABASE statements', () => {
+		it( 'instances of CREATE DATABASE statements', () => {
 			expect( output ).toContain( 'CREATE DATABASE statement on line(s) 1' );
 		} );
-		it( 'TRIGGER statements', () => {
+		it( 'instances of TRIGGER statements', () => {
 			expect( output ).toContain( 'TRIGGER statement on line(s) 16' );
 		} );
-		it( 'DROP DATABASE statements', () => {
+		it( 'instances of DROP DATABASE statements', () => {
 			expect( output ).toContain( 'DROP DATABASE statement on line(s) 27' );
 		} );
-		it( 'ALTER USER statements', () => {
+		it( 'instances of ALTER USER statements', () => {
 			expect( output ).toContain( 'ALTER USER statement on line(s) 25' );
 		} );
-		it( 'no DROP TABLE IF EXISTS statements', () => {
+		it( 'no instances of DROP TABLE IF EXISTS statements', () => {
 			expect( output ).toContain( 'DROP TABLE was not found' );
 		} );
-		it( 'no CREATE TABLE statements', () => {
+		it( 'no instances of CREATE TABLE statements', () => {
 			expect( output ).toContain( 'CREATE TABLE was not found' );
 		} );
 		it.skip( 'siteurl/home matches', () => {
 			// TODO: the validator should warn when these fields are mismatched
 		} );
-		it( 'ENGINE != InnoDB', () => {
+		it( 'instances of ENGINE != InnoDB', () => {
 			expect( output ).toContain( 'ENGINE != InnoDB on line(s) 14' );
 		} );
 	} );

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -43,27 +43,21 @@ describe( 'lib/validations/sql', () => {
 			debug( 'output', output );
 		} );
 		it( 'an error, and exits with code 1', () => {
-			debug( 'b1' );
 			expect( mockExit ).toHaveBeenCalledWith( ERROR_CODE );
 		} );
 		it( 'USE statements', () => {
-			debug( 'b2' );
 			expect( output ).toContain( 'USE statement on line(s) 3' );
 		} );
 		it( 'CREATE DATABASE statements', () => {
-			debug( 'b3' );
 			expect( output ).toContain( 'CREATE DATABASE statement on line(s) 1' );
 		} );
 		it( 'TRIGGER statements', () => {
-			debug( 'b4' );
 			expect( output ).toContain( 'TRIGGER statement on line(s) 16' );
 		} );
 		it( 'DROP DATABASE statements', () => {
-			debug( 'b5' );
 			expect( output ).toContain( 'DROP DATABASE statement on line(s) 27' );
 		} );
 		it( 'ALTER USER statements', () => {
-			debug( 'b6' );
 			expect( output ).toContain( 'ALTER USER statement on line(s) 25' );
 		} );
 		it( 'no DROP TABLE IF EXISTS statements', () => {

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -1,0 +1,82 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import path from 'path';
+import debugLib from 'debug';
+import fetch, { Response } from 'node-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { validate } from 'lib/validations/sql';
+
+const debug = debugLib( '@automattic/vip:__tests__:validations:sql' );
+
+// Mock console.log()
+let output;
+global.console = {
+	log: ( m, d = '' ) => output += m + d + '\n',
+	error: ( m, d = '' ) => output += m + d + '\n',
+};
+jest.spyOn( global.console, 'log' );
+
+const mockExit = jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
+const ERROR_CODE = 1;
+
+jest.mock( 'node-fetch' );
+fetch.mockReturnValue( Promise.resolve( new Response( 'ok' ) ) );
+
+describe( 'lib/validations/sql', () => {
+	describe( 'it fails when the SQL has', () => {
+		beforeAll( async () => {
+			try {
+				output = '';
+				const badSqlDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'bad-sql-dump.sql' );
+				await validate( badSqlDumpPath );
+			} catch ( e ) {
+				debug( 'Error:', e.toString() );
+			}
+			debug( 'output', output );
+		} );
+		it( 'an error, and exits with code 1', () => {
+			debug( 'b1' );
+			expect( mockExit ).toHaveBeenCalledWith( ERROR_CODE );
+		} );
+		it( 'USE statements', () => {
+			debug( 'b2' );
+			expect( output ).toContain( 'USE statement on line(s) 3' );
+		} );
+		it( 'CREATE DATABASE statements', () => {
+			debug( 'b3' );
+			expect( output ).toContain( 'CREATE DATABASE statement on line(s) 1' );
+		} );
+		it( 'TRIGGER statements', () => {
+			debug( 'b4' );
+			expect( output ).toContain( 'TRIGGER statement on line(s) 16' );
+		} );
+		it( 'DROP DATABASE statements', () => {
+			debug( 'b5' );
+			expect( output ).toContain( 'DROP DATABASE statement on line(s) 27' );
+		} );
+		it( 'ALTER USER statements', () => {
+			debug( 'b6' );
+			expect( output ).toContain( 'ALTER USER statement on line(s) 25' );
+		} );
+		it( 'no DROP TABLE IF EXISTS statements', () => {
+			expect( output ).toContain( 'DROP TABLE was not found' );
+		} );
+		it( 'no CREATE TABLE statements', () => {
+			expect( output ).toContain( 'CREATE TABLE was not found' );
+		} );
+		it.skip( 'siteurl/home matches', () => {
+			// TODO: the validator should warn when these fields are mismatched
+		} );
+		it( 'ENGINE != InnoDB', () => {
+			expect( output ).toContain( 'ENGINE != InnoDB on line(s) 14' );
+		} );
+	} );
+} );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -228,8 +228,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	console.log( '\n' );
 	const errorSummary = {};
 	const checkEntires: any = Object.entries( checks );
-	for ( const entry of checkEntires ) {
-		const [ type, check ]: [string, CheckType] = entry;
+	for ( const [ type, check ]: [string, CheckType] of checkEntires ) {
 		check.outputFormatter( check, type );
 		console.log( '' );
 
@@ -244,12 +243,14 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	if ( problemsFound > 0 ) {
 		console.error( `Total of ${ chalk.red( problemsFound ) } errors found` );
 		await trackEvent( 'import_validate_sql_command_failure', { isImport, errorSummary } );
-		process.exit( 1 );
+		return process.exit( 1 );
 	}
 
 	console.log( '✅ Your database file looks good.' );
 
 	await trackEvent( 'import_validate_sql_command_success', { isImport } );
+
+	readInterface.close();
 
 	if ( isImport ) {
 		console.log( '\n🎉 Continuing to the import process.' );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -48,6 +48,29 @@ const infoCheckFormatter = check => {
 	} );
 };
 
+function checkTablePrefixes( tables ) {
+	const wpTables = [], notWPTables = [], wpMultisiteTables = [];
+	tables.forEach( tableName => {
+		if ( tableName.match( /^wp_(\d+_)/ ) ) {
+			wpMultisiteTables.push( tableName );
+		} else if ( tableName.match( /^wp_/ ) ) {
+			wpTables.push( tableName );
+		} else if ( ! tableName.match( /^wp_/ ) ) {
+			notWPTables.push( tableName );
+		}
+	} );
+	if ( wpTables.length > 0 ) {
+		console.log( ` - wp_ prefix tables found: ${ wpTables.length } ` );
+	}
+	if ( notWPTables.length > 0 ) {
+		problemsFound += 1;
+		console.error( chalk.red( 'Error:' ), `tables without wp_ prefix found: ${ notWPTables.join( ',' ) } ` );
+	}
+	if ( wpMultisiteTables.length > 0 ) {
+		console.log( ` - wp_n_ prefix tables found: ${ wpMultisiteTables.length } ` );
+	}
+}
+
 export type CheckType = {
     excerpt: string,
     matchHandler: Function,
@@ -142,30 +165,16 @@ const checks: Checks = {
 		excerpt: 'Siteurl/home options',
 		recommendation: '',
 	},
+	engineInnoDB: {
+		matcher: /ENGINE=(?!(InnoDB))/i,
+		matchHandler: lineNumber => lineNumber,
+		outputFormatter: errorCheckFormatter,
+		results: [],
+		message: 'ENGINE != InnoDB',
+		excerpt: '\'ENGINE=InnoDB\' should be present (case-insensitive) for all tables',
+		recommendation: 'Ensure your application works with InnoDB and update your SQL dump to include only \'ENGINE=InnoDB\' engine definitions in \'CREATE TABLE\' statements',
+	},
 };
-
-function checkTablePrefixes( tables ) {
-	const wpTables = [], notWPTables = [], wpMultisiteTables = [];
-	tables.forEach( tableName => {
-		if ( tableName.match( /^wp_(\d+_)/ ) ) {
-			wpMultisiteTables.push( tableName );
-		} else if ( tableName.match( /^wp_/ ) ) {
-			wpTables.push( tableName );
-		} else if ( ! tableName.match( /^wp_/ ) ) {
-			notWPTables.push( tableName );
-		}
-	} );
-	if ( wpTables.length > 0 ) {
-		console.log( ` - wp_ prefix tables found: ${ wpTables.length } ` );
-	}
-	if ( notWPTables.length > 0 ) {
-		problemsFound += 1;
-		console.error( chalk.red( 'Error:' ), `tables without wp_ prefix found: ${ notWPTables.join( ',' ) } ` );
-	}
-	if ( wpMultisiteTables.length > 0 ) {
-		console.log( ` - wp_n_ prefix tables found: ${ wpMultisiteTables.length } ` );
-	}
-}
 
 function openFile( filename, flags = 'r', mode = 666 ) {
 	return new Promise( ( resolve, reject ) => {


### PR DESCRIPTION
## Description

We want to ensure that our SQL validator ensures customers are using the InnoDB Engine on their tables.
This validation checks for ENGINE != InnoDB and warns the user of which lines in the SQL dump are impacting the result.

## Steps to Test

Example:

1. Check out this PR
1. `npm ci` if you haven't in a while
1. Test a file that passes: `npm run build && VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-validate-sql ./__fixtures__/client-file-uploader/db-dump-ipsum-67mb.sql` and note that no validations are triggered.
1. Test a file that fails: `npm run build && VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-validate-sql ./__fixtures__/client-file-uploader/db-dump-ipsum-67mb-myisam.sql` and note that the validation fails and shows two line numbers where ENGINE=MyISAM

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_