### PR TITLE
Move vip-import-sql to the CLI command line output

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "vip-app": "dist/bin/vip-app.js",
     "vip-app-list": "dist/bin/vip-app-list.js",
     "vip-import": "dist/bin/vip-import.js",
+    "vip-import-sql": "dist/bin/vip-import-sql.js",
     "vip-import-validate-files": "dist/bin/vip-import-validate-files.js",
     "vip-import-validate-sql": "dist/bin/vip-import-validate-sql.js",
     "vip-search-replace": "dist/bin/vip-search-replace.js",

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -45,11 +45,12 @@ const debug = debugLib( 'vip:vip-import-sql' );
 command( {
 	appContext: true,
 	appQuery,
-	requiredArgs: 1, // TODO print proper usage example
 	envContext: true,
 	module: 'import-sql',
+	requiredArgs: 1,
 	requireConfirm: 'Are you sure you want to import the contents of the provided SQL file?',
 } )
+	.example( 'vip import sql <file>', 'Import SQL provided in <file> to your site' )
 	.option( 'search-replace', 'Specify the <from> and <to> pairs to be replaced' )
 	.option( 'in-place', 'Perform the search and replace explicitly on the input file' )
 	.argv( process.argv, async ( arg, opts ) => {

--- a/src/bin/vip-import-validate-files.js
+++ b/src/bin/vip-import-validate-files.js
@@ -31,7 +31,7 @@ import { trackEvent } from 'lib/tracker';
 const stat = promisify( fs.stat );
 
 command( { requiredArgs: 1, format: true } )
-	.example( 'vip import validate files <file>', 'Run the import validation against the file' )
+	.example( 'vip import validate-files <file>', 'Run the import validation against the file' )
 	.argv( process.argv, async arg => {
 		await trackEvent( 'import_validate_files_command_execute' );
 		/**

--- a/src/bin/vip-import-validate-sql.js
+++ b/src/bin/vip-import-validate-sql.js
@@ -14,7 +14,7 @@ import { validate } from 'lib/validations/sql';
 command( {
 	requiredArgs: 1,
 } )
-	.example( 'vip import validate sql <file>', 'Run the import validation against file' )
+	.example( 'vip import validate-sql <file>', 'Run the import validation against file' )
 	.argv( process.argv, async arg => {
 		const filename = arg[ 0 ];
 		if ( ! arg && ! filename ) {

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -12,8 +12,8 @@ import { trackEvent } from 'lib/tracker';
 
 command( )
 	.command( 'sql', 'Import SQL to your database from a file' )
-	.command( 'validate sql', 'Validate your SQL dump' )
-	.command( 'validate files', 'Validate your media file library' )
+	.command( 'validate-sql', 'Validate your SQL dump' )
+	.command( 'validate-files', 'Validate your media file library' )
 	.argv( process.argv, async () => {
 		await trackEvent( 'vip_import_command_execute' );
 	} );

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import command from 'lib/cli/command';
+import { trackEvent } from 'lib/tracker';
+
+command( )
+	.command( 'sql', 'Import SQL to your database from a file' )
+	.command( 'validate sql', 'Validate your SQL dump' )
+	.command( 'validate files', 'Validate your media file library' )
+	.argv( process.argv, async () => {
+		await trackEvent( 'vip_import_command_execute' );
+	} );


### PR DESCRIPTION
## Description

Wires up the automated sql import command with a description and usage example.

## Steps to Test

1. Check out PR on your sandbox and `npm run build`
2. `node ./dist/bin/vip-import.js`
3. `node ./dist/bin/vip-import-sql.js`

Note that there is descriptive output.


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_