### PR TITLE
Forno 493/lowercase environment name

### DIFF
--- a/__tests__/lib/cli/envAlias.js
+++ b/__tests__/lib/cli/envAlias.js
@@ -21,6 +21,7 @@ describe( 'utils/cli/envAlias', () => {
 			'@app.env.instance-01',
 			'@1',
 			'@1.env',
+			'@2.MixedCaseEnv',
 		] )( 'should identify valid aliases - %p', alias => {
 			expect( envAlias.isAlias( alias ) ).toBe( true );
 		} );
@@ -88,6 +89,12 @@ describe( 'utils/cli/envAlias', () => {
 				app: '1',
 				env: 'env.instance',
 			},
+			{
+				alias: '@2.Env.instance',
+				app: '1',
+				env: 'env.instance',
+			},
+
 		] )( 'should parse out the app and env from an alias', input => {
 			const parsed = envAlias.parseEnvAlias( input.alias );
 

--- a/__tests__/lib/cli/envAlias.js
+++ b/__tests__/lib/cli/envAlias.js
@@ -91,7 +91,7 @@ describe( 'utils/cli/envAlias', () => {
 			},
 			{
 				alias: '@2.Env.instance',
-				app: '1',
+				app: '2',
 				env: 'env.instance',
 			},
 

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -54,7 +54,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 	// If we have both an --app/--env and an alias, we need to give a warning
 	if ( parsedAlias.app && ( options.app || options.env ) ) {
-		console.error( chalk`{red Please only use an envirionment alias, or the --app and --env parameters, but not both}` );
+		console.error( chalk`{red Please only use an environment alias, or the --app and --env parameters, but not both}` );
 
 		process.exit();
 	}

--- a/src/lib/cli/envAlias.js
+++ b/src/lib/cli/envAlias.js
@@ -5,7 +5,7 @@
  */
 
 exports.isAlias = function( alias: string ): boolean {
-	return /^@[a-z0-9\.\-]+$/.test( alias );
+	return /^@[A-Za-z0-9\.\-]+$/.test( alias );
 };
 
 exports.parseEnvAlias = function( alias: string ) {
@@ -14,9 +14,10 @@ exports.parseEnvAlias = function( alias: string ) {
 	}
 
 	// Remove the '@'
-	const stripped = alias.substr( 1 );
+	const stripped = alias.substr( 1 ).toLowerCase();
 
 	// in JS, .split() with a limit discards the extra ones, so can't use it
+	// Also convert to lowercase because mixed case environment names would cause problems
 	const [ app, ...rest ] = stripped.split( '.' );
 
 	let env = undefined;


### PR DESCRIPTION
## Description

Since our internal API automatically converts mixed case environment names to lowercase, we want to convert them 
## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-wp.js @3203.Sit -- option get home` (note the uppercase `Sit`)
1. Verify the command is working. Without this PR, the above command would return `command not found` .

