### PR TITLE
file import validator: Allow SVG files

### DIFF
--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -13,6 +13,7 @@ export const acceptedExtensions = [
 	'gif',
 	'png',
 	'bmp',
+	'svg',
 	'tiff', 'tif',
 	'ico',
 	'asf',


### PR DESCRIPTION
It's a very common file format.

Matching change has been made in our internal tools as well.

## Steps to Test

1. Pull down PR
1. `mkdir tmp-import`
1. `cd tmp-import`
1. `wget https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/o_O.svg`
2. `cd ..`
2. `npm run build`
1. Run `./dist/bin/vip-import-validate-files.js tmp-import`
1. Verify no errors.

