### PR TITLE
SQL Search & Replace: Don't specify stream encoding

### DIFF
--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -64,9 +64,9 @@ export function getReadAndWriteStreams( {
 		debug( `Set output to the original file path ${ fileName }` );
 		return {
 			outputFileName,
-			readStream: fs.createReadStream( midputFileName, { encoding: 'utf8' } ),
+			readStream: fs.createReadStream( midputFileName ),
 			usingStdOut,
-			writeStream: fs.createWriteStream( fileName, { encoding: 'utf8' } ),
+			writeStream: fs.createWriteStream( fileName ),
 		};
 	}
 
@@ -74,7 +74,7 @@ export function getReadAndWriteStreams( {
 
 	switch ( typeof output ) {
 		case 'string':
-			writeStream = fs.createWriteStream( output, { encoding: 'utf8' } );
+			writeStream = fs.createWriteStream( output );
 			outputFileName = output;
 			debug( `Outputting to file: ${ outputFileName }` );
 			break;
@@ -89,9 +89,7 @@ export function getReadAndWriteStreams( {
 			break;
 		default:
 			const tmpOutFile = path.join( makeTempDir(), path.basename( fileName ) );
-			writeStream = fs.createWriteStream( tmpOutFile, {
-				encoding: 'utf8',
-			} );
+			writeStream = fs.createWriteStream( tmpOutFile );
 			outputFileName = tmpOutFile;
 			debug( `Outputting to file: ${ outputFileName }` );
 			break;
@@ -99,7 +97,7 @@ export function getReadAndWriteStreams( {
 
 	return {
 		outputFileName,
-		readStream: fs.createReadStream( fileName, { encoding: 'utf8' } ),
+		readStream: fs.createReadStream( fileName ),
 		usingStdOut,
 		writeStream,
 	};


### PR DESCRIPTION
## Description

SQL files can contain [sections of binary](https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html).  When we specify `utf8` encoding, those binary sections are being erroneously encoded as text.

This change specifies no encoding for any of the streams in the search & replace lib to access the raw streams. Hopefully that suffices for our purposes :)

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run imports with and without binary columns.

