### PR TITLE
SQL Import: Move some debug output to debug command

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -115,7 +115,8 @@ command( {
 				result,
 			} = await uploadImportSqlFileToS3( { app, env, fileName: fileNameToUpload } );
 
-			console.log( { basename, md5, result } );
+			debug( { basename, md5, result } );
+			console.log( 'Cloud upload complete. Initiating the import.' );
 
 			try {
 				await api.mutate( {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -116,7 +116,7 @@ command( {
 			} = await uploadImportSqlFileToS3( { app, env, fileName: fileNameToUpload } );
 
 			debug( { basename, md5, result } );
-			console.log( 'Cloud upload complete. Initiating the import.' );
+			console.log( 'Upload complete. Initiating the import.' );
 
 			try {
 				await api.mutate( {

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -24,6 +24,8 @@ import debugLib from 'debug';
 import API from 'lib/api';
 import { MB_IN_BYTES } from 'lib/constants/file-size';
 
+const debug = debugLib( 'vip:lib/client-file-uploader' );
+
 // Files smaller than COMPRESS_THRESHOLD will not be compressed before upload
 export const COMPRESS_THRESHOLD = 16 * MB_IN_BYTES;
 
@@ -190,7 +192,7 @@ export async function uploadUsingPutObject( {
 	env,
 	fileMeta: { basename, fileContent, fileName, fileSize },
 }: UploadUsingArguments ) {
-	console.log( `Uploading ${ chalk.cyan( basename ) } to S3 using the \`PutObject\` command` );
+	debug( `Uploading ${ chalk.cyan( basename ) } to S3 using the \`PutObject\` command` );
 
 	const presignedRequest = await getSignedUploadRequestData( {
 		appId: app.id,
@@ -244,7 +246,7 @@ export async function uploadUsingPutObject( {
 export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingArguments ) {
 	const { basename } = fileMeta;
 
-	console.log( 'Uploading to S3 using the Multipart API.' );
+	debug( `Uploading ${ chalk.cyan( basename ) } to S3 using the Multipart API.` );
 
 	const presignedCreateMultipartUpload = await getSignedUploadRequestData( {
 		appId: app.id,
@@ -282,7 +284,7 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 
 	const uploadId = parsedResponse.InitiateMultipartUploadResult.UploadId;
 
-	console.log( { uploadId } );
+	debug( { uploadId } );
 
 	const parts = getPartBoundaries( fileMeta.fileSize );
 	const etagResults = await uploadParts( {

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -16,6 +16,7 @@ import { createHash } from 'crypto';
 import { PassThrough } from 'stream';
 import { Parser as XmlParser } from 'xml2js';
 import { stdout as singleLogLine } from 'single-line-log';
+import debugLib from 'debug';
 
 /**
  * Internal dependencies
@@ -112,9 +113,9 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 
 		const isCompressed = [ 'application/zip', 'application/gzip' ].includes( mimeType );
 
-		console.log( 'Calculating file md5 checksum...' );
+		debug( 'Calculating file md5 checksum...' );
 		const md5 = await getFileMD5Hash( fileName );
-		console.log( `Calculated file md5 checksum: ${ md5 }\n` );
+		debug( `Calculated file md5 checksum: ${ md5 }\n` );
 
 		resolve( {
 			basename,
@@ -291,7 +292,7 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 		parts,
 		uploadId,
 	} );
-	console.log( { etagResults } );
+	debug( { etagResults } );
 
 	return completeMultipartUpload( {
 		app,


### PR DESCRIPTION
## Description

In order to decrease the default verbosity, change some `console.log`s to `debug`. That way, we can still see the debug output as needed, but customers are not subjected to it.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run an import (with `./dist/bin/vip-import-sql.js` ... etc.)
    * Verify only information that is pertinent to the customer is displayed
1. Repeat with the `DEBUG=*` prefix
    * Verify debug data are included
