### PR TITLE
FORNO-506: Add optional IF NOT EXISTS to CREATE TABLE checks

### DIFF
--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -149,7 +149,7 @@ const checks: Checks = {
 		recommendation: 'Check import settings to include DROP TABLE statements',
 	},
 	createTable: {
-		matcher: /^CREATE TABLE `?([a-z0-9_]*)/i,
+		matcher: /^CREATE TABLE (?:IF NOT EXISTS )?`?([a-z0-9_]*)/i,
 		matchHandler: ( lineNumber, results ) => results [ 1 ],
 		outputFormatter: requiredCheckFormatter,
 		results: [],


### PR DESCRIPTION
## Description

Sometimes SQL files have `CREATE TABLE IF NOT EXISTS` clauses.
This PR adds support for those clauses, leaving `IF NOT EXISTS` as an optional group to maximise case coverage.

## Steps to Test

Take a MySQL dump for a valid WordPress site and make sure it contains `CREATE TABLE IF NOT EXISTS` statements (just add `IF NOT EXISTS` to one or more statements. that will do).

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-validate-sql.js yourdump.sql`
1. Verify all is green.

