### PR TITLE
SQL Imports: Simplify import update progress logs

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -125,11 +125,12 @@ command( {
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
+		searchReplace ? '' : console.log();
 
 		if ( searchReplace && searchReplace.length ) {
 			const params = searchReplace.split( ',' );
 
-			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }` );
+			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }\n` );
 		}
 
 		let fileNameToUpload = fileName;

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -11,7 +11,6 @@
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 import debugLib from 'debug';
-import { stdout } from 'single-line-log';
 
 /**
  * Internal dependencies

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -132,23 +132,21 @@ command( {
 		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
 		searchReplace ? '' : console.log();
 
-		if ( searchReplace && searchReplace.length ) {
-			const params = searchReplace.split( ',' );
-
-			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }\n` );
-		}
-
 		let fileNameToUpload = fileName;
 
 		// Run Search and Replace if the --search-replace flag was provided
 		if ( searchReplace && searchReplace.length ) {
+			const params = searchReplace.split( ',' );
+
+			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }\n` );
+
 			const { outputFileName } = await searchAndReplace( fileName, searchReplace, {
 				isImport: true,
 				inPlace: opts.inPlace,
 				output: true,
 			} );
 
-			fileNameToUpload = outputFileName;
+			fileNameToUpload = outputFileName
 		} else {
 			progress( 'replace', 'skipped' );
 		}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -237,7 +237,7 @@ command( {
 		console.log( 'Uploading…' );
 
 		try {
-      progress( step, 'running' );
+			progress( step, 'running' );
 			const {
 				fileMeta: { basename, md5 },
 				result,
@@ -248,7 +248,7 @@ command( {
 				basename: basename,
 				md5: md5,
 			};
-      progress( step, 'success' );
+			progress( step, 'success' );
 			debug( { basename, md5, result } );
 
 			debug( 'Upload complete. Initiating the import.' );
@@ -257,24 +257,24 @@ command( {
 
 			console.log( '\n🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );
 		} catch ( e ) {
-      progress( step, 'failed' );
+			progress( step, 'failed' );
 			await track( 'import_sql_command_error', { error_type: 'upload_failed', e } );
 			exit.withError( e );
 		}
 
 		try {
-      progress( nextStep, 'running' );
- 
+			progress( nextStep, 'running' );
+
 			const startImportResults = await api.mutate( {
 				mutation: START_IMPORT_MUTATION,
 				variables: startImportVariables,
 			} );
-      
-      progress( nextStep, 'success' );
+
+			progress( nextStep, 'success' );
 
 			debug( { startImportResults } );
 		} catch ( gqlErr ) {
-      progress( nextStep, 'failed' );
+			progress( nextStep, 'failed' );
 
 			await track( 'import_sql_command_error', {
 				error_type: 'StartImport-failed',

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -30,7 +30,7 @@ import { progress } from 'lib/cli/progress';
  * - Include `hasImporterS3Credentials` & error out if false (this needs to be implemented)
  */
 
-	// For progress logs
+// For progress logs
 const step = 'startImport';
 const nextStep = 'import';
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -119,16 +119,16 @@ command( {
 				'Please split it into multiple files or contact support for assistance.' );
 		}
 
-		// Log summary of import details to user
-		const t = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;
-		const tt = searchReplace.split( ',' );
+		// Log summary of import details
+		const domain = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;
+		const params = searchReplace.split( ',' );
 
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
-		console.log( `         to: ${ chalk.cyan( t ) }` );
+		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
 
 		if ( searchReplace && searchReplace.length ) {
-			console.log( `        s-r: ${ chalk.blue( tt[ 0 ] ) } -> ${ chalk.blue( tt [ 1 ] ) }` );
+			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }` );
 		}
 
 		let fileNameToUpload = fileName;

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -149,6 +149,8 @@ command( {
 			} );
 
 			fileNameToUpload = outputFileName;
+		} else {
+			progress( 'replace', 'skipped' );
 		}
 
 		// Run SQL validation

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -19,6 +19,7 @@ import command from 'lib/cli/command';
 import { currentUserCanImportForApp, isSupportedApp, SQL_IMPORT_FILE_SIZE_LIMIT } from 'lib/site-import/db-file-import';
 import { getFileSize, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
 import { trackEvent } from 'lib/tracker';
+import { formatEnvironment } from 'lib/cli/format';
 import { validate } from 'lib/validations/sql';
 import { searchAndReplace } from 'lib/search-and-replace';
 import API from 'lib/api';
@@ -115,6 +116,18 @@ command( {
 			err(
 				`The sql import file size (${ fileSize } bytes) exceeds the limit the limit (${ SQL_IMPORT_FILE_SIZE_LIMIT } bytes).` +
 				'Please split it into multiple files or contact support for assistance.' );
+		}
+
+		// Log summary of import details to user
+		const t = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;
+		const tt = searchReplace.split( ',' );
+
+		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
+		console.log( `         to: ${ chalk.cyan( t ) }` );
+		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
+
+		if ( searchReplace && searchReplace.length ) {
+			console.log( `        s-r: ${ chalk.blue( tt[ 0 ] ) } -> ${ chalk.blue( tt [ 1 ] ) }` );
 		}
 
 		let fileNameToUpload = fileName;

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -29,6 +29,11 @@ import { progress } from 'lib/cli/progress';
  * - Include `import_in_progress` state & error out if appropriate (this likely needs to be exposed in the data graph)
  * - Include `hasImporterS3Credentials` & error out if false (this needs to be implemented)
  */
+
+	// For progress logs
+const step = 'startImport';
+const nextStep = 'import';
+
 const appQuery = `
 	id,
 	name,
@@ -159,8 +164,9 @@ command( {
 			} = await uploadImportSqlFileToS3( { app, env, fileName: fileNameToUpload } );
 
 			debug( { basename, md5, result } );
+
 			debug( 'Upload complete. Initiating the import.' );
-			progress( 'running', 'startImport' );
+			progress( step, 'running' );
 
 			try {
 				await api.mutate( {
@@ -185,9 +191,11 @@ command( {
 						},
 					},
 				} );
-				progress( 'success', 'startImport' );
+
+				progress( step, 'success' );
 			} catch ( gqlErr ) {
-				progress( 'failed', 'startImport' );
+				progress( step, 'failed' );
+
 				await trackEventWithEnv( 'import_sql_command_error', {
 					error_type: 'StartImport-failed',
 					gql_err: gqlErr,
@@ -195,7 +203,7 @@ command( {
 				err( `StartImport call failed: ${ gqlErr }` );
 			}
 
-			progress( 'running', 'import' );
+			progress( nextStep, 'running' );
 			await trackEventWithEnv( 'import_sql_command_queued' );
 
 			console.log( '\n🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -11,6 +11,7 @@
 import chalk from 'chalk';
 import gql from 'graphql-tag';
 import debugLib from 'debug';
+import { stdout } from 'single-line-log';
 
 /**
  * Internal dependencies

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -91,7 +91,7 @@ command( {
 
 		await trackEventWithEnv( 'import_sql_command_execute' );
 
-		console.log( '** Welcome to the WPVIP Site SQL Importer! **\n' );
+		console.log( `\n${ chalk.underline( '** Welcome to the WPVIP Site SQL Importer! **' ) }\n` );
 
 		debug( 'Options: ', opts );
 		debug( 'Args: ', arg );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -193,6 +193,7 @@ command( {
 				err( `StartImport call failed: ${ gqlErr }` );
 			}
 
+			progress( 'running', 'import' );
 			await trackEventWithEnv( 'import_sql_command_queued' );
 
 			console.log( '\n🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -146,7 +146,7 @@ command( {
 				output: true,
 			} );
 
-			fileNameToUpload = outputFileName
+			fileNameToUpload = outputFileName;
 		} else {
 			progress( 'replace', 'skipped' );
 		}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -10,6 +10,7 @@
  */
 import gql from 'graphql-tag';
 import debugLib from 'debug';
+import chalk from 'chalk';
 
 /**
  * Internal dependencies

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -23,6 +23,7 @@ import { formatEnvironment } from 'lib/cli/format';
 import { validate } from 'lib/validations/sql';
 import { searchAndReplace } from 'lib/search-and-replace';
 import API from 'lib/api';
+import { progress } from 'lib/cli/progress';
 
 /**
  * - Include `import_in_progress` state & error out if appropriate (this likely needs to be exposed in the data graph)
@@ -156,7 +157,8 @@ command( {
 			} = await uploadImportSqlFileToS3( { app, env, fileName: fileNameToUpload } );
 
 			debug( { basename, md5, result } );
-			console.log( 'Upload complete. Initiating the import.' );
+			debug( 'Upload complete. Initiating the import.' );
+			progress( 'running', 'startImport' );
 
 			try {
 				await api.mutate( {
@@ -181,7 +183,9 @@ command( {
 						},
 					},
 				} );
+				progress( 'success', 'startImport' );
 			} catch ( gqlErr ) {
+				progress( 'failed', 'startImport' );
 				await trackEventWithEnv( 'import_sql_command_error', {
 					error_type: 'StartImport-failed',
 					gql_err: gqlErr,

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -121,13 +121,14 @@ command( {
 
 		// Log summary of import details
 		const domain = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;
-		const params = searchReplace.split( ',' );
 
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
 
 		if ( searchReplace && searchReplace.length ) {
+			const params = searchReplace.split( ',' );
+
 			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }` );
 		}
 

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -24,7 +24,6 @@ import { trackEvent } from 'lib/tracker';
 import pager from 'lib/cli/pager';
 import { parseEnvAliasFromArgv } from './envAlias';
 import { rollbar } from '../rollbar';
-import { searchAndReplace } from '../search-and-replace';
 
 function uncaughtError( err ) {
 	// Error raised when trying to write to an already closed stream

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -362,8 +362,8 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 					const replacements = [
 						{
-							'From': `${ params[ 0 ] }`,
-							'To': `${ params[ 1 ] }`,
+							From: `${ params[ 0 ] }`,
+							To: `${ params[ 1 ] }`,
 						},
 					];
 

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -354,7 +354,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 					info.push( { key: 'Primary Domain Name', value: primaryDomainName } );
 				}
 
-				this.sub && info.push( { key: 'SQL File', value: this.sub } );
+				this.sub && info.push( { key: 'SQL File', value: `${ chalk.blueBright( this.sub ) }` } );
 
 				// Show S-R params if the `search-replace` flag is set
 				if ( options.searchReplace ) {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -24,6 +24,7 @@ import { trackEvent } from 'lib/tracker';
 import pager from 'lib/cli/pager';
 import { parseEnvAliasFromArgv } from './envAlias';
 import { rollbar } from '../rollbar';
+import { searchAndReplace } from '../search-and-replace';
 
 function uncaughtError( err ) {
 	// Error raised when trying to write to an already closed stream
@@ -352,7 +353,23 @@ args.argv = async function( argv, cb ): Promise<any> {
 					const primaryDomainName = options.env.primaryDomain.name;
 					info.push( { key: 'Primary Domain Name', value: primaryDomainName } );
 				}
+
 				this.sub && info.push( { key: 'SQL File', value: this.sub } );
+
+				// Show S-R params if the `search-replace` flag is set
+				if ( options.searchReplace ) {
+					const params = options.searchReplace.split( ',' );
+
+					const replacements = [
+						{
+							'From': `${ params[ 0 ] }`,
+							'To': `${ params[ 1 ] }`,
+						},
+					];
+
+					// Format data into a user-friendly table
+					info.push( { key: 'Replacements', value: '\n' + formatData( replacements, 'table' ) } );
+				}
 				break;
 			case 'sync':
 				const { backup, canSync, errors } = options.env.syncPreview;

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -30,7 +30,7 @@ const marks = {
 	running: chalk.blueBright( sprite.next().value ),
 	success: chalk.green( '✓' ),
 	failed: chalk.red( '✕' ),
-	unknown: chalk.yellow( '✕' ),
+	skipped: chalk.green( '✕' ),
 };
 
 // Various action steps for SQL imports
@@ -55,17 +55,30 @@ export const progress = ( currentStep, status ) => {
 			message = ` ${ marks[ status ] } ${ steps[ currentStep ] }`;
 			messages.push( message );
 
-			// Keep track of completed steps
+			// Keep track of completed and skipped steps
 			if ( status === 'success' ) {
 				completedSteps.push( currentStep );
+			}
+
+			if ( status === 'skipped' ) {
+				completedSteps.push( `${ currentStep }-skipped` );
 			}
 		}
 
 		// Status of all the other steps
 		if ( key !== currentStep ) {
 			const stepCompleted = completedSteps.includes( key );
+			
+			const skipped = `${ key }-skipped`;
 
-			if ( stepCompleted ) {
+			const stepSkipped = completedSteps.find( step =>
+				step === skipped
+			);
+
+			if ( stepSkipped ===  skipped ) {
+				message = ` ${ marks.skipped } ${ steps[ key ] }`;
+				messages.push( message );
+			} else if ( stepCompleted ) {
 				message = ` ${ marks.success } ${ steps[ key ] }`;
 				messages.push( message );
 			} else {

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -1,0 +1,50 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+import chalk from 'chalk';
+import { stdout } from 'single-line-log';
+
+// Progress spinner
+const sprite = {
+ i: 0,
+ sprite: [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ],
+ next() {
+  this.i++;
+
+  if ( this.i >= this.sprite.length ) {
+   this.i = 0;
+  }
+
+  return {
+   value: this.sprite[ this.i ],
+   done: false,
+  };
+ },
+};
+
+// Icons for different action states/status
+const marks = {
+ pending: '○',
+ running: chalk.blueBright( sprite.next().value ),
+ success: chalk.green( '✓' ),
+ failed: chalk.red( '✕' ),
+ unknown: chalk.yellow( '✕' ),
+};
+
+// Various action steps for SQL imports
+const steps = {
+ replace: 'Performing Search and Replace',
+ validate: 'Validating SQL',
+ upload: 'Uploading file to S3',
+ startImport: 'Starting import...',
+};
+
+// Progress update logs
+export const progress = ( status, action ) => {
+	const actionProgress = ` ${ marks[ status ] } ${ steps[ action ] }`;
+
+	stdout( `${ actionProgress }` );
+	console.log();
+};

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -38,7 +38,9 @@ const steps = {
  replace: 'Performing Search and Replace',
  validate: 'Validating SQL',
  upload: 'Uploading file to S3',
- startImport: 'Starting import...',
+	startImport: 'Starting import',
+	import: 'Importing...'
+	// Add more as neededs
 };
 
 // Progress update logs

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import chalk from 'chalk';
-import { stdout } from 'single-line-log';
+import { stdout as progressLog } from 'single-line-log';
 
 // Progress spinner
 const sprite = {
@@ -43,10 +43,42 @@ const steps = {
 	// Add more as neededs
 };
 
-// Progress update logs
-export const progress = ( status, action ) => {
-	const actionProgress = ` ${ marks[ status ] } ${ steps[ action ] }`;
+// Progress Logs
+let message;
+let messages = [];
+const completedSteps = [];
 
-	stdout( `${ actionProgress }` );
-	console.log();
+export const progress = ( currentStep, status ) => {
+		for ( const key of Object.keys( steps ) ) {
+
+			// Status of the current step in progress
+			if ( key === currentStep ) {
+				message = ` ${ marks[ status ] } ${ steps[ currentStep ] }`;
+				messages.push( message );
+
+				// Keep track of completed steps
+				if ( status === 'success' ) {
+					completedSteps.push( currentStep );
+				}
+			}
+
+			// Status of all the other steps
+			if ( key !== currentStep ) {
+				const stepCompleted = completedSteps.includes( key );
+
+				if ( stepCompleted ) {
+					message = ` ${ marks[ 'success' ] } ${ steps[ key ] }`;
+					messages.push( message );
+				} else {
+					message = chalk.dim( ` ${ marks[ 'pending' ] } ${ steps[ key ] }` );
+					messages.push( message );
+				}
+			}
+		}
+
+		// Finally, print the progress logs
+		progressLog( messages.join( '\n' ) );
+
+		// Reset the messages array for each iteration
+		messages = [];
 };

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -40,7 +40,7 @@ const steps = {
 	upload: 'Uploading file to S3',
 	startImport: 'Starting import',
 	import: 'Importing...',
-	// Add more as neededs
+	// Add more as needed
 };
 
 // Progress Logs
@@ -49,36 +49,35 @@ let messages = [];
 const completedSteps = [];
 
 export const progress = ( currentStep, status ) => {
-		for ( const key of Object.keys( steps ) ) {
+	for ( const key of Object.keys( steps ) ) {
+		// Status of the current step in progress
+		if ( key === currentStep ) {
+			message = ` ${ marks[ status ] } ${ steps[ currentStep ] }`;
+			messages.push( message );
 
-			// Status of the current step in progress
-			if ( key === currentStep ) {
-				message = ` ${ marks[ status ] } ${ steps[ currentStep ] }`;
-				messages.push( message );
-
-				// Keep track of completed steps
-				if ( status === 'success' ) {
-					completedSteps.push( currentStep );
-				}
-			}
-
-			// Status of all the other steps
-			if ( key !== currentStep ) {
-				const stepCompleted = completedSteps.includes( key );
-
-				if ( stepCompleted ) {
-					message = ` ${ marks[ 'success' ] } ${ steps[ key ] }`;
-					messages.push( message );
-				} else {
-					message = chalk.dim( ` ${ marks[ 'pending' ] } ${ steps[ key ] }` );
-					messages.push( message );
-				}
+			// Keep track of completed steps
+			if ( status === 'success' ) {
+				completedSteps.push( currentStep );
 			}
 		}
 
-		// Finally, print the progress logs
-		progressLog( messages.join( '\n' ) );
+		// Status of all the other steps
+		if ( key !== currentStep ) {
+			const stepCompleted = completedSteps.includes( key );
 
-		// Reset the messages array for each iteration
-		messages = [];
+			if ( stepCompleted ) {
+				message = ` ${ marks.success } ${ steps[ key ] }`;
+				messages.push( message );
+			} else {
+				message = chalk.dim( ` ${ marks.pending } ${ steps[ key ] }` );
+				messages.push( message );
+			}
+		}
+	}
+
+	// Finally, print the progress logs
+	progressLog( messages.join( '\n' ) );
+
+	// Reset the messages array for each iteration
+	messages = [];
 };

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -8,38 +8,38 @@ import { stdout } from 'single-line-log';
 
 // Progress spinner
 const sprite = {
- i: 0,
- sprite: [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ],
- next() {
-  this.i++;
+	i: 0,
+	sprite: [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ],
+	next() {
+		this.i++;
 
-  if ( this.i >= this.sprite.length ) {
-   this.i = 0;
-  }
+		if ( this.i >= this.sprite.length ) {
+			this.i = 0;
+		}
 
-  return {
-   value: this.sprite[ this.i ],
-   done: false,
-  };
- },
+		return {
+			value: this.sprite[ this.i ],
+			done: false,
+		};
+	},
 };
 
 // Icons for different action states/status
 const marks = {
- pending: '○',
- running: chalk.blueBright( sprite.next().value ),
- success: chalk.green( '✓' ),
- failed: chalk.red( '✕' ),
- unknown: chalk.yellow( '✕' ),
+	pending: '○',
+	running: chalk.blueBright( sprite.next().value ),
+	success: chalk.green( '✓' ),
+	failed: chalk.red( '✕' ),
+	unknown: chalk.yellow( '✕' ),
 };
 
 // Various action steps for SQL imports
 const steps = {
- replace: 'Performing Search and Replace',
- validate: 'Validating SQL',
- upload: 'Uploading file to S3',
+	replace: 'Performing Search and Replace',
+	validate: 'Validating SQL',
+	upload: 'Uploading file to S3',
 	startImport: 'Starting import',
-	import: 'Importing...'
+	import: 'Importing...',
 	// Add more as neededs
 };
 

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -68,14 +68,14 @@ export const progress = ( currentStep, status ) => {
 		// Status of all the other steps
 		if ( key !== currentStep ) {
 			const stepCompleted = completedSteps.includes( key );
-			
+
 			const skipped = `${ key }-skipped`;
 
 			const stepSkipped = completedSteps.find( step =>
 				step === skipped
 			);
 
-			if ( stepSkipped ===  skipped ) {
+			if ( stepSkipped === skipped ) {
 				message = ` ${ marks.skipped } ${ steps[ key ] }`;
 				messages.push( message );
 			} else if ( stepCompleted ) {

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -241,10 +241,12 @@ export async function uploadUsingPutObject( {
 	try {
 		parsedResponse = await parser.parseStringPromise( result );
 	} catch ( e ) {
+		progress( 'failed', 'upload' );
 		throw `Invalid response from cloud service. ${ e }`;
 	}
 
 	const { Code, Message } = parsedResponse.Error || {};
+	progress( 'failed', 'upload' );
 	throw `Unable to upload to cloud storage. ${ JSON.stringify( { Code, Message } ) }`;
 }
 
@@ -276,6 +278,7 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 
 	if ( parsedResponse.Error ) {
 		const { Code, Message } = parsedResponse.Error;
+		progress( 'failed', 'upload' );
 		throw `Unable to create cloud storage object. Error: ${ JSON.stringify( { Code, Message } ) }`;
 	}
 
@@ -284,6 +287,7 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 		parsedResponse.InitiateMultipartUploadResult &&
 		parsedResponse.InitiateMultipartUploadResult.UploadId
 	) {
+		progress( 'failed', 'upload' );
 		throw `Unable to get Upload ID from cloud storage. Error: ${ multipartUploadResult }`;
 	}
 

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -142,7 +142,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		throw `Unable to create temporary working directory: ${ e }`;
 	}
 
-	console.log(
+	debug(
 		`File ${ chalk.cyan( fileMeta.basename ) } is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n`
 	);
 
@@ -156,13 +156,13 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.basename = fileMeta.basename.replace( /(.gz)?$/i, '.gz' );
 		fileMeta.fileName = path.join( tmpDir, fileMeta.basename );
 
-		console.log( `Compressing the file to ${ chalk.cyan( fileMeta.fileName ) } prior to transfer...` );
+		debug( `Compressing the file to ${ chalk.cyan( fileMeta.fileName ) } prior to transfer...` );
 
 		await gzipFile( uncompressedFileName, fileMeta.fileName );
 		fileMeta.isCompressed = true;
 		fileMeta.fileSize = await getFileSize( fileMeta.fileName );
 
-		console.log( `Compressed file is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
+		debug( `Compressed file is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
 
 		const fewerBytes = uncompressedFileSize - fileMeta.fileSize;
 
@@ -170,7 +170,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 			( 100 * fewerBytes ) / uncompressedFileSize
 		) }%)`;
 
-		console.log( `** Compression resulted in a ${ calculation } smaller file 📦 **\n` );
+		debug( `** Compression resulted in a ${ calculation } smaller file 📦 **\n` );
 	}
 
 	const result =

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -179,7 +179,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 			: await uploadUsingMultipart( { app, env, fileMeta } );
 
 	progress( 'success', 'upload' );
-	
+
 	return {
 		fileMeta,
 		result,

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -15,7 +15,6 @@ import { createGzip } from 'zlib';
 import { createHash } from 'crypto';
 import { PassThrough } from 'stream';
 import { Parser as XmlParser } from 'xml2js';
-import { stdout as singleLogLine } from 'single-line-log';
 import debugLib from 'debug';
 
 /**
@@ -219,9 +218,8 @@ export async function uploadUsingPutObject( {
 	const progressPassThrough = new PassThrough();
 	progressPassThrough.on( 'data', data => {
 		readBytes += data.length;
-		singleLogLine( `${ Math.floor( ( 100 * readBytes ) / fileSize ) }%...` );
+		debug( `${ Math.floor( ( 100 * readBytes ) / fileSize ) }%...` );
 	} );
-	progressPassThrough.on( 'end', () => console.log( '\n' ) );
 
 	const response = await fetch( presignedRequest.url, {
 		...fetchOptions,
@@ -440,7 +438,7 @@ export async function uploadParts( { app, env, fileMeta, uploadId, parts }: Uplo
 		} );
 
 	const printProgress = () =>
-		singleLogLine(
+		debug(
 			partPercentages
 				.map( ( partPercentage, index ) => {
 					const { partSize } = parts[ index ];

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -23,6 +23,7 @@ import debugLib from 'debug';
  */
 import API from 'lib/api';
 import { MB_IN_BYTES } from 'lib/constants/file-size';
+import { progress } from 'lib/cli/progress';
 
 const debug = debugLib( 'vip:lib/client-file-uploader' );
 
@@ -130,12 +131,14 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 }
 
 export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArguments ) {
+	progress( 'running', 'upload' );
 	const fileMeta = await getFileMeta( fileName );
 
 	let tmpDir;
 	try {
 		tmpDir = await getWorkingTempDir();
 	} catch ( e ) {
+		progress( 'failed', 'upload' );
 		throw `Unable to create temporary working directory: ${ e }`;
 	}
 
@@ -175,6 +178,8 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 			? await uploadUsingPutObject( { app, env, fileMeta } )
 			: await uploadUsingMultipart( { app, env, fileMeta } );
 
+	progress( 'success', 'upload' );
+	
 	return {
 		fileMeta,
 		result,

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -12,13 +12,13 @@ import path from 'path';
 import chalk from 'chalk';
 import debugLib from 'debug';
 import { replace } from '@automattic/vip-search-replace';
-import { stdout } from 'single-line-log';
 
 /**
  * Internal dependencies
  */
 import { trackEvent } from 'lib/tracker';
 import { confirm } from 'lib/cli/prompt';
+import { progress } from 'lib/cli/progress';
 import { getFileSize } from 'lib/client-file-uploader';
 
 const debug = debugLib( '@automattic/vip:lib:search-and-replace' );
@@ -128,7 +128,7 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	progress( 'running' );
+	progress( 'running', 'replace' );
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
 	const startTime = process.hrtime();
@@ -136,7 +136,7 @@ export const searchAndReplace = async (
 
 	// if we don't have any pairs to replace with, return the input file
 	if ( ! pairs || ! pairs.length ) {
-		progress( 'failed' );
+		progress( 'failed', 'replace' );
 		throw new Error( 'No search and replace parameters provided.' );
 	}
 
@@ -158,7 +158,7 @@ export const searchAndReplace = async (
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {
-			progress( 'unknown' );
+			progress( 'unknown', 'replace' );
 			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
 
 			process.exit();
@@ -189,7 +189,7 @@ export const searchAndReplace = async (
 					)
 				);
 
-				progress( 'failed' );
+				progress( 'failed', 'replace' );
 
 				reject();
 			} );
@@ -198,7 +198,7 @@ export const searchAndReplace = async (
 	const endTime = process.hrtime( startTime );
 	const end = endTime[ 1 ] / 1000000; // time in ms
 	
-	progress( 'success' );
+	progress( 'success', 'replace' );
 	await trackEvent( 'searchreplace_completed', { time_to_run: end, file_size: fileSize } );
 
 	return result;

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -197,7 +197,7 @@ export const searchAndReplace = async (
 
 	const endTime = process.hrtime( startTime );
 	const end = endTime[ 1 ] / 1000000; // time in ms
-	
+
 	progress( 'success', 'replace' );
 	await trackEvent( 'searchreplace_completed', { time_to_run: end, file_size: fileSize } );
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -155,7 +155,8 @@ const progress = status => {
 
 	let actionProgress = ` ${ marks[ status ] } ${ action }`;
 
-	return stdout( `${ actionProgress }` );
+	stdout( `${ actionProgress }` );
+	console.log();
 };
 
 export const searchAndReplace = async (

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -122,43 +122,6 @@ export type SearchReplaceOutput = {
 	usingStdOut: boolean,
 };
 
-// Progress spinner
-const sprite = {
- i: 0,
- sprite: [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ],
- next() {
-  this.i++;
-
-  if ( this.i >= this.sprite.length ) {
-   this.i = 0;
-  }
-
-  return {
-   value: this.sprite[ this.i ],
-   done: false,
-  };
- },
-};
-
-// Status signs for progress updates
-const marks = {
- pending: '○',
- running: chalk.blueBright( sprite.next().value ),
- success: chalk.green( '✓' ),
- failed: chalk.red( '✕' ),
- unknown: chalk.yellow( '✕' ),
-};
-
-// Progress update logs
-const progress = status => {
-	const action = 'Performing Search and Replace';
-
-	let actionProgress = ` ${ marks[ status ] } ${ action }`;
-
-	stdout( `${ actionProgress }` );
-	console.log();
-};
-
 export const searchAndReplace = async (
 	fileName: string,
 	pairs: Array<String> | String,

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -23,6 +23,9 @@ import { getFileSize } from 'lib/client-file-uploader';
 
 const debug = debugLib( '@automattic/vip:lib:search-and-replace' );
 
+// For progress logs
+const step = 'replace';
+
 const flatten = arr => {
 	return arr.reduce( function( flat, toFlatten ) {
 		return flat.concat( Array.isArray( toFlatten ) ? flatten( toFlatten ) : toFlatten );
@@ -128,7 +131,8 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	progress( 'running', 'replace' );
+	// Track progress
+	progress( step, 'running' );
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
 	const startTime = process.hrtime();
@@ -136,7 +140,7 @@ export const searchAndReplace = async (
 
 	// if we don't have any pairs to replace with, return the input file
 	if ( ! pairs || ! pairs.length ) {
-		progress( 'failed', 'replace' );
+		progress( step, 'failed' );
 		throw new Error( 'No search and replace parameters provided.' );
 	}
 
@@ -158,7 +162,7 @@ export const searchAndReplace = async (
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {
-			progress( 'unknown', 'replace' );
+			progress( step, 'unknown' );
 			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
 
 			process.exit();
@@ -189,7 +193,7 @@ export const searchAndReplace = async (
 					)
 				);
 
-				progress( 'failed', 'replace' );
+				progress( step, 'failed' );
 
 				reject();
 			} );
@@ -198,7 +202,7 @@ export const searchAndReplace = async (
 	const endTime = process.hrtime( startTime );
 	const end = endTime[ 1 ] / 1000000; // time in ms
 
-	progress( 'success', 'replace' );
+	progress( step, 'success' );
 	await trackEvent( 'searchreplace_completed', { time_to_run: end, file_size: fileSize } );
 
 	return result;

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -61,10 +61,8 @@ export function getReadAndWriteStreams( {
 		fs.copyFileSync( fileName, midputFileName );
 
 		debug( `Copied input file to ${ midputFileName }` );
-		console.log( `Searching ${ chalk.cyan( fileName ) }` );
 
 		debug( `Set output to the original file path ${ fileName }` );
-		console.log( 'Replacing...' );
 
 		outputFileName = fileName;
 
@@ -77,14 +75,12 @@ export function getReadAndWriteStreams( {
 	}
 
 	debug( `Reading input from file: ${ fileName }` );
-	console.log( `Searching file ${ chalk.cyan( fileName ) }` );
 
 	switch ( typeof output ) {
 		case 'string':
 			writeStream = fs.createWriteStream( output );
 			outputFileName = output;
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( 'Replacing...' );
 			break;
 		case 'object':
 			writeStream = output;
@@ -101,7 +97,6 @@ export function getReadAndWriteStreams( {
 			outputFileName = tmpOutFile;
 
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( 'Replacing...' );
 
 			break;
 	}
@@ -132,8 +127,6 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	console.log( 'Starting Search and Replace...' );
-
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
 	const startTime = process.hrtime();
@@ -162,8 +155,6 @@ export const searchAndReplace = async (
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {
-			console.log( `${ chalk.red( 'Cancelling' ) }` );
-
 			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
 
 			process.exit();
@@ -181,17 +172,6 @@ export const searchAndReplace = async (
 		replacedStream
 			.pipe( writeStream )
 			.on( 'finish', () => {
-				if ( ! usingStdOut ) {
-					console.log();
-					console.log( `${ 'Search and Replace Complete!' }` );
-
-					// Only log this message if the output SQL file isn't the original input file
-					const message = `Your new SQL file has been saved to ${ chalk.cyan( outputFileName ) }`;
-
-					inPlace ? '' : console.log( message );
-
-					console.log();
-				}
 				resolve( {
 					inputFileName: fileName,
 					outputFileName,

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -162,7 +162,7 @@ export const searchAndReplace = async (
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {
-			progress( step, 'unknown' );
+			progress( step, 'failed' );
 			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
 
 			process.exit();

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -154,27 +154,6 @@ export const searchAndReplace = async (
 	const replacements = flatten( replacementsArr );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 
-	// Add a confirmation step for search-replace
-	const yes = await confirm( [
-		{
-			key: 'From',
-			value: `${ chalk.cyan( replacements[ 0 ] ) }`,
-		},
-		{
-			key: 'To',
-			value: `${ chalk.cyan( replacements[ 1 ] ) }`,
-		},
-	], 'Proceed with the following values?' );
-
-	// Bail if user does not wish to proceed
-	if ( ! yes ) {
-		console.log( `${ chalk.red( 'Cancelling' ) }` );
-
-		await trackEvent( 'search_replace_cancelled', { is_import: isImport, in_place: inPlace } );
-
-		process.exit();
-	}
-
 	if ( inPlace ) {
 		const approved = await confirm(
 			[],

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -15,6 +15,9 @@ import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
 import * as exit from 'lib/cli/exit';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
+import debugLib from 'debug';
+
+const debug = debugLib( 'vip:vip-import-sql' );
 
 let isMultiSiteSqlDump = false;
 
@@ -29,8 +32,8 @@ export const siteTypeValidations = {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
-		console.log( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
-		console.log( `The SQL dump provided is ${ isMultiSiteSqlDump ? 'from a multisite.' : 'not from a multisite' }\n` );
+		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
+		debug( `The SQL dump provided is ${ isMultiSiteSqlDump ? 'from a multisite.' : 'not from a multisite' }\n` );
 
 		// if site is a multisite but import sql is not
 		if ( isMultiSite && ! isMultiSiteSqlDump ) {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -198,7 +198,7 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 }
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
-	progress( step ,'running' );
+	progress( step, 'running' );
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
 	let fd;

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -187,7 +187,7 @@ const checks: Checks = {
 	},
 };
 
-export const postValidation = async ( filename: string, isImport: boolean = false ) => {
+export const postValidation = async ( filename: string, isImport: boolean ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
 	isImport ? '' : log( `Finished processing ${ lineNum } lines.` );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -228,7 +228,8 @@ const progress = status => {
 
 	let actionProgress = ` ${ marks[ status ] } ${ action }`;
 
-	stdout( `${ actionProgress }` );
+	// Write to the same line for progress updates
+	log( `${ actionProgress }` );
 	console.log();
 };
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -198,7 +198,7 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
-	console.log( `${ chalk.underline( 'Starting SQL Validation...' ) }` );
+	console.log( 'Validating SQL file' );
 
 	let fd;
 
@@ -258,8 +258,6 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
-
-	console.log( '** Your database file looks good 🎉 **\n' );
 
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -218,7 +218,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 
 	readInterface.on( 'line', function( line ) {
 		if ( lineNum % 500 === 0 ) {
-			log( `Reading line ${ lineNum } ` );
+			isImport ? '' : log( `Reading line ${ lineNum } ` );
 		}
 
 		const checkValues: any = Object.values( checks );
@@ -234,8 +234,8 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	// Block until the processing completes
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 
-	log( `Finished processing ${ lineNum } lines.` );
-	console.log( '\n' );
+	isImport ? '' : log( `Finished processing ${ lineNum } lines.` );
+	isImport ? '' : console.log( '\n' );
 	const errorSummary = {};
 	const checkEntires: any = Object.entries( checks );
 	for ( const [ type, check ]: [string, CheckType] of checkEntires ) {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -198,7 +198,6 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
-	console.log( 'Validating SQL file' );
 
 	let fd;
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -246,9 +246,13 @@ const execute = ( line: string, isImport: boolean = true ) => {
 	perLineValidations( line, isImport );
 };
 
+const postLineExecutionProcessing = async ( { fileName, isImport }: PostLineExecutionProcessingParams ) => {
+	await postValidation( fileName, isImport );
+};
+
 export const staticSqlValidations = {
 	execute,
-	postLineExecutionProcessing: postValidation,
+	postLineExecutionProcessing,
 };
 
 // For standalone SQL validations
@@ -262,5 +266,5 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 	readInterface.close();
 
-	await staticSqlValidations.postLineExecutionProcessing( { filename, isImport } );
+	await postLineExecutionProcessing( { filename, isImport } );
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -17,6 +17,9 @@ import { stdout as log } from 'single-line-log';
 import { trackEvent } from 'lib/tracker';
 import { progress } from 'lib/cli/progress';
 
+// For progress logs
+const step = 'validate';
+
 let problemsFound = 0;
 let lineNum = 1;
 
@@ -195,7 +198,7 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 }
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
-	progress( 'running', 'validate' );
+	progress( step ,'running' );
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
 	let fd;
@@ -205,7 +208,9 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	} catch ( e ) {
 		console.log( chalk.red( 'Error: ' ) + 'The file at the provided path is either missing or not readable.' );
 		console.log( 'Please check the input and try again.' );
-		progress( 'failed', 'validate' );
+
+		progress( step, 'failed' );
+
 		process.exit( 1 );
 	}
 
@@ -254,12 +259,14 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 			console.log();
 		}
 
-		progress( 'failed', 'validate' );
+		progress( step, 'failed' );
+
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
 
-	progress( 'success', 'validate' );
+	progress( step, 'success' );
+
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 
 	readInterface.close();

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -188,6 +188,7 @@ const checks: Checks = {
 };
 
 export const postValidation = async ( filename: string, isImport: boolean ) => {
+	progress( step, 'running' );
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
 	isImport ? '' : log( `Finished processing ${ lineNum } lines.` );
@@ -228,6 +229,7 @@ export const postValidation = async ( filename: string, isImport: boolean ) => {
 };
 
 const perLineValidations = ( line: string, runAsImport: boolean ) => {
+	progress( step, 'running' );
 	if ( lineNum % 500 === 0 ) {
 		runAsImport ? '' : log( `Reading line ${ lineNum } ` );
 	}

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -15,6 +15,7 @@ import { stdout as log } from 'single-line-log';
  * Internal dependencies
  */
 import { trackEvent } from 'lib/tracker';
+import { progress } from 'lib/cli/progress';
 
 let problemsFound = 0;
 let lineNum = 1;
@@ -196,7 +197,7 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 }
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
-	progress( 'running' );
+	progress( 'running', 'validate' );
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
 	let fd;
@@ -206,7 +207,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	} catch ( e ) {
 		console.log( chalk.red( 'Error: ' ) + 'The file at the provided path is either missing or not readable.' );
 		console.log( 'Please check the input and try again.' );
-		progress( 'failed' );
+		progress( 'failed', 'validate' );
 		process.exit( 1 );
 	}
 
@@ -255,12 +256,12 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 			console.log();
 		}
 
-		progress( 'failed' );
+		progress( 'failed', 'validate' );
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
 
-	progress( 'success' );
+	progress( 'success', 'validate' );
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 
 	readInterface.close();

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -26,9 +26,7 @@ const errorCheckFormatter = ( isImport, check ) => {
 		console.error( chalk.red( 'Error:' ), `${ check.message } on line(s) ${ check.results.join( ', ' ) }.` );
 		console.error( chalk.yellow( 'Recommendation:' ), `${ check.recommendation }` );
 	} else {
-		if ( ! isImport ) {
-			console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
-		}
+		isImport ? '' : console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
 	}
 };
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -20,21 +20,27 @@ import { confirm } from 'lib/cli/prompt';
 let problemsFound = 0;
 let lineNum = 1;
 
-const errorCheckFormatter = check => {
+const errorCheckFormatter = ( isImport, check ) => {
 	if ( check.results.length > 0 ) {
 		problemsFound += 1;
 		console.error( chalk.red( 'Error:' ), `${ check.message } on line(s) ${ check.results.join( ', ' ) }.` );
 		console.error( chalk.yellow( 'Recommendation:' ), `${ check.recommendation }` );
 	} else {
-		console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
+		if ( ! isImport ) {
+			console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
+		}
 	}
 };
 
-const requiredCheckFormatter = ( check, type ) => {
+const requiredCheckFormatter = ( isImport, check, type ) => {
 	if ( check.results.length > 0 ) {
-		console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
+		if ( ! isImport ) {
+			console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
+		}
 		if ( type === 'createTable' ) {
-			checkTablePrefixes( check.results );
+			if ( ! isImport ) {
+				checkTablePrefixes( check.results );
+			}
 		}
 	} else {
 		problemsFound += 1;
@@ -43,9 +49,11 @@ const requiredCheckFormatter = ( check, type ) => {
 	}
 };
 
-const infoCheckFormatter = check => {
+const infoCheckFormatter = ( isImport, check ) => {
 	check.results.forEach( item => {
-		console.log( item );
+		if ( ! isImport ) {
+			console.log( item );
+		}
 	} );
 };
 
@@ -231,8 +239,8 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	const errorSummary = {};
 	const checkEntires: any = Object.entries( checks );
 	for ( const [ type, check ]: [string, CheckType] of checkEntires ) {
-		check.outputFormatter( check, type );
-		console.log( '' );
+		check.outputFormatter( isImport, check, type );
+		isImport ? '' : console.log( '' );
 
 		errorSummary[ type ] = check.results.length;
 	}

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -15,7 +15,6 @@ import { stdout as log } from 'single-line-log';
  * Internal dependencies
  */
 import { trackEvent } from 'lib/tracker';
-import { confirm } from 'lib/cli/prompt';
 
 let problemsFound = 0;
 let lineNum = 1;
@@ -196,7 +195,45 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 	} );
 }
 
+// Progress spinner
+const sprite = {
+ i: 0,
+ sprite: [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ],
+ next() {
+  this.i++;
+
+  if ( this.i >= this.sprite.length ) {
+   this.i = 0;
+  }
+
+  return {
+   value: this.sprite[ this.i ],
+   done: false,
+  };
+ },
+};
+
+// Status signs for progress updates
+const marks = {
+ pending: '○',
+ running: chalk.blueBright( sprite.next().value ),
+ success: chalk.green( '✓' ),
+ failed: chalk.red( '✕' ),
+ unknown: chalk.yellow( '✕' ),
+};
+
+// Progress update logs
+const progress = status => {
+	const action = 'Validating SQL';
+
+	let actionProgress = ` ${ marks[ status ] } ${ action }`;
+
+	stdout( `${ actionProgress }` );
+	console.log();
+};
+
 export const validate = async ( filename: string, isImport: boolean = false ) => {
+	progress( 'running' );
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
 	let fd;
@@ -206,6 +243,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	} catch ( e ) {
 		console.log( chalk.red( 'Error: ' ) + 'The file at the provided path is either missing or not readable.' );
 		console.log( 'Please check the input and try again.' );
+		progress( 'failed' );
 		process.exit( 1 );
 	}
 
@@ -254,32 +292,15 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 			console.log();
 		}
 
+		progress( 'failed' );
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
 
+	progress( 'success' );
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 
 	readInterface.close();
-
-	if ( isImport ) {
-		// Add a confirmation step before running the import
-		const yes = await confirm(
-			[], 'Are you sure you want to continue with the import?'
-		);
-
-		// Bail if user does not wish to proceed
-		if ( ! yes ) {
-			console.log( `${ chalk.red( 'Exiting' ) }` );
-
-			await trackEvent( 'import_continue_cancelled', { is_import: isImport, import_file: filename } );
-
-			process.exit();
-		}
-
-		console.log( `\n${ chalk.underline( 'Starting the import process...' ) }` );
-		return;
-	}
 
 	console.log( '\n🎉 You can now submit for import, see here for more details: ' +
 		'https://docs.wpvip.com/how-tos/prepare-for-site-launch/migrate-content-databases/' );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -195,44 +195,6 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 	} );
 }
 
-// Progress spinner
-const sprite = {
- i: 0,
- sprite: [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ],
- next() {
-  this.i++;
-
-  if ( this.i >= this.sprite.length ) {
-   this.i = 0;
-  }
-
-  return {
-   value: this.sprite[ this.i ],
-   done: false,
-  };
- },
-};
-
-// Status signs for progress updates
-const marks = {
- pending: '○',
- running: chalk.blueBright( sprite.next().value ),
- success: chalk.green( '✓' ),
- failed: chalk.red( '✕' ),
- unknown: chalk.yellow( '✕' ),
-};
-
-// Progress update logs
-const progress = status => {
-	const action = 'Validating SQL';
-
-	let actionProgress = ` ${ marks[ status ] } ${ action }`;
-
-	// Write to the same line for progress updates
-	log( `${ actionProgress }` );
-	console.log();
-};
-
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	progress( 'running' );
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -264,6 +264,6 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 
 	readInterface.close();
 
-	console.log( '\n🎉 You can now submit for import, see here for more details: ' +
+	isImport ? '' : console.log( '\n🎉 You can now submit for import, see here for more details: ' +
 		'https://docs.wpvip.com/how-tos/prepare-for-site-launch/migrate-content-databases/' );
 };


### PR DESCRIPTION
## Description

Simplifying the user output logs for the SQL import progress.
We also want the output to visually match our other processes (e.g.- data sync).

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql @103.staging /path/to/file.sql --search-replace="hello.com,goodbye.com"`
1. Verify update progress logs look good
1. Try without the S-R flag, and verify that you don't see any of the S-R-related output