### PR TITLE
Fix output for the standalone S-R command

### DIFF
--- a/src/bin/vip-search-replace.js
+++ b/src/bin/vip-search-replace.js
@@ -44,7 +44,7 @@ command( {
 } )
 	.option( 'search-replace', 'Specify the <from> and <to> pairs to be replaced' )
 	.option( 'in-place', 'Perform the search and replace explicitly on the input file' )
-	.option( 'output', 'Specify the replacement output file for Search and Replace', 'process.stdout' )
+	.option( 'output', 'Specify the replacement output file for Search and Replace' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		// TODO: tracks event for usage of this command stand alone


### PR DESCRIPTION
## Description

Output for standalone Search and Replace command should be `stdout`, but it's currently getting outputted to a file called `process.stdout`.

## Steps to Test

1. Run `npm run build`
2. Run `npm link` to link your locally checked out copy to your development setup
3. Run `node ./dist/bin/vip search-replace /path/to/file.sql --search-replace="test.com,bye.com"`
4. Verify S-R works
5. Try again with the shorthand S-R command and verify it works as expected: `node ./dist/bin/vip search-replace /path/to/file.sql -s="test.com,bye.com"`
