### PR TITLE
More robust check for import status object

### DIFF
--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -162,6 +162,7 @@ export async function importSqlCheckStatus( { app, env }: ImportSqlCheckStatusIn
 				debug( { createdAt, dbOperationInProgress, importInProgress, importStepProgress } );
 
 				if (
+					importStepProgress &&
 					importStepProgress.started_at &&
 					importStepProgress.started_at * 1000 > new Date( createdAt ).getTime()
 				) {

--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -161,7 +161,14 @@ export async function importSqlCheckStatus( { app, env }: ImportSqlCheckStatusIn
 
 				debug( { createdAt, dbOperationInProgress, importInProgress, importStepProgress } );
 
-				if ( importStepProgress?.started_at * 1000 > new Date( createdAt ).getTime() ) {
+				let jobCreationTime;
+				try {
+					jobCreationTime = new Date( createdAt ).getTime();
+				} catch ( e ) {
+					debug( 'Unable to parse createdAt to a Date' );
+				}
+
+				if ( jobCreationTime && importStepProgress?.started_at * 1000 > jobCreationTime ) {
 					// The contents of the `import_progress` meta are pertinent to the most recent import job
 					const failedImportStep = importStepProgress.steps.find(
 						step =>

--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -161,23 +161,12 @@ export async function importSqlCheckStatus( { app, env }: ImportSqlCheckStatusIn
 
 				debug( { createdAt, dbOperationInProgress, importInProgress, importStepProgress } );
 
-				if (
-					importStepProgress &&
-					importStepProgress.started_at &&
-					importStepProgress.started_at * 1000 > new Date( createdAt ).getTime()
-				) {
+				if ( importStepProgress?.started_at * 1000 > new Date( createdAt ).getTime() ) {
 					// The contents of the `import_progress` meta are pertinent to the most recent import job
-					const failedImportStep = importStepProgress.steps.find( step => {
-						step.result === 'failed' &&
-							debug( {
-								failedStep: step,
-								sa: 1000 * step.started_at,
-								ca: new Date( createdAt ).getTime(),
-							} );
-						return (
-							step.result === 'failed' && 1000 * step.started_at > new Date( createdAt ).getTime()
-						);
-					} );
+					const failedImportStep = importStepProgress.steps.find(
+						step =>
+							step?.result === 'failed' && 1000 * step?.started_at > new Date( createdAt ).getTime()
+					);
 
 					if ( failedImportStep ) {
 						return reject( {


### PR DESCRIPTION
## Description

When an import is kicked off, we might not have an import progress object, so we need to short-circuit before checking any properties of the object or doing any additional processing.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vipvip-import-sql @siteid ./db123.sql`
1. Verify import doesn't error out with `TypeError: Cannot read property 'started_at' of null`

