### PR TITLE
SQL Imports: Reinstitute check for file access in command gate fn

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -85,7 +85,7 @@ const gates = async ( app, env, fileName ) => {
 	try {
 		await checkFileAccess( fileName );
 	} catch ( e ) {
-		await track( 'import_sql_command_error', { error_type: 'missing-file' } );
+		await track( 'import_sql_command_error', { error_type: 'sqlfile-missing' } );
 		exit.withError( `File '${ fileName }' does not exist or is not readable.` );
 	}
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -21,7 +21,7 @@ import {
 	SQL_IMPORT_FILE_SIZE_LIMIT,
 } from 'lib/site-import/db-file-import';
 import { importSqlCheckStatus } from 'lib/site-import/status';
-import { getFileSize, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
+import { checkFileAccess, getFileSize, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
 import { trackEventWithEnv } from 'lib/tracker';
 import { staticSqlValidations } from 'lib/validations/sql';
 import { siteTypeValidations } from 'lib/validations/site-type';
@@ -80,6 +80,13 @@ const gates = async ( app, env, fileName ) => {
 		exit.withError(
 			'The type of application you specified does not currently support SQL imports.'
 		);
+	}
+
+	try {
+		await checkFileAccess( fileName );
+	} catch ( e ) {
+		await track( 'import_sql_command_error', { error_type: 'missing-file' } );
+		exit.withError( `File '${ fileName }' does not exist or is not readable.` );
 	}
 
 	const fileSize = await getFileSize( fileName );


### PR DESCRIPTION
## Description

At some point, we lost graceful handling of missing or unreadable files. This brings it back and uses `fs.promises` functions since we've dropped node 8 support.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js` with paths to empty, non-existent, & unreadable files
    * Failure should be graceful & not point to contact support
1. Repeat with a readable file
    * It should not fail

