### PR TITLE
Tracks: Show an error via debug when a tracks event name or prop is invalid

### DIFF
--- a/src/lib/analytics/clients/tracks.js
+++ b/src/lib/analytics/clients/tracks.js
@@ -12,6 +12,8 @@ const debug = require( 'debug' )( '@automattic/vip:analytics:clients:tracks' );
  */
 import type { AnalyticsClient } from './client';
 
+const validEventOrPropNamePattern = /^[a-z_][a-z0-9_]*$/;
+
 /**
  * Simple class for tracking using Automattic Tracks.
  *
@@ -48,6 +50,16 @@ export default class Tracks implements AnalyticsClient {
 		if ( ! name.startsWith( this.eventPrefix ) ) {
 			name = this.eventPrefix + name;
 		}
+
+		if ( ! validEventOrPropNamePattern.test( name ) ) {
+			debug( `Error: Invalid event name detected: ${ name } -- this event will be rejected during ETL` );
+		}
+
+		Object.keys( eventProps ).forEach( propName => {
+			if ( ! validEventOrPropNamePattern.test( propName ) ) {
+				debug( `Error: Invalid prop name detected: ${ propName } -- this event will be rejected during ETL` );
+			}
+		} );
 
 		const event = Object.assign( {
 			_en: name,


### PR DESCRIPTION
## Description

As shown in #629, there's currently no visibility into events that will be rejected by the tracks service due to naming issues.  This adds a check that the event name and all property names conform to the proper pattern & shows a debug error if not.

## Steps to Test

1. Check out PR.
2. Add some events like: `await trackEvent( 'ThisEventWillBeRejected' );` & `await trackEventWithEnv( 'thiseventwillberejectedtoo', { SnakeCase: 'nope' } );`
1. Run `npm run build`
1. Run the code path that fires the events with `DEBUG=@automattic/vip:analytics:clients:tracks`
1. Verify the error is shown

