### PR TITLE
SQL Import: Error out if the file is too large

### DIFF
--- a/__tests__/lib/client-file-uploader.js
+++ b/__tests__/lib/client-file-uploader.js
@@ -12,14 +12,6 @@ import { getFileMD5Hash, getFileMeta, getPartBoundaries } from 'lib/client-file-
 
 describe( 'client-file-uploader', () => {
 	describe( 'getFileMeta()', () => {
-		it( 'should fail on empty file', async () => {
-			const fileName = '__fixtures__/client-file-uploader/emptyfile.txt';
-			expect.assertions( 1 );
-			await expect( getFileMeta( fileName ) ).rejects.toEqual(
-				"File '__fixtures__/client-file-uploader/emptyfile.txt' is empty."
-			);
-		} );
-
 		it( 'should get meta from a 67mb sql file', async () => {
 			const fileName = '__fixtures__/client-file-uploader/db-dump-ipsum-67mb.sql';
 			const meta = await getFileMeta( fileName );

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -104,10 +104,6 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 
 		const fileSize = await getFileSize( fileName );
 
-		if ( ! fileSize ) {
-			return reject( `File '${ fileName }' is empty.` );
-		}
-
 		const basename = path.posix.basename( fileName );
 		// TODO Validate File basename...  encodeURIComponent, maybe...?
 

--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -4,8 +4,11 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
+import { GB_IN_BYTES } from 'lib/constants/file-size';
+
+export const SQL_IMPORT_FILE_SIZE_LIMIT = 10 * GB_IN_BYTES;
 
 export interface AppForImport {
 	id: Number;


### PR DESCRIPTION
## Description

We want to limit the size of the file we permit to be uploaded and imported.

Currently, the limit is arbitrarily set at 10 GiB (10 * 1024 * 1024 * 1024 );

## Steps to Test

1. Generate a large empty file: `dd if=/dev/zero of=/tmp/zero-filled-file-11gb.sql bs=64m count=176` (Linux users probably have to capitalize the `M` in the `bs` flag)
1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js @0000.production /tmp/zero-filled-file-11gb.sql`
1. Verify the error is thrown and copy is good and actionable
1. Repeat with a file smaller than the threshold and confirm it does not error out.

