### PR TITLE
App command: include launch status

### DIFF
--- a/src/bin/vip-app.js
+++ b/src/bin/vip-app.js
@@ -25,7 +25,7 @@ command( { requiredArgs: 1, format: true } )
 		try {
 			res = await app(
 				arg[ 0 ],
-				'id,repo,name,environments{id,appId,name,type,branch,currentCommit,primaryDomain{name}}'
+				'id,repo,name,environments{id,appId,name,type,branch,currentCommit,primaryDomain{name},launched}'
 			);
 		} catch ( e ) {
 			await trackEvent( 'app_command_fetch_error', {


### PR DESCRIPTION
## Description

Include the environment `launched` status in the output of the `vip app` command.

|Before|After|
|---|---|
|![Screen Shot 2021-01-27 at 3 44 37 PM](https://user-images.githubusercontent.com/1587282/106051638-b44a1380-60b6-11eb-9063-c11b23ac6406.png)|![Screen Shot 2021-01-27 at 3 44 19 PM](https://user-images.githubusercontent.com/1587282/106051658-bb712180-60b6-11eb-8047-4b6afed409c3.png)|



## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-app.js 1000`
1. Verify launch status is accurately displayed for all envs of the app

