### PR TITLE
Clean up search and replace pairs when importing

### DIFF
--- a/__tests__/lib/search-and-replace.js
+++ b/__tests__/lib/search-and-replace.js
@@ -89,4 +89,26 @@ describe( 'lib/search-and-replace', () => {
 		expect( fileContents ).not.toContain( 'purty' );
 		fs.unlinkSync( outputFileName );
 	} );
+
+	it( 'will remove whitespace from the beginning and end of pairs', async () => {
+		const { usingStdOut, outputFileName } = await searchAndReplace(
+			testFilePath,
+			[ ' ohai		,\t\n\tohHey\t\n\r', '	  purty		, \t\n\rpretty\t\n ' ], // tabs spaces, LFs
+			{ output: true },
+			binary
+		);
+
+		expect( usingStdOut ).toBe( false );
+		expect( outputFileName ).not.toBe( testFilePath );
+
+		const fileContents = fs.readFileSync( outputFileName, { encoding: 'utf-8' } );
+		expect( fileContents ).toContain( 'ohHey' );
+		expect( fileContents ).not.toContain( 't\n\tohHey\t\n\r' );
+		expect( fileContents ).not.toContain( 'ohai' );
+		expect( fileContents ).toContain( 'pretty' );
+		expect( fileContents ).not.toContain( '\t\n\rpretty\t\n' );
+		expect( fileContents ).not.toContain( 'purty' );
+
+		fs.unlinkSync( outputFileName );
+	} );
 } );

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -150,7 +150,10 @@ export const searchAndReplace = async (
 	}
 
 	// determine all the replacements required
-	const replacementsArr = pairs.map( str => str.split( ',' ) );
+	const replacementsArr = pairs.map( str => {
+		const filtered = str.replace( /[\s\x00-\x1F\x7F]/g, '' ); //whitespace & char codes 0-32, 127.
+		return filtered.split( ',' );
+	}	);
 	const replacements = flatten( replacementsArr );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -150,10 +150,7 @@ export const searchAndReplace = async (
 	}
 
 	// determine all the replacements required
-	const replacementsArr = pairs.map( str => {
-		const filtered = str.replace( /[\s\x00-\x1F\x7F]/g, '' ); //whitespace & char codes 0-32, 127.
-		return filtered.split( ',' );
-	}	);
+	const replacementsArr = pairs.map( str => str.split( ',' ).map( s => s.trim() ) );
 	const replacements = flatten( replacementsArr );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 


### PR DESCRIPTION
## Description
Removes spaces and other whitespace/non-printable chars from the `--search-replace` pairs when running an import.  This will prevent problems such as cut and paste errors, spaces between pairs( `www.domain1.com, www.domain2.com`) , etc

Note: there is some redundancy in the regex pattern between the low (1-32) chars and the "\s" pattern but I thought it was best to have both. 

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql @1000.dev --search-replace="www.dom ain1.com,    www.domain2.com" ./db.sq`
1. Verify that repairs displayed in confirmation are free from extraneous chars

