### PR TITLE
Block import of multisite into single site and vice versa

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -18,7 +18,6 @@ import command from 'lib/cli/command';
 import { currentUserCanImportForApp, isSupportedApp, SQL_IMPORT_FILE_SIZE_LIMIT } from 'lib/site-import/db-file-import';
 import { getFileSize, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
 import { trackEventWithEnv } from 'lib/tracker';
-// import { validate } from 'lib/validations/sql';
 import { staticSqlValidations } from 'lib/validations/sql';
 import { siteTypeValidations } from 'lib/validations/site-type';
 import { searchAndReplace } from 'lib/search-and-replace';

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -19,7 +19,7 @@ import command from 'lib/cli/command';
 import { currentUserCanImportForApp, isSupportedApp } from 'lib/site-import/db-file-import';
 import { uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
 import { trackEvent } from 'lib/tracker';
-import { validate } from 'lib/validations/sql';
+import { validate, getReadInterface } from 'lib/validations/sql';
 import { searchAndReplace } from 'lib/search-and-replace';
 import API from 'lib/api';
 
@@ -42,6 +42,109 @@ const err = message => {
 
 const debug = debugLib( 'vip:vip-import-sql' );
 
+const trackEventWithEnv = async ( appId, envId, eventName, eventProps = {} ) => {
+	return trackEvent( eventName, { ...eventProps, app_id: appId, env_id: envId } );
+};
+
+const isMultiSiteDumpFile = fileName => {
+	return new Promise( async resolve => {
+		const readInterface = await getReadInterface( fileName );
+		readInterface.on( 'line', line => {
+			const multiSiteTableNameRegex = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i;
+			// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options
+			if ( multiSiteTableNameRegex.test( line ) ) {
+				resolve( true );
+			}
+		} );
+
+		readInterface.on( 'error', () => {
+			err( 'An error was encountered while reading your SQL dump file.  Please verify the file contents.' );
+		} );
+		// Block until the processing completes
+		await new Promise( resolveBlock => readInterface.on( 'close', resolveBlock ) );
+		resolve( false );
+	} );
+};
+
+const isMultiSiteInSiteMeta = async ( appId: number, envId: number, api: Object ): Promise<boolean> => {
+	let res;
+	try {
+		res = await api.query( {
+			query: gql`query AppMultiSiteCheck( $appId: Int, $envId: Int) {
+				app(id: $appId) {
+					id
+					name
+					repo
+					environments(id: $envId) {
+						id
+						appId
+						name
+						type
+						isMultisite
+						isSubdirectoryMultisite
+					}
+				}
+			}`,
+			variables: {
+				appId,
+				envId,
+			},
+		} );
+	} catch ( GraphQlError ) {
+		await trackEventWithEnv( 'import_sql_command_error', {
+			error_type: 'GraphQL-MultiSite-Check-failed',
+			gql_err: GraphQlError,
+		} );
+		err( `StartImport call failed: ${ GraphQlError }` );
+	}
+
+	if ( Array.isArray( res?.data?.app?.environments ) ) {
+		const environments = res.data.app.environments;
+		if ( ! environments.length ) {
+			return false;
+		}
+		// we asked for one result with one appId and one envId, so...
+		const thisEnv = environments[ 0 ];
+		if ( thisEnv.isMultiSite || thisEnv.isSubdirectoryMultisite ) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+const gates = async ( app, env, fileName, api ) => {
+	const { id: envId, appId } = env;
+	trackEventWithEnv.bind( null, appId, envId );
+
+	if ( ! currentUserCanImportForApp( app ) ) {
+		err(
+			'The currently authenticated account does not have permission to perform a SQL import.'
+		);
+	}
+
+	if ( ! isSupportedApp( app ) ) {
+		await trackEventWithEnv( 'import_sql_command_error', { error_type: 'unsupported-app' } );
+		err( 'The type of application you specified does not currently support SQL imports.' );
+	}
+
+	// is the import for a multisite?
+	const isMultiSiteSqlDump = await isMultiSiteDumpFile( fileName );
+	const isMultiSite = await isMultiSiteInSiteMeta( appId, envId, api );
+
+	// if site is a multisite but import sql is not
+	if ( isMultiSite && ! isMultiSiteSqlDump ) {
+		await trackEventWithEnv( 'import_sql_command_error', { error_type: 'multisite-but-not-multisite-sql-dump' } );
+		err( 'You have provided a non-multisite SQL dump file for import into a multisite.' );
+	}
+
+	// if site is a single site but import sql is for a multi site
+	if ( ! isMultiSite && isMultiSiteSqlDump ) {
+		await trackEventWithEnv( 'import_sql_command_error', { error_type: 'not-multisite-with-multisite-sql-dump' } );
+		err( 'You have provided a multisite SQL dump file for import into a single site (non-multisite).' );
+	}
+};
+
 command( {
 	appContext: true,
 	appQuery,
@@ -56,27 +159,17 @@ command( {
 	.argv( process.argv, async ( arg, opts ) => {
 		const { app, env, searchReplace } = opts;
 		const [ fileName ] = arg;
-
-		const trackEventWithEnv = async ( eventName, eventProps = {} ) =>
-			trackEvent( eventName, { ...eventProps, app_id: env.appId, env_id: env.id } );
-
-		await trackEventWithEnv( 'import_sql_command_execute' );
-
-		console.log( '** Welcome to the WPVIP Site SQL Importer! **\n' );
+		const api = await API();
 
 		debug( 'Options: ', opts );
 		debug( 'Args: ', arg );
 
-		if ( ! currentUserCanImportForApp( app ) ) {
-			err(
-				'The currently authenticated account does not have permission to perform a SQL import.'
-			);
-		}
+		console.log( '** Welcome to the WPVIP Site SQL Importer! **\n' );
+		trackEventWithEnv.bind( null, env.appId, env.id );
+		await trackEventWithEnv( 'import_sql_command_execute' );
 
-		if ( ! isSupportedApp( app ) ) {
-			await trackEventWithEnv( 'import_sql_command_error', { error_type: 'unsupported-app' } );
-			err( 'The type of application you specified does not currently support SQL imports.' );
-		}
+		// halt operation of the import based on some rules
+		await gates( app, env, fileName, api );
 
 		let fileNameToUpload = fileName;
 
@@ -95,8 +188,6 @@ command( {
 		await validate( fileNameToUpload, true );
 
 		// Call the Public API
-		const api = await API();
-
 		try {
 			const {
 				fileMeta: { basename, md5 },

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -62,7 +62,7 @@ const gates = async ( app, env, fileName ) => {
 
 	if ( fileSize > SQL_IMPORT_FILE_SIZE_LIMIT ) {
 		exit.withError(
-			`The sql import file size (${ fileSize } bytes) exceeds the limit the limit (${ SQL_IMPORT_FILE_SIZE_LIMIT } bytes).` +
+			`The sql import file size (${ fileSize } bytes) exceeds the limit (${ SQL_IMPORT_FILE_SIZE_LIMIT } bytes).` +
 				'Please split it into multiple files or contact support for assistance.' );
 	}
 };

--- a/src/lib/cli/exit.js
+++ b/src/lib/cli/exit.js
@@ -1,0 +1,18 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import chalk from 'chalk';
+
+/**
+ * Internal dependencies
+ */
+
+export function withError( message: string ) {
+	console.log( chalk.red( message.toString().replace( /^(Error: )*/, 'Error: ' ) ) );
+	process.exit( 1 );
+}

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -60,3 +60,7 @@ export async function aliasUser( vipUserId ): Promise<Response> {
 		debug( 'aliasUser() failed', e );
 	}
 }
+
+export async function trackEventWithEnv( appId, envId, eventName, eventProps = {} ): Promise<Response> {
+	return trackEvent( eventName, { ...eventProps, app_id: appId, env_id: envId } );
+}

--- a/src/lib/validations/is-multi-site-sql-dump.js
+++ b/src/lib/validations/is-multi-site-sql-dump.js
@@ -13,7 +13,7 @@
 import { getReadInterface } from 'lib/validations/line-by-line';
 import * as exit from 'lib/cli/exit';
 
-const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i
+const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i;
 
 export function sqlDumpLineIsMultiSite( line: string ): boolean {
 	// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options

--- a/src/lib/validations/is-multi-site-sql-dump.js
+++ b/src/lib/validations/is-multi-site-sql-dump.js
@@ -13,13 +13,22 @@
 import { getReadInterface } from 'lib/validations/sql';
 import * as exit from 'lib/cli/exit';
 
+const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i
+
+export function sqlDumpLineIsMultiSite( line: string ): boolean {
+	// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options
+	if ( SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX.test( line ) ) {
+		return true;
+	}
+	return false;
+}
+
 export function isMultiSiteDumpFile( fileName: string ): Promise<boolean> {
 	return new Promise( async resolve => {
 		const readInterface = await getReadInterface( fileName );
 		readInterface.on( 'line', line => {
-			const multiSiteTableNameRegex = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i;
-			// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options
-			if ( multiSiteTableNameRegex.test( line ) ) {
+			const result = sqlDumpLineIsMultiSite( line );
+			if ( true === result ) {
 				resolve( true );
 			}
 		} );

--- a/src/lib/validations/is-multi-site-sql-dump.js
+++ b/src/lib/validations/is-multi-site-sql-dump.js
@@ -1,0 +1,38 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getReadInterface } from 'lib/validations/sql';
+import * as exit from 'lib/cli/exit';
+
+export function isMultiSiteDumpFile( fileName: string ): Promise<boolean> {
+	return new Promise( async resolve => {
+		const readInterface = await getReadInterface( fileName );
+		readInterface.on( 'line', line => {
+			const multiSiteTableNameRegex = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i;
+			// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options
+			if ( multiSiteTableNameRegex.test( line ) ) {
+				resolve( true );
+			}
+		} );
+
+		readInterface.on( 'error', () => {
+			exit.withError(
+				'An error was encountered while reading your SQL dump file.  Please verify the file contents.'
+			);
+		} );
+		// Block until the processing completes
+		await new Promise( resolveBlock =>
+			readInterface.on( 'close', resolveBlock )
+		);
+		resolve( false );
+	} );
+}

--- a/src/lib/validations/is-multi-site-sql-dump.js
+++ b/src/lib/validations/is-multi-site-sql-dump.js
@@ -10,7 +10,7 @@
 /**
  * Internal dependencies
  */
-import { getReadInterface } from 'lib/validations/sql';
+import { getReadInterface } from 'lib/validations/line-by-line';
 import * as exit from 'lib/cli/exit';
 
 const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i

--- a/src/lib/validations/is-multi-site.js
+++ b/src/lib/validations/is-multi-site.js
@@ -1,0 +1,64 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+import { trackEventWithEnv } from 'lib/tracker';
+import * as exit from 'lib/cli/exit';
+
+export async function isMultiSiteInSiteMeta( appId: number, envId: number ): Promise<boolean> {
+	const api = await API();
+	let res;
+	try {
+		res = await api.query( {
+			query: gql`query AppMultiSiteCheck( $appId: Int, $envId: Int) {
+				app(id: $appId) {
+					id
+					name
+					repo
+					environments(id: $envId) {
+						id
+						appId
+						name
+						type
+						isMultisite
+						isSubdirectoryMultisite
+					}
+				}
+			}`,
+			variables: {
+				appId,
+				envId,
+			},
+		} );
+	} catch ( GraphQlError ) {
+		await trackEventWithEnv( 'import_sql_command_error', {
+			error_type: 'GraphQL-MultiSite-Check-failed',
+			gql_err: GraphQlError,
+		} );
+		exit.withError( `StartImport call failed: ${ GraphQlError }` );
+	}
+
+	if ( Array.isArray( res?.data?.app?.environments ) ) {
+		const environments = res.data.app.environments;
+		if ( ! environments.length ) {
+			return false;
+		}
+		// we asked for one result with one appId and one envId, so...
+		const thisEnv = environments[ 0 ];
+		if ( thisEnv.isMultiSite || thisEnv.isSubdirectoryMultisite ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/src/lib/validations/is-multi-site.js
+++ b/src/lib/validations/is-multi-site.js
@@ -16,6 +16,7 @@ import { trackEventWithEnv } from 'lib/tracker';
 import * as exit from 'lib/cli/exit';
 
 export async function isMultiSiteInSiteMeta( appId: number, envId: number ): Promise<boolean> {
+	const track = trackEventWithEnv.bind( null, appId, envId );
 	const api = await API();
 	let res;
 	try {
@@ -41,7 +42,7 @@ export async function isMultiSiteInSiteMeta( appId: number, envId: number ): Pro
 			},
 		} );
 	} catch ( GraphQlError ) {
-		await trackEventWithEnv( 'import_sql_command_error', {
+		await track( 'import_sql_command_error', {
 			error_type: 'GraphQL-MultiSite-Check-failed',
 			gql_err: GraphQlError,
 		} );

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -76,9 +76,9 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 	readInterface.close();
 
-	validations.map( async validation => {
+	await Promise.all( validations.map( async validation => {
 		if ( validation.hasOwnProperty( 'postLineExecutionProcessing' ) && typeof validation.postLineExecutionProcessing === 'function' ) {
 			await validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
 		}
-	} );
+	} ) );
 }

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -41,25 +41,3 @@ export async function getReadInterface( filename: string ) {
 		console: false,
 	} );
 }
-
-export function validateLineByLine( readInterface, functions: array ) {
-	readInterface.on( 'line', function( line ) {
-		if ( lineNum % 500 === 0 ) {
-			log( `Reading line ${ lineNum } ` );
-		}
-
-		functions.map( validationObject => {
-
-		} );
-
-		const checkValues: any = Object.values( checks );
-		checkValues.forEach( ( check: CheckType ) => {
-			const results = line.match( check.matcher );
-			if ( results ) {
-				check.results.push( check.matchHandler( lineNum, results ) );
-			}
-		} );
-
-		lineNum += 1;
-	} );
-}

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -14,6 +14,7 @@ import debugLib from 'debug';
 /**
  * Internal dependencies
  */
+import * as exit from 'lib/cli/exit';
 
 const debug = debugLib( 'vip:validations:line-by-line' );
 export type PerLineValidationObject = {
@@ -44,9 +45,7 @@ export async function getReadInterface( filename: string ) {
 	try {
 		fd = await openFile( filename );
 	} catch ( e ) {
-		console.log( chalk.red( 'Error: ' ) + 'The file at the provided path is either missing or not readable.' );
-		console.log( 'Please check the input and try again.' );
-		process.exit( 1 );
+		exit.withError( 'The file at the provided path is either missing or not readable. Please check the input and try again.' );
 	}
 
 	return readline.createInterface( {

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -1,0 +1,65 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import readline from 'readline';
+import fs from 'fs';
+import chalk from 'chalk';
+
+/**
+ * Internal dependencies
+ */
+
+function openFile( filename, flags = 'r', mode = 666 ) {
+	return new Promise( ( resolve, reject ) => {
+		fs.open( filename, flags, mode, ( err, fd ) => {
+			if ( err ) {
+				return reject( err );
+			}
+			resolve( fd );
+		} );
+	} );
+}
+
+export async function getReadInterface( filename: string ) {
+	let fd;
+	try {
+		fd = await openFile( filename );
+	} catch ( e ) {
+		console.log( chalk.red( 'Error: ' ) + 'The file at the provided path is either missing or not readable.' );
+		console.log( 'Please check the input and try again.' );
+		process.exit( 1 );
+	}
+
+	return readline.createInterface( {
+		input: fs.createReadStream( '', { fd } ),
+		output: null,
+		console: false,
+	} );
+}
+
+export function validateLineByLine( readInterface, functions: array ) {
+	readInterface.on( 'line', function( line ) {
+		if ( lineNum % 500 === 0 ) {
+			log( `Reading line ${ lineNum } ` );
+		}
+
+		functions.map( validationObject => {
+
+		} );
+
+		const checkValues: any = Object.values( checks );
+		checkValues.forEach( ( check: CheckType ) => {
+			const results = line.match( check.matcher );
+			if ( results ) {
+				check.results.push( check.matchHandler( lineNum, results ) );
+			}
+		} );
+
+		lineNum += 1;
+	} );
+}

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -81,4 +81,4 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 			await validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
 		}
 	} );
-};
+}

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -14,6 +14,7 @@ import { trackEventWithEnv } from 'lib/tracker';
 import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
 import * as exit from 'lib/cli/exit';
+import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
 
 let isMultiSiteSqlDump = false;
 
@@ -24,7 +25,7 @@ export const siteTypeValidations = {
 			isMultiSiteSqlDump = true;
 		}
 	},
-	postLineExecutionProcessing: async ( { appId, envId } ) => {
+	postLineExecutionProcessing: async ( { appId, envId }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const track = trackEventWithEnv.bind( null, appId, envId );
 

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -1,0 +1,46 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { trackEventWithEnv } from 'lib/tracker';
+import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
+import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
+import * as exit from 'lib/cli/exit';
+
+let isMultiSiteSqlDump = false;
+
+export const siteTypeValidations = {
+	execute: ( line: string ) => {
+		const lineIsMultiSite = sqlDumpLineIsMultiSite( line );
+		if ( lineIsMultiSite ) {
+			isMultiSiteSqlDump = true;
+		}
+	},
+	postLineExecutionProcessing: async ( { appId, envId } ) => {
+		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
+		const track = trackEventWithEnv.bind( null, appId, envId );
+
+		console.log( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
+		console.log( `The SQL dump provided is ${ isMultiSiteSqlDump ? 'from a multisite.' : 'not from a multisite' }\n` );
+
+		// if site is a multisite but import sql is not
+		if ( isMultiSite && ! isMultiSiteSqlDump ) {
+			await track( 'import_sql_command_error', { error_type: 'multisite-but-not-multisite-sql-dump' } );
+			exit.withError( 'You have provided a non-multisite SQL dump file for import into a multisite.' );
+		}
+
+		// if site is a single site but import sql is for a multi site
+		if ( ! isMultiSite && isMultiSiteSqlDump ) {
+			await track( 'import_sql_command_error', { error_type: 'not-multisite-with-multisite-sql-dump' } );
+			exit.withError( 'You have provided a multisite SQL dump file for import into a single site (non-multisite).' );
+		}
+	},
+};

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -188,12 +188,8 @@ function openFile( filename, flags = 'r', mode = 666 ) {
 	} );
 }
 
-export const validate = async ( filename: string, isImport: boolean = false ) => {
-	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
-	console.log( `${ chalk.underline( 'Starting SQL Validation...' ) }` );
-
+export const getReadInterface = async ( filename: string ) => {
 	let fd;
-
 	try {
 		fd = await openFile( filename );
 	} catch ( e ) {
@@ -202,11 +198,18 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 		process.exit( 1 );
 	}
 
-	const readInterface = readline.createInterface( {
+	return readline.createInterface( {
 		input: fs.createReadStream( '', { fd } ),
 		output: null,
 		console: false,
 	} );
+};
+
+export const validate = async ( filename: string, isImport: boolean = false ) => {
+	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
+	console.log( `${ chalk.underline( 'Starting SQL Validation...' ) }` );
+
+	const readInterface = await getReadInterface(filename);
 
 	readInterface.on( 'line', function( line ) {
 		if ( lineNum % 500 === 0 ) {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -8,7 +8,6 @@
  */
 import chalk from 'chalk';
 import { stdout as log } from 'single-line-log';
-import debugLib from 'debug';
 
 /**
  * Internal dependencies

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -8,6 +8,7 @@
  */
 import chalk from 'chalk';
 import { stdout as log } from 'single-line-log';
+import debugLib from 'debug';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import { trackEvent } from 'lib/tracker';
 import { confirm } from 'lib/cli/prompt';
 import { getReadInterface } from 'lib/validations/line-by-line';
 
+const debug = debugLib( 'vip:vip-import-sql' );
 let problemsFound = 0;
 let lineNum = 1;
 
@@ -200,7 +202,6 @@ export const postValidation = async ( filename: string, isImport: boolean = fals
 			console.log( `${ chalk.red( 'Please adjust these error(s) before proceeding with the import.' ) }` );
 			console.log();
 		}
-
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -16,8 +16,8 @@ import debugLib from 'debug';
 import { trackEvent } from 'lib/tracker';
 import { confirm } from 'lib/cli/prompt';
 import { getReadInterface } from 'lib/validations/line-by-line';
+import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
 
-const debug = debugLib( 'vip:vip-import-sql' );
 let problemsFound = 0;
 let lineNum = 1;
 
@@ -249,11 +249,11 @@ const perLineValidations = ( line: string ) => {
 };
 
 export const staticSqlValidations = {
-	execute: line => {
+	execute: ( line: string ) => {
 		perLineValidations( line );
 	},
-	postLineExecutionProcessing: async ( { filename, isImport } ) => {
-		await postValidation( filename, isImport );
+	postLineExecutionProcessing: async ( { fileName, isImport }: PostLineExecutionProcessingParams ) => {
+		await postValidation( fileName, isImport );
 	},
 };
 
@@ -267,5 +267,5 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 	readInterface.close();
 
-	await staticSqlValidations.postExecutionOutput( filename, isImport );
+	await staticSqlValidations.postLineExecutionProcessing( { filename, isImport } );
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -209,7 +209,7 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 	console.log( `${ chalk.underline( 'Starting SQL Validation...' ) }` );
 
-	const readInterface = await getReadInterface(filename);
+	const readInterface = await getReadInterface( filename );
 
 	readInterface.on( 'line', function( line ) {
 		if ( lineNum % 500 === 0 ) {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -252,7 +252,7 @@ export const staticSqlValidations = {
 	execute: line => {
 		perLineValidations( line );
 	},
-	postExecutionOutput: async ( filename, isImport ) => {
+	postLineExecutionProcessing: async ( { filename, isImport } ) => {
 		await postValidation( filename, isImport );
 	},
 };


### PR DESCRIPTION
## Description

We should fail in the instances that a:

* multisite sql dump file was provided for a single site
* single site sql dump file was provided for a multisite

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Execute an import that would pass -- script continues with import
1. Execute an import that would fail because the SQL dump is multi and the site is not -- scripts exits
1. Execute an import that would fail because the SQL dump is single site and the site is multisite -- script exits

Example commands coming!

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_