### PR TITLE
Fix SQL validation for imports

### DIFF
--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -8,7 +8,6 @@
  */
 import readline from 'readline';
 import fs from 'fs';
-import chalk from 'chalk';
 import debugLib from 'debug';
 
 /**

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -232,9 +232,9 @@ export const postValidation = async ( filename: string, isImport: boolean = fals
 		'https://docs.wpvip.com/how-tos/prepare-for-site-launch/migrate-content-databases/' );
 };
 
-const perLineValidations = ( line: string ) => {
+const perLineValidations = ( line: string, runAsImport: boolean ) => {
 	if ( lineNum % 500 === 0 ) {
-		log( `Reading line ${ lineNum } ` );
+		runAsImport ? '' : log( `Reading line ${ lineNum } ` );
 	}
 
 	const checkValues: any = Object.values( checks );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -247,8 +247,8 @@ const perLineValidations = ( line: string, runAsImport: boolean ) => {
 	lineNum += 1;
 };
 
-const execute = ( line: string ) => {
- perLineValidations( line );
+const execute = ( line: string, isImport: boolean = true ) => {
+ perLineValidations( line, isImport );
 };
 
 const postLineExecutionProcessing = async ( { fileName, isImport }: PostLineExecutionProcessingParams ) => {
@@ -263,7 +263,7 @@ export const staticSqlValidations = {
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	const readInterface = await getReadInterface( filename );
 	readInterface.on( 'line', line => {
-		execute( line );
+		execute( line, isImport );
 	} );
 
 	// Block until the processing completes

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -249,6 +249,7 @@ const perLineValidations = ( line: string, runAsImport: boolean ) => {
 
 const execute = ( line: string, isImport: boolean = true ) => {
 	perLineValidations( line, isImport );
+};
 
 export const staticSqlValidations = {
 	execute,

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -248,18 +248,19 @@ const perLineValidations = ( line: string, runAsImport: boolean ) => {
 };
 
 const execute = ( line: string, isImport: boolean = true ) => {
- perLineValidations( line, isImport );
+	perLineValidations( line, isImport );
 };
 
 const postLineExecutionProcessing = async ( { fileName, isImport }: PostLineExecutionProcessingParams ) => {
- await postValidation( fileName, isImport );
+	await postValidation( fileName, isImport );
 };
 
 export const staticSqlValidations = {
- execute,
- postLineExecutionProcessing,
+	execute,
+	postLineExecutionProcessing,
 };
 
+// For standalone SQL validations
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	const readInterface = await getReadInterface( filename );
 	readInterface.on( 'line', line => {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -267,5 +267,5 @@ export const validate = async ( filename: string, isImport: boolean = false ) =>
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 	readInterface.close();
 
-	await postLineExecutionProcessing( { filename, isImport } );
+	await staticSqlValidations.postLineExecutionProcessing( { filename, isImport } );
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -247,24 +247,28 @@ const perLineValidations = ( line: string, runAsImport: boolean ) => {
 	lineNum += 1;
 };
 
+const execute = ( line: string ) => {
+ perLineValidations( line );
+};
+
+const postLineExecutionProcessing = async ( { fileName, isImport }: PostLineExecutionProcessingParams ) => {
+ await postValidation( fileName, isImport );
+};
+
 export const staticSqlValidations = {
-	execute: ( line: string ) => {
-		perLineValidations( line );
-	},
-	postLineExecutionProcessing: async ( { fileName, isImport }: PostLineExecutionProcessingParams ) => {
-		await postValidation( fileName, isImport );
-	},
+ execute,
+ postLineExecutionProcessing,
 };
 
 export const validate = async ( filename: string, isImport: boolean = false ) => {
 	const readInterface = await getReadInterface( filename );
 	readInterface.on( 'line', line => {
-		staticSqlValidations.execute( line );
+		execute( line );
 	} );
 
 	// Block until the processing completes
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 	readInterface.close();
 
-	await staticSqlValidations.postLineExecutionProcessing( { filename, isImport } );
+	await postLineExecutionProcessing( { filename, isImport } );
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -249,15 +249,10 @@ const perLineValidations = ( line: string, runAsImport: boolean ) => {
 
 const execute = ( line: string, isImport: boolean = true ) => {
 	perLineValidations( line, isImport );
-};
-
-const postLineExecutionProcessing = async ( { fileName, isImport }: PostLineExecutionProcessingParams ) => {
-	await postValidation( fileName, isImport );
-};
 
 export const staticSqlValidations = {
 	execute,
-	postLineExecutionProcessing,
+	postLineExecutionProcessing: postValidation,
 };
 
 // For standalone SQL validations


### PR DESCRIPTION
## Description

With the changes to SQL validation in #640, we need to identify if the SQL validation is running via an import or as a standalone command.

## Steps to Test=

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql @103.staging /Users/joannelee/Downloads/test.sql --search-replace="hello.com,goodbye.com"`
1. This mainly works in conjuction with #639, where we're changing the output logs for imports

