### PR TITLE
Import SQL: Add and clean up progress logs

### DIFF
--- a/__tests__/lib/search-and-replace.js
+++ b/__tests__/lib/search-and-replace.js
@@ -13,6 +13,9 @@ import fetch, { Response } from 'node-fetch';
  * Internal dependencies
  */
 import { searchAndReplace } from 'lib/search-and-replace';
+// Import prompt as a module since that's how we implement it in lib/search-and-replace.js,
+// as opposed to importing prompt.confirm on its own
+import * as prompt from 'lib/cli/prompt';
 
 global.console = { log: jest.fn(), error: jest.fn() };
 
@@ -45,6 +48,9 @@ describe( 'lib/search-and-replace', () => {
 		);
 	} );
 	it( 'will accept and use a string of replacement pairs (when one replacement provided)', async () => {
+		// Mock the confirmation prompt so it doesn't actually prompt, and manipulate the resolved value
+		await jest.spyOn( prompt, 'confirm' ).mockResolvedValue( true );
+
 		const { usingStdOut, outputFileName } = await searchAndReplace(
 			testFilePath,
 			'ohai,ohHey',

--- a/__tests__/lib/search-and-replace.js
+++ b/__tests__/lib/search-and-replace.js
@@ -49,7 +49,7 @@ describe( 'lib/search-and-replace', () => {
 	} );
 	it( 'will accept and use a string of replacement pairs (when one replacement provided)', async () => {
 		// Mock the confirmation prompt so it doesn't actually prompt, and manipulate the resolved value
-		await jest.spyOn( prompt, 'confirm' ).mockResolvedValue( true );
+		const promptMock = await jest.spyOn( prompt, 'confirm' ).mockResolvedValue( true );
 
 		const { usingStdOut, outputFileName } = await searchAndReplace(
 			testFilePath,
@@ -62,9 +62,13 @@ describe( 'lib/search-and-replace', () => {
 		expect( outputFileName ).not.toBe( testFilePath );
 
 		const fileContents = fs.readFileSync( outputFileName, { encoding: 'utf-8' } );
+
 		expect( fileContents ).toContain( 'ohHey' );
 		expect( fileContents ).not.toContain( 'ohai' );
+
+		// Clean up
 		fs.unlinkSync( outputFileName );
+		promptMock.mockClear(); // Clear the mock
 	} );
 
 	it( 'will accept and use an array of replacement pairs (when multiple replacement provided)', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3481,7 +3481,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -4257,7 +4257,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4270,7 +4270,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -4617,7 +4617,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -11212,7 +11212,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -139,6 +139,7 @@ command( {
 			await trackEventWithEnv( 'import_sql_command_queued' );
 
 			console.log( '🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );
+			console.log( `You can check the status of your import via the \`import_progress\` site meta in the VIP Go Admin Console!` );
 		} catch ( e ) {
 			err( e );
 		}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -48,7 +48,7 @@ command( {
 	envContext: true,
 	module: 'import-sql',
 	requiredArgs: 1,
-	requireConfirm: 'Are you sure you want to import the contents of the provided SQL file?',
+	requireConfirm: 'Are you sure you want to proceed?',
 } )
 	.example( 'vip import sql <file>', 'Import SQL provided in <file> to your site' )
 	.option( 'search-replace', 'Specify the <from> and <to> pairs to be replaced' )

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -80,6 +80,7 @@ command( {
 
 		let fileNameToUpload = fileName;
 
+		// Run Search and Replace if the --search-replace flag was provided
 		if ( searchReplace && searchReplace.length ) {
 			const { outputFileName } = await searchAndReplace( fileName, searchReplace, {
 				isImport: true,
@@ -90,8 +91,10 @@ command( {
 			fileNameToUpload = outputFileName;
 		}
 
+		// Run SQL validation
 		await validate( fileNameToUpload, true );
 
+		// Call the Public API
 		const api = await API();
 
 		try {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -48,7 +48,7 @@ command( {
 	envContext: true,
 	module: 'import-sql',
 	requiredArgs: 1,
-	requireConfirm: 'Are you sure you want to proceed?',
+	requireConfirm: 'Are you sure you want to import the contents of the provided SQL file?',
 } )
 	.example( 'vip import sql <file>', 'Import SQL provided in <file> to your site' )
 	.option( 'search-replace', 'Specify the <from> and <to> pairs to be replaced' )
@@ -139,7 +139,7 @@ command( {
 			await trackEventWithEnv( 'import_sql_command_queued' );
 
 			console.log( '\n🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );
-			console.log( '--> Check the status of your import via the \`import_progress\` site meta in the VIP Go Admin Console!\n' );
+			console.log( '--> Check the status of your import via the \`import_progress\` site meta in the VIP internal console!\n' );
 			console.log( '===================================' );
 		} catch ( e ) {
 			err( e );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -138,8 +138,9 @@ command( {
 
 			await trackEventWithEnv( 'import_sql_command_queued' );
 
-			console.log( '🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );
-			console.log( `You can check the status of your import via the \`import_progress\` site meta in the VIP Go Admin Console!` );
+			console.log( '\n🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );
+			console.log( '--> Check the status of your import via the \`import_progress\` site meta in the VIP Go Admin Console!\n' );
+			console.log( '===================================' );
 		} catch ( e ) {
 			err( e );
 		}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -139,6 +139,7 @@ command( {
 			await trackEventWithEnv( 'import_sql_command_queued' );
 
 			console.log( '\n🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );
+			// TOD0: Remove the log below before the PUBLIC release
 			console.log( '--> Check the status of your import via the \`import_progress\` site meta in the VIP internal console!\n' );
 			console.log( '===================================' );
 		} catch ( e ) {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -334,11 +334,11 @@ args.argv = async function( argv, cb ): Promise<any> {
 		const info: Array<Tuple> = [];
 
 		if ( options.app ) {
-			info.push( { key: 'app', value: options.app.name } );
+			info.push( { key: 'App', value: options.app.name } );
 		}
 
 		if ( options.env ) {
-			info.push( { key: 'environment', value: getEnvIdentifier( options.env ) } );
+			info.push( { key: 'Environment', value: getEnvIdentifier( options.env ) } );
 		}
 
 		let message = 'Are you sure?';

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -91,8 +91,10 @@ function formatFields( fields: Array<string> ) {
 
 export function keyValue( values: Array<Tuple> ): string {
 	const lines = [];
+	const pairs = values.length > 0;
 
-	lines.push( '===================================' );
+	pairs ? lines.push( '===================================' ) : '';
+
 	for ( const i of values ) {
 		let v = i.value;
 
@@ -104,6 +106,7 @@ export function keyValue( values: Array<Tuple> ): string {
 
 		lines.push( `+ ${ i.key }: ${ v }` );
 	}
+
 	lines.push( '===================================' );
 
 	return lines.join( '\n' );

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -160,7 +160,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.isCompressed = true;
 		fileMeta.fileSize = await getFileSize( fileMeta.fileName );
 
-		console.log( `Compressed file ${ chalk.cyan( fileMeta.basename ) } is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
+		console.log( `Compressed file is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
 
 		const fewerBytes = uncompressedFileSize - fileMeta.fileSize;
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -157,11 +157,11 @@ export const searchAndReplace = async (
 	const yes = await confirm( [
 		{
 			key: 'from',
-			value: `${ replacements[ 0 ]}`,
+			value: `${ chalk.cyan( replacements[ 0 ] ) }`,
 		},
 		{
 			key: 'to',
-			value: `${ replacements[ 1 ] }`,
+			value: `${ chalk.cyan( replacements[ 1 ] ) }`,
 		}
 	], 'Proceed with the following Search and Replace values?' );
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -195,7 +195,12 @@ export const searchAndReplace = async (
 				if ( ! usingStdOut ) {
 					console.log();
 					console.log( `${ 'Search and Replace Complete!' }` );
-					console.log(`Your new SQL file has been saved to ${ chalk.cyan( outputFileName ) }` );
+
+					// Only log this message if the output SQL file isn't the original input file
+					const message = `Your new SQL file has been saved to ${ chalk.cyan( outputFileName ) }`;
+
+					inPlace ? '' : console.log( message );
+
 					console.log();
 				}
 				resolve( {

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -175,10 +175,18 @@ export const searchAndReplace = async (
 	}
 
 	if ( inPlace ) {
-		await confirm(
+		const approved = await confirm(
 			[],
 			'Are you sure you want to run search and replace on your input file? This operation is not reversible.'
 		);
+		
+		if ( ! approved ) {
+			console.log( `${ chalk.red( 'Cancelling' ) }` );
+			
+			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
+			
+			process.exit();
+		}
 	}
 
 	const { usingStdOut, outputFileName, readStream, writeStream } = getReadAndWriteStreams( {

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -166,7 +166,7 @@ export const searchAndReplace = async (
 			key: 'To',
 			value: `${ chalk.cyan( replacements[ 1 ] ) }`,
 		},
-	], 'Proceed with the following Search and Replace values?' );
+	], 'Proceed with the following values?' );
 
 	// Bail if user does not wish to proceed
 	if ( ! yes ) {

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -61,10 +61,10 @@ export function getReadAndWriteStreams( {
 		fs.copyFileSync( fileName, midputFileName );
 
 		debug( `Copied input file to ${ midputFileName }` );
-		console.log( chalk.green( `Copied input file to ${ midputFileName }` ) );
+		console.log( `Searching ${ chalk.cyan( fileName ) }` );
 
 		debug( `Set output to the original file path ${ fileName }` );
-		console.log( chalk.green( `Set output to the original file path ${ fileName }` ) );
+		console.log( 'Replacing...' );
 		return {
 			outputFileName,
 			readStream: fs.createReadStream( midputFileName, { encoding: 'utf8' } ),

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -134,7 +134,7 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	console.log( `${ 'Starting Search and Replace...' }` );
+	console.log( 'Starting Search and Replace...' );
 
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -44,6 +44,7 @@ export type GetReadAndWriteStreamsOutput = {
 function makeTempDir() {
 	const tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'vip-search-replace-' ) );
 	debug( `Created a directory to hold temporary files: ${ tmpDir }` );
+	console.log( chalk.green( `Created a directory to hold temporary files: ${ tmpDir }` ) );
 	return tmpDir;
 }
 
@@ -61,7 +62,10 @@ export function getReadAndWriteStreams( {
 		fs.copyFileSync( fileName, midputFileName );
 
 		debug( `Copied input file to ${ midputFileName }` );
+		console.log( chalk.green( `Copied input file to ${ midputFileName }` ) );
+
 		debug( `Set output to the original file path ${ fileName }` );
+		console.log( chalk.green( `Set output to the original file path ${ fileName }` ) );
 		return {
 			outputFileName,
 			readStream: fs.createReadStream( midputFileName, { encoding: 'utf8' } ),
@@ -71,12 +75,14 @@ export function getReadAndWriteStreams( {
 	}
 
 	debug( `Reading input from file: ${ fileName }` );
+	console.log( chalk.green( `Reading input from file: ${ fileName }` ) );
 
 	switch ( typeof output ) {
 		case 'string':
 			writeStream = fs.createWriteStream( output, { encoding: 'utf8' } );
 			outputFileName = output;
 			debug( `Outputting to file: ${ outputFileName }` );
+			console.log( chalk.green( `Outputting to file: ${ outputFileName }` ) );
 			break;
 		case 'object':
 			writeStream = output;
@@ -85,6 +91,7 @@ export function getReadAndWriteStreams( {
 				debug( 'Outputting to the standard output stream' );
 			} else {
 				debug( 'Outputting to the provided output stream' );
+				console.log( chalk.green( `Outputting to file: ${ outputFileName }` ) );
 			}
 			break;
 		default:
@@ -93,7 +100,10 @@ export function getReadAndWriteStreams( {
 				encoding: 'utf8',
 			} );
 			outputFileName = tmpOutFile;
+
 			debug( `Outputting to file: ${ outputFileName }` );
+			console.log( chalk.green( `Outputting to file: ${ outputFileName }` ) );
+
 			break;
 	}
 
@@ -123,6 +133,10 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
+	if ( ! usingStdOut ) {
+		console.log( chalk.green( 'Starting Search and Replace...' ) );
+	}
+
 	await trackEvent( 'searchreplace_started', { isImport, inPlace } );
 
 	const startTime = process.hrtime();
@@ -142,6 +156,10 @@ export const searchAndReplace = async (
 	const replacementsArr = pairs.map( str => str.split( ',' ) );
 	const replacements = flatten( replacementsArr );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
+
+	if ( ! usingStdOut ) {
+		console.log( chalk.green( `Replacing ${ replacements[ 0 ] } -> ${ replacements[ 1 ] }` ) );
+	}
 
 	if ( inPlace ) {
 		await confirm(

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -67,7 +67,7 @@ export function getReadAndWriteStreams( {
 		console.log( 'Replacing...' );
 
 		outputFileName = fileName;
-		
+
 		return {
 			outputFileName,
 			readStream: fs.createReadStream( midputFileName, { encoding: 'utf8' } ),
@@ -182,12 +182,13 @@ export const searchAndReplace = async (
 			[],
 			'Are you sure you want to run search and replace on your input file? This operation is not reversible.'
 		);
-		
+
+		// Bail if user does not wish to proceed
 		if ( ! approved ) {
 			console.log( `${ chalk.red( 'Cancelling' ) }` );
-			
+
 			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
-			
+
 			process.exit();
 		}
 	}

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -74,14 +74,14 @@ export function getReadAndWriteStreams( {
 	}
 
 	debug( `Reading input from file: ${ fileName }` );
-	console.log( `Reading file ${ chalk.magentaBright ( fileName ) }` );
+	console.log( `Searching file ${ chalk.cyan( fileName ) }` );
 
 	switch ( typeof output ) {
 		case 'string':
 			writeStream = fs.createWriteStream( output, { encoding: 'utf8' } );
 			outputFileName = output;
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( `Replacing to ${ chalk.magenta ( outputFileName ) }` );
+			console.log( 'Replacing...' );
 			break;
 		case 'object':
 			writeStream = output;
@@ -100,7 +100,7 @@ export function getReadAndWriteStreams( {
 			outputFileName = tmpOutFile;
 
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( `Replacing to ${ chalk.magenta( outputFileName ) }` );
+			console.log( 'Replacing...' );
 
 			break;
 	}
@@ -131,7 +131,7 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	console.log( `${ chalk.cyan( 'Starting Search and Replace...' ) }` );
+	console.log( `${ 'Starting Search and Replace...' }` );
 
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
@@ -193,7 +193,9 @@ export const searchAndReplace = async (
 			.pipe( writeStream )
 			.on( 'finish', () => {
 				if ( ! usingStdOut ) {
-					console.log( `${ chalk.cyan ( 'Search and Replace Complete!' ) }` );
+					console.log();
+					console.log( `${ 'Search and Replace Complete!' }` );
+					console.log();
 				}
 				resolve( {
 					inputFileName: fileName,

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -162,7 +162,7 @@ export const searchAndReplace = async (
 		{
 			key: 'to',
 			value: `${ chalk.cyan( replacements[ 1 ] ) }`,
-		}
+		},
 	], 'Proceed with the following Search and Replace values?' );
 
 	// Bail if user does not wish to proceed
@@ -170,7 +170,7 @@ export const searchAndReplace = async (
 		console.log( `${ chalk.red( 'Cancelling' ) }` );
 
 		await trackEvent( 'search_replace_cancelled', { is_import: isImport, in_place: inPlace } );
-	
+
 		process.exit();
 	}
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -65,6 +65,9 @@ export function getReadAndWriteStreams( {
 
 		debug( `Set output to the original file path ${ fileName }` );
 		console.log( 'Replacing...' );
+
+		outputFileName = fileName;
+		
 		return {
 			outputFileName,
 			readStream: fs.createReadStream( midputFileName, { encoding: 'utf8' } ),

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -195,6 +195,7 @@ export const searchAndReplace = async (
 				if ( ! usingStdOut ) {
 					console.log();
 					console.log( `${ 'Search and Replace Complete!' }` );
+					console.log(`Your new SQL file has been saved to ${ chalk.cyan( outputFileName ) }` );
 					console.log();
 				}
 				resolve( {

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -44,7 +44,6 @@ export type GetReadAndWriteStreamsOutput = {
 function makeTempDir() {
 	const tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'vip-search-replace-' ) );
 	debug( `Created a directory to hold temporary files: ${ tmpDir }` );
-	console.log( chalk.green( `Created a directory to hold temporary files: ${ tmpDir }` ) );
 	return tmpDir;
 }
 
@@ -75,14 +74,14 @@ export function getReadAndWriteStreams( {
 	}
 
 	debug( `Reading input from file: ${ fileName }` );
-	console.log( chalk.green( `Reading input from file: ${ fileName }` ) );
+	console.log( `Reading file ${ chalk.magentaBright ( fileName ) }` );
 
 	switch ( typeof output ) {
 		case 'string':
 			writeStream = fs.createWriteStream( output, { encoding: 'utf8' } );
 			outputFileName = output;
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( chalk.green( `Outputting to file: ${ outputFileName }` ) );
+			console.log( `Replacing to ${ chalk.magenta ( outputFileName ) }` );
 			break;
 		case 'object':
 			writeStream = output;
@@ -91,7 +90,6 @@ export function getReadAndWriteStreams( {
 				debug( 'Outputting to the standard output stream' );
 			} else {
 				debug( 'Outputting to the provided output stream' );
-				console.log( chalk.green( `Outputting to file: ${ outputFileName }` ) );
 			}
 			break;
 		default:
@@ -102,7 +100,7 @@ export function getReadAndWriteStreams( {
 			outputFileName = tmpOutFile;
 
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( chalk.green( `Outputting to file: ${ outputFileName }` ) );
+			console.log( `Replacing to ${ chalk.magenta( outputFileName ) }` );
 
 			break;
 	}
@@ -133,9 +131,7 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	if ( ! usingStdOut ) {
-		console.log( chalk.green( 'Starting Search and Replace...' ) );
-	}
+	console.log( `${ chalk.cyan( 'Starting Search and Replace...' ) }` );
 
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
@@ -157,10 +153,6 @@ export const searchAndReplace = async (
 	const replacements = flatten( replacementsArr );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 
-	if ( ! usingStdOut ) {
-		console.log( chalk.green( `Replacing ${ replacements[ 0 ] } -> ${ replacements[ 1 ] }` ) );
-	}
-
 	if ( inPlace ) {
 		await confirm(
 			[],
@@ -180,7 +172,7 @@ export const searchAndReplace = async (
 			.pipe( writeStream )
 			.on( 'finish', () => {
 				if ( ! usingStdOut ) {
-					console.log( chalk.green( 'Search and Replace Complete!' ) );
+					console.log( `${ chalk.cyan ( 'Search and Replace Complete!' ) }` );
 				}
 				resolve( {
 					inputFileName: fileName,

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -153,6 +153,24 @@ export const searchAndReplace = async (
 	const replacements = flatten( replacementsArr );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 
+	// Add a confirmation step for search-replace
+	const yes = await confirm( [
+		{
+			key: 'from',
+			value: `${ replacements[ 0 ]}`,
+		},
+		{
+			key: 'to',
+			value: `${ replacements[ 1 ] }`,
+		}
+	], 'Proceed with the following Search and Replace values?' );
+
+	// Bail if user does not wish to proceed
+	if ( ! yes ) {
+		console.log( `${ chalk.red( 'Cancelling' ) }` );
+		process.exit();
+	}
+
 	if ( inPlace ) {
 		await confirm(
 			[],

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -168,6 +168,9 @@ export const searchAndReplace = async (
 	// Bail if user does not wish to proceed
 	if ( ! yes ) {
 		console.log( `${ chalk.red( 'Cancelling' ) }` );
+
+		await trackEvent( 'search_replace_cancelled', { is_import: isImport, in_place: inPlace } );
+	
 		process.exit();
 	}
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -156,11 +156,11 @@ export const searchAndReplace = async (
 	// Add a confirmation step for search-replace
 	const yes = await confirm( [
 		{
-			key: 'from',
+			key: 'From',
 			value: `${ chalk.cyan( replacements[ 0 ] ) }`,
 		},
 		{
-			key: 'to',
+			key: 'To',
 			value: `${ chalk.cyan( replacements[ 1 ] ) }`,
 		},
 	], 'Proceed with the following Search and Replace values?' );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -189,8 +189,7 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
-	console.log( `${ 'Starting SQL Validation...' }` );
-	console.log();
+	console.log( `${ chalk.underline( 'Starting SQL Validation...' ) }` );
 
 	let fd;
 
@@ -240,7 +239,14 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	errorSummary.problems_found = problemsFound;
 
 	if ( problemsFound > 0 ) {
-		console.error( `Total of ${ chalk.red( problemsFound ) } errors found` );
+		console.error( `** Total of ${ chalk.red( problemsFound ) } errors found ** ` );
+
+		if ( isImport ) {
+			//console.log();
+			console.log( `${ chalk.red( 'Please adjust these error(s) before continuing on with the import.' ) }` );
+			console.log();
+		}
+	
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -272,7 +272,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 			process.exit();
 		}
 
-		console.log( '\nContinuing to the import process.' );
+		console.log( `\n${ chalk.underline( 'Starting the import process...' ) }` );
 		return;
 	}
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -246,7 +246,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 			console.log( `${ chalk.red( 'Please adjust these error(s) before proceeding with the import.' ) }` );
 			console.log();
 		}
-	
+
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -242,8 +242,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 		console.error( `** Total of ${ chalk.red( problemsFound ) } errors found ** ` );
 
 		if ( isImport ) {
-			//console.log();
-			console.log( `${ chalk.red( 'Please adjust these error(s) before continuing on with the import.' ) }` );
+			console.log( `${ chalk.red( 'Please adjust these error(s) before proceeding with the import.' ) }` );
 			console.log();
 		}
 	

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -189,6 +189,8 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
+	console.log( `${ 'Starting SQL Validation...' }` );
+	console.log();
 
 	let fd;
 


### PR DESCRIPTION
## Description

Our logs for imports are quite sparse right now.
We've gotten requests to separate/better organize logs, especially for imports that complete really fast.

Current Logs|
|---|
|<img width="1280" alt="logs main cov" src="https://user-images.githubusercontent.com/29221840/104437902-35949880-5544-11eb-878d-1305a37f08f5.png"><img width="1278" alt="logs main 2" src="https://user-images.githubusercontent.com/29221840/104438518-f0bd3180-5544-11eb-8289-8ba0e062e071.png">|

- Adding logs for search and replace progress
- Require confirmation from users to verify search-replace values + send Track event if user bails
- Note the start & stop of each piece for better clarity (S-R, SQL validation, etc.)
- When we exit on error, log a message instead of just exiting suddenly

Also some fixes:
- Upon cancelling the confirmation prompt when the in-place flag is set, exit instead of continuing on
- Ensure we're returning the `outputFileName` when the in-place flag is set

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run an import:
```
VIP_PROXY="<proxy>" node ./dist/bin/vip-import-sql @2909.develop /path/to/file/dump.sql --search-replace="platform-import-test.go-vip.net,test-import.com"
```

4. Verify you see the correct progress logs:

Revised Logs|
|---|
|<img width="1280" alt="import logs 1 cov" src="https://user-images.githubusercontent.com/29221840/104436519-90c58b80-5542-11eb-870a-3d09ca43fb2b.png"><img width="1279" alt="import logs 2" src="https://user-images.githubusercontent.com/29221840/104438655-10ecf080-5545-11eb-8103-7f75a583cc77.png">|

5. Try the command again and answer `no/false` to some of the prompts. Verify that the program exits
6. This time, try the command with the `--in-place` flag and verify the appropriate logs

