### PR TITLE
Fix standalone Search and Replace command

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -46,7 +46,7 @@ const rootCmd = async function() {
 			} )
 			.command( 'app', 'List and modify your VIP applications' )
 			.command( 'import', 'Check the validity of an import source' )
-			.command( 'search', 'Perform Search and Replace tasks on files' )
+			.command( 'search-replace', 'Perform Search and Replace tasks on files' )
 			.command( 'sync', 'Sync production to a development environment' )
 			.command( 'wp', 'Run WP CLI commands against an environment' )
 			.argv( process.argv );


### PR DESCRIPTION
## Description

The standalone S-R command currently doesn't work because we need to link the full name of the command as specified in `package.json`: https://github.com/Automattic/vip/blob/master/package.json#L14

## Steps to Test

1. Try the standalone S-R on master:
```
VIP_PROXY="<proxy>" vip search /path/to/file.sql --search-replace="test.com,bye.com"

  ✕  Unexpected error: Please contact VIP Support with the following error:
  Error: spawn vip-search ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:268:19)
    at onErrorNT (internal/child_process.js:468:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

1. Check out PR.
1. Run `npm run build`
2. Run `npm link` to link your locally checked out copy to your development setup
1. Run `VIP_PROXY="<proxy>" node ./dist/bin/vip search-replace /path/to/file.sql --search-replace="test.com,bye.com"`
1. Verify S-R works

