### PR TITLE
Streamline import progress output

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -239,9 +239,6 @@ command( {
 		debug( 'Uploading…' );
 
 		try {
-			currentStatus = setStatusForCurrentAction( 'running', currentAction );
-			progress( currentStatus );
-
 			const {
 				fileMeta: { basename, md5 },
 				result,
@@ -280,9 +277,6 @@ command( {
 				mutation: START_IMPORT_MUTATION,
 				variables: startImportVariables,
 			} );
-
-			currentStatus = setStatusForCurrentAction( 'success', currentAction );
-			progress( currentStatus );
 
 			debug( { startImportResults } );
 		} catch ( gqlErr ) {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -184,8 +184,6 @@ command( {
 		debug( 'Options: ', opts );
 		debug( 'Args: ', arg );
 
-		console.log( `\n${ chalk.underline( '** Welcome to the WPVIP Site SQL Importer! **' ) }\n` );
-
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		await track( 'import_sql_command_execute' );
@@ -264,8 +262,6 @@ command( {
 			debug( 'Upload complete. Initiating the import.' );
 
 			await track( 'import_sql_upload_complete' );
-
-			console.log( '\n🚧 🚧 🚧 Your sql file import is queued 🚧 🚧 🚧' );
 		} catch ( e ) {
 			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
 			progress( currentStatus, runningSprite );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -35,7 +35,7 @@ import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
 
 // For progress logs
 let currentStatus;
-let currentAction;
+const currentAction = 'import';
 
 const appQuery = `
 	id,
@@ -196,8 +196,6 @@ command( {
 		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
 		searchReplace ? '' : console.log();
 
-		currentAction = 'startImport';
-
 		let fileNameToUpload = fileName;
 		// Run Search and Replace if the --search-replace flag was provided
 		if ( searchReplace && searchReplace.length ) {
@@ -249,8 +247,6 @@ command( {
 				basename: basename,
 				md5: md5,
 			};
-			currentStatus = setStatusForCurrentAction( 'success', currentAction );
-			progress( currentStatus );
 
 			debug( { basename, md5, result } );
 
@@ -258,16 +254,9 @@ command( {
 
 			await track( 'import_sql_upload_complete' );
 		} catch ( e ) {
-			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-			progress( currentStatus );
-
 			await track( 'import_sql_command_error', { error_type: 'upload_failed', e } );
 			exit.withError( e );
 		}
-
-		// Which step of the import we're in
-		// `startImport` -> `import`
-		currentAction = 'import';
 
 		try {
 			currentStatus = setStatusForCurrentAction( 'running', currentAction );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -240,7 +240,7 @@ command( {
 
 		const startImportVariables = {};
 
-		console.log( 'Uploading…' );
+		debug( 'Uploading…' );
 
 		try {
 			currentStatus = setStatusForCurrentAction( 'running', currentAction );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -196,7 +196,7 @@ command( {
 		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
 		searchReplace ? '' : console.log();
 
-		currentAction = 'startImport'
+		currentAction = 'startImport';
 
 		let fileNameToUpload = fileName;
 		// Run Search and Replace if the --search-replace flag was provided

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -32,13 +32,10 @@ import * as exit from 'lib/cli/exit';
 import { fileLineValidations } from 'lib/validations/line-by-line';
 import { formatEnvironment } from 'lib/cli/format';
 import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
-import { formatJobSteps, RunningSprite } from 'lib/cli/format';
 
 // For progress logs
 let currentStatus;
 let currentAction;
-
-const runningSprite = new RunningSprite();
 
 const appQuery = `
 	id,
@@ -223,8 +220,9 @@ command( {
 
 			fileNameToUpload = outputFileName;
 		} else {
-			currentStatus = setStatusForCurrentAction( 'skipped', currentAction );
-			progress( currentStatus, runningSprite );
+			// Indicate that S-R was skipped in the progress logs
+			currentStatus = setStatusForCurrentAction( 'skipped', 'replace' );
+			progress( currentStatus );
 		}
 
 		// VALIDATIONS
@@ -242,7 +240,7 @@ command( {
 
 		try {
 			currentStatus = setStatusForCurrentAction( 'running', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 			const {
 				fileMeta: { basename, md5 },
@@ -255,7 +253,7 @@ command( {
 				md5: md5,
 			};
 			currentStatus = setStatusForCurrentAction( 'success', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 			debug( { basename, md5, result } );
 
@@ -264,7 +262,7 @@ command( {
 			await track( 'import_sql_upload_complete' );
 		} catch ( e ) {
 			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 			await track( 'import_sql_command_error', { error_type: 'upload_failed', e } );
 			exit.withError( e );
@@ -276,7 +274,7 @@ command( {
 
 		try {
 			currentStatus = setStatusForCurrentAction( 'running', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 			const startImportResults = await api.mutate( {
 				mutation: START_IMPORT_MUTATION,
@@ -284,12 +282,12 @@ command( {
 			} );
 
 			currentStatus = setStatusForCurrentAction( 'success', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 			debug( { startImportResults } );
 		} catch ( gqlErr ) {
 			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 			await track( 'import_sql_command_error', {
 				error_type: 'StartImport-failed',

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -120,7 +120,8 @@ const gates = async ( app, env, fileName ) => {
 		);
 	}
 };
-// Command examples
+
+// Command examples for the `vip import sql` help prompt
 const examples = [
 	// `sql` subcommand
 	{
@@ -191,12 +192,14 @@ command( {
 		// Log summary of import details
 		const domain = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;
 
+		console.log();
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
-		console.log( `       site: ${ app.name }(${ formatEnvironment( opts.env.type ) })` );
+		console.log( `       site: ${ app.name } (${ formatEnvironment( opts.env.type ) })` );
 		searchReplace ? '' : console.log();
 
 		let fileNameToUpload = fileName;
+
 		// Run Search and Replace if the --search-replace flag was provided
 		if ( searchReplace && searchReplace.length ) {
 			const params = searchReplace.split( ',' );
@@ -223,7 +226,7 @@ command( {
 			progress( currentStatus );
 		}
 
-		// VALIDATIONS
+		// SQL file validations
 		const validations = [];
 		validations.push( staticSqlValidations );
 		validations.push( siteTypeValidations );
@@ -236,11 +239,13 @@ command( {
 
 		debug( 'Uploading…' );
 
+		// Uploading the SQL file to AWS S3
 		try {
 			const {
 				fileMeta: { basename, md5 },
 				result,
 			} = await uploadImportSqlFileToS3( { app, env, fileName: fileNameToUpload } );
+
 			startImportVariables.input = {
 				id: app.id,
 				environmentId: env.id,
@@ -258,6 +263,7 @@ command( {
 			exit.withError( e );
 		}
 
+		// Start the import
 		try {
 			currentStatus = setStatusForCurrentAction( 'running', currentAction );
 			progress( currentStatus );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -9,6 +9,7 @@
  * External dependencies
  */
 import gql from 'graphql-tag';
+import chalk from 'chalk';
 import debugLib from 'debug';
 
 /**
@@ -29,15 +30,12 @@ import { searchAndReplace } from 'lib/search-and-replace';
 import API from 'lib/api';
 import * as exit from 'lib/cli/exit';
 import { fileLineValidations } from 'lib/validations/line-by-line';
-<<<<<<< HEAD
 import { formatEnvironment } from 'lib/cli/format';
 import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
 
 // For progress logs
 let currentStatus;
 const currentAction = 'import';
-=======
->>>>>>> c113e672f70108133e7d6270d85e49202827e10b
 
 const appQuery = `
 	id,
@@ -211,6 +209,10 @@ command( {
 
 		// Run Search and Replace if the --search-replace flag was provided
 		if ( searchReplace && searchReplace.length ) {
+			const params = searchReplace.split( ',' );
+
+			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }\n` );
+
 			const { outputFileName } = await searchAndReplace( fileName, searchReplace, {
 				isImport: true,
 				inPlace: opts.inPlace,
@@ -257,11 +259,15 @@ command( {
 				basename: basename,
 				md5: md5,
 			};
+
 			debug( { basename, md5, result } );
-			console.log( 'Upload complete. Initiating the import.' );
+			debug( 'Upload complete. Initiating the import.' );
 
 			await track( 'import_sql_upload_complete' );
 		} catch ( e ) {
+			currentStatus = setStatusForCurrentAction( 'failed', 'upload' );
+			progress( currentStatus );
+
 			await track( 'import_sql_command_error', { error_type: 'upload_failed', e } );
 			exit.withError( e );
 		}

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -352,7 +352,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 					const primaryDomainName = options.env.primaryDomain.name;
 					info.push( { key: 'Primary Domain Name', value: primaryDomainName } );
 				}
-				
+
 				this.sub && info.push( { key: 'SQL File', value: `${ chalk.blueBright( this.sub ) }` } );
 
 				// Show S-R params if the `search-replace` flag is set

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -352,7 +352,24 @@ args.argv = async function( argv, cb ): Promise<any> {
 					const primaryDomainName = options.env.primaryDomain.name;
 					info.push( { key: 'Primary Domain Name', value: primaryDomainName } );
 				}
-				this.sub && info.push( { key: 'SQL File', value: this.sub } );
+				
+				this.sub && info.push( { key: 'SQL File', value: `${ chalk.blueBright( this.sub ) }` } );
+
+				// Show S-R params if the `search-replace` flag is set
+				if ( options.searchReplace ) {
+					const params = options.searchReplace.split( ',' );
+
+					const replacements = [
+						{
+							From: `${ params[ 0 ] }`,
+							To: `${ params[ 1 ] }`,
+						},
+					];
+
+					// Format data into a user-friendly table
+					info.push( { key: 'Replacements', value: '\n' + formatData( replacements, 'table' ) } );
+				}
+
 				break;
 			case 'sync':
 				const { backup, canSync, errors } = options.env.syncPreview;

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -161,7 +161,7 @@ export function getGlyphForStatus( status: string, runningSprite: RunningSprite 
 		case 'unknown':
 			return chalk.yellow( '✕' );
 		case 'skipped':
-			return chalk.green( '✕' );	
+			return chalk.green( '✕' );
 	}
 }
 

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -160,6 +160,8 @@ export function getGlyphForStatus( status: string, runningSprite: RunningSprite 
 			return chalk.red( '✕' );
 		case 'unknown':
 			return chalk.yellow( '✕' );
+		case 'skipped':
+			return chalk.green( '✕' );	
 	}
 }
 

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -32,9 +32,9 @@ export const setStatusForCurrentAction = ( status, action ) => {
 const completedSteps = [];
 
 export function progress( steps: Object[], runningSprite: RunningSprite ) {
-	const logs = steps.reduce(
-		( carry, step ) => {
-			let statusOfAction;
+	// Iterate over each step and collect the logs to output
+ const reducer = ( accumulator, step ) => {
+		let statusOfAction;
 		statusOfAction = step.status;
 
 		const skipped = `${ step.id }-skipped`;
@@ -63,12 +63,13 @@ export function progress( steps: Object[], runningSprite: RunningSprite ) {
 			statusOfAction = 'pending';
 		}
 
-		const outputStep = carry + `${ getGlyphForStatus( statusOfAction, runningSprite ) } ${ step.name }\n`;
+		const outputStep = accumulator + `${ statusIcon } ${ step.name }\n`;
 
   return outputStep;
-	},
-		''
-	);
- 
+	}
+	
+	const logs = steps.reduce( reducer, '' );
+
+	// Output the logs
  return progressLog( logs );
 }

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import chalk from 'chalk';
 import { stdout as progressLog } from 'single-line-log';
 import { getGlyphForStatus, RunningSprite } from 'lib/cli/format';
 
@@ -25,16 +24,16 @@ export const setStatusForCurrentAction = ( status, action ) => {
 
 		return step;
 	} );
-	
+
 	return currentProgressSteps;
-}
+};
 
 const completedSteps = [];
 const runningSprite = new RunningSprite();
 
 export function progress( steps: Object[] ) {
 	// Iterate over each step and collect the logs to output
- const reducer = ( accumulator, step ) => {
+	const reducer = ( accumulator, step ) => {
 		let statusOfAction;
 		statusOfAction = step.status;
 
@@ -59,7 +58,7 @@ export function progress( steps: Object[] ) {
 		if ( stepSkipped === skipped ) {
 			statusOfAction = 'skipped';
 		} else if ( stepCompleted ) {
-			statusOfAction = 'success'
+			statusOfAction = 'success';
 		} else {
 			statusOfAction = 'pending';
 		}
@@ -67,10 +66,10 @@ export function progress( steps: Object[] ) {
 		const outputStep = accumulator + `${ statusIcon } ${ step.name }\n`;
 
   return outputStep;
-	}
+	};
 	
 	const logs = steps.reduce( reducer, '' );
 
 	// Output the logs
- return progressLog( logs );
+	return progressLog( logs );
 }

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -5,7 +5,7 @@
  */
 import chalk from 'chalk';
 import { stdout as progressLog } from 'single-line-log';
-import { getGlyphForStatus } from 'lib/cli/format';
+import { getGlyphForStatus, RunningSprite } from 'lib/cli/format';
 
 // Various action steps for SQL imports
 export const progressSteps = [
@@ -30,8 +30,9 @@ export const setStatusForCurrentAction = ( status, action ) => {
 }
 
 const completedSteps = [];
+const runningSprite = new RunningSprite();
 
-export function progress( steps: Object[], runningSprite: RunningSprite ) {
+export function progress( steps: Object[] ) {
 	// Iterate over each step and collect the logs to output
  const reducer = ( accumulator, step ) => {
 		let statusOfAction;

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -43,7 +43,7 @@ export function progress( steps: Object[] ) {
 		const skipped = `${ step.id }-skipped`;
 		const statusIcon = getGlyphForStatus( statusOfAction, runningSprite );
 
-		 // Keep track of completed and skipped steps
+		// Keep track of completed and skipped steps
 		if ( step.status === 'success' ) {
 			completedSteps.push( step.id );
 		}

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -11,7 +11,6 @@ export const progressSteps = [
 	{ id: 'replace', name: 'Performing Search and Replace', status: 'pending' },
 	{ id: 'validate', name: 'Validating SQL', status: 'pending' },
 	{ id: 'upload', name: 'Uploading file to S3', status: 'pending' },
-	{ id: 'startImport', name: 'Starting import', status: 'pending' },
 	{ id: 'import', name: 'Importing...', status: 'pending' },
 ];
 
@@ -67,7 +66,7 @@ export function progress( steps: Object[] ) {
 
   return outputStep;
 	};
-	
+
 	const logs = steps.reduce( reducer, '' );
 
 	// Output the logs

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -27,9 +27,13 @@ export const setStatusForCurrentAction = ( status, action ) => {
 	return currentProgressSteps;
 };
 
-const completedSteps = [];
+// Instantiate a new instance of the RunningSprite class
 const runningSprite = new RunningSprite();
 
+// Keep track of completed and skipped steps
+const completedSteps = [];
+
+// Progress output logs
 export function progress( steps: Object[] ) {
 	// Iterate over each step and collect the logs to output
 	const reducer = ( accumulator, step ) => {
@@ -64,7 +68,7 @@ export function progress( steps: Object[] ) {
 
 		const outputStep = accumulator + `${ statusIcon } ${ step.name }\n`;
 
-  return outputStep;
+		return outputStep;
 	};
 
 	const logs = steps.reduce( reducer, '' );

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -7,7 +7,7 @@ import { stdout as progressLog } from 'single-line-log';
 import { getGlyphForStatus, RunningSprite } from 'lib/cli/format';
 
 // Various action steps for SQL imports
-export const progressSteps = [
+export const SQL_IMPORT_PROGRESS_STEPS = [
 	{ id: 'replace', name: 'Performing Search and Replace', status: 'pending' },
 	{ id: 'validate', name: 'Validating SQL', status: 'pending' },
 	{ id: 'upload', name: 'Uploading file to S3', status: 'pending' },
@@ -16,7 +16,7 @@ export const progressSteps = [
 
 // Need to format the response to return an array
 export const setStatusForCurrentAction = ( status, action ) => {
-	const currentProgressSteps = progressSteps.map( step => {
+	const currentProgressSteps = SQL_IMPORT_PROGRESS_STEPS.map( step => {
 		if ( step.id === action ) {
 			step.status = status;
 		}

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -184,9 +184,9 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.fileSize < MULTIPART_THRESHOLD
 			? await uploadUsingPutObject( { app, env, fileMeta } )
 			: await uploadUsingMultipart( { app, env, fileMeta } );
-
-			currentStatus = setStatusForCurrentAction( 'success', currentAction );
-			progress( currentStatus );
+			
+	currentStatus = setStatusForCurrentAction( 'success', currentAction );
+	progress( currentStatus );
 
 	return {
 		fileMeta,

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -23,15 +23,12 @@ import debugLib from 'debug';
 import API from 'lib/api';
 import { MB_IN_BYTES } from 'lib/constants/file-size';
 import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
-import { formatJobSteps, RunningSprite } from 'lib/cli/format';
 
 const debug = debugLib( 'vip:lib/client-file-uploader' );
 
 // For progress logs
 let currentStatus;
 const currentAction = 'upload';
-
-const runningSprite = new RunningSprite();
 
 // Files smaller than COMPRESS_THRESHOLD will not be compressed before upload
 export const COMPRESS_THRESHOLD = 16 * MB_IN_BYTES;
@@ -138,7 +135,7 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 
 export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArguments ) {
 	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus, runningSprite );
+	progress( currentStatus );
 
 	const fileMeta = await getFileMeta( fileName );
 
@@ -147,7 +144,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		tmpDir = await getWorkingTempDir();
 	} catch ( e ) {
 		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus, runningSprite );
+		progress( currentStatus );
 
 		throw `Unable to create temporary working directory: ${ e }`;
 	}
@@ -189,7 +186,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 			: await uploadUsingMultipart( { app, env, fileMeta } );
 
 			currentStatus = setStatusForCurrentAction( 'success', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 	return {
 		fileMeta,
@@ -252,7 +249,7 @@ export async function uploadUsingPutObject( {
 		parsedResponse = await parser.parseStringPromise( result );
 	} catch ( e ) {
 		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus, runningSprite );
+		progress( currentStatus );
 
 		throw `Invalid response from cloud service. ${ e }`;
 	}
@@ -260,7 +257,7 @@ export async function uploadUsingPutObject( {
 	const { Code, Message } = parsedResponse.Error || {};
 
 	currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-	progress( currentStatus, runningSprite );
+	progress( currentStatus );
 
 	throw `Unable to upload to cloud storage. ${ JSON.stringify( { Code, Message } ) }`;
 }
@@ -295,7 +292,7 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 		const { Code, Message } = parsedResponse.Error;
 
 		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus, runningSprite );
+		progress( currentStatus );
 
 		throw `Unable to create cloud storage object. Error: ${ JSON.stringify( { Code, Message } ) }`;
 	}
@@ -307,7 +304,7 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 	) {
 
 		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus, runningSprite );
+		progress( currentStatus );
 
 		throw `Unable to get Upload ID from cloud storage. Error: ${ multipartUploadResult }`;
 	}

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -184,7 +184,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.fileSize < MULTIPART_THRESHOLD
 			? await uploadUsingPutObject( { app, env, fileMeta } )
 			: await uploadUsingMultipart( { app, env, fileMeta } );
-			
+
 	currentStatus = setStatusForCurrentAction( 'success', currentAction );
 	progress( currentStatus );
 

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -15,7 +15,6 @@ import { createGzip } from 'zlib';
 import { createHash } from 'crypto';
 import { PassThrough } from 'stream';
 import { Parser as XmlParser } from 'xml2js';
-import { stdout as singleLogLine } from 'single-line-log';
 import debugLib from 'debug';
 
 /**
@@ -144,7 +143,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		throw `Unable to create temporary working directory: ${ e }`;
 	}
 
-	console.log(
+	debug(
 		`File ${ chalk.cyan( fileMeta.basename ) } is ~ ${ Math.floor(
 			fileMeta.fileSize / MB_IN_BYTES
 		) } MB\n`
@@ -160,7 +159,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.basename = fileMeta.basename.replace( /(.gz)?$/i, '.gz' );
 		fileMeta.fileName = path.join( tmpDir, fileMeta.basename );
 
-		console.log(
+		debug(
 			`Compressing the file to ${ chalk.cyan( fileMeta.fileName ) } prior to transfer...`
 		);
 
@@ -168,7 +167,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.isCompressed = true;
 		fileMeta.fileSize = await getFileSize( fileMeta.fileName );
 
-		console.log( `Compressed file is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
+		debug( `Compressed file is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
 
 		const fewerBytes = uncompressedFileSize - fileMeta.fileSize;
 
@@ -176,7 +175,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 			( 100 * fewerBytes ) / uncompressedFileSize
 		) }%)`;
 
-		console.log( `** Compression resulted in a ${ calculation } smaller file 📦 **\n` );
+		debug( `** Compression resulted in a ${ calculation } smaller file 📦 **\n` );
 	}
 
 	const result =
@@ -223,9 +222,8 @@ export async function uploadUsingPutObject( {
 	const progressPassThrough = new PassThrough();
 	progressPassThrough.on( 'data', data => {
 		readBytes += data.length;
-		singleLogLine( `${ Math.floor( ( 100 * readBytes ) / fileSize ) }%...` );
+		debug( `${ Math.floor( ( 100 * readBytes ) / fileSize ) }%...` );
 	} );
-	progressPassThrough.on( 'end', () => console.log( '\n' ) );
 
 	const response = await fetch( presignedRequest.url, {
 		...fetchOptions,
@@ -433,7 +431,7 @@ export async function uploadParts( { app, env, fileMeta, uploadId, parts }: Uplo
 		} );
 
 	const printProgress = () =>
-		singleLogLine(
+		debug(
 			partPercentages
 				.map( ( partPercentage, index ) => {
 					const { partSize } = parts[ index ];

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -19,7 +19,6 @@ import { replace } from '@automattic/vip-search-replace';
 import { trackEvent } from 'lib/tracker';
 import { confirm } from 'lib/cli/prompt';
 import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
-import { formatJobSteps, RunningSprite } from 'lib/cli/format';
 import { getFileSize } from 'lib/client-file-uploader';
 
 const debug = debugLib( '@automattic/vip:lib:search-and-replace' );
@@ -27,8 +26,6 @@ const debug = debugLib( '@automattic/vip:lib:search-and-replace' );
 // For progress logs
 let currentStatus;
 const currentAction = 'replace';
-
-const runningSprite = new RunningSprite();
 
 const flatten = arr => {
 	return arr.reduce( function( flat, toFlatten ) {
@@ -137,7 +134,7 @@ export const searchAndReplace = async (
 ): Promise<SearchReplaceOutput> => {
 	// Track progress
 	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus, runningSprite );
+	progress( currentStatus );
 
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
@@ -147,7 +144,7 @@ export const searchAndReplace = async (
 	// if we don't have any pairs to replace with, return the input file
 	if ( ! pairs || ! pairs.length ) {
 		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus, runningSprite );
+		progress( currentStatus );
 
 		throw new Error( 'No search and replace parameters provided.' );
 	}
@@ -171,7 +168,7 @@ export const searchAndReplace = async (
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {
 			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-			progress( currentStatus, runningSprite );
+			progress( currentStatus );
 
 			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
 
@@ -204,7 +201,7 @@ export const searchAndReplace = async (
 				);
 
 				currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-				progress( currentStatus, runningSprite );
+				progress( currentStatus );
 
 				reject();
 			} );
@@ -214,7 +211,7 @@ export const searchAndReplace = async (
 	const end = endTime[ 1 ] / 1000000; // time in ms
 
 	currentStatus = setStatusForCurrentAction( 'success', currentAction );
-	progress( currentStatus, runningSprite );
+	progress( currentStatus );
 
 	await trackEvent( 'searchreplace_completed', { time_to_run: end, file_size: fileSize } );
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -133,9 +133,11 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	// Track progress
-	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus );
+	// Track progress for imports
+	if ( isImport ) {
+		currentStatus = setStatusForCurrentAction( 'running', currentAction );
+		progress( currentStatus );
+	}
 
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
@@ -144,8 +146,10 @@ export const searchAndReplace = async (
 
 	// if we don't have any pairs to replace with, return the input file
 	if ( ! pairs || ! pairs.length ) {
-		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus );
+		if ( isImport ) {
+			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
+			progress( currentStatus );
+		}
 
 		throw new Error( 'No search and replace parameters provided.' );
 	}
@@ -168,8 +172,10 @@ export const searchAndReplace = async (
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {
-			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-			progress( currentStatus );
+			if ( isImport ) {
+				currentStatus = setStatusForCurrentAction( 'failed', currentAction );
+				progress( currentStatus );
+			}
 
 			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
 
@@ -201,8 +207,10 @@ export const searchAndReplace = async (
 					)
 				);
 
-				currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-				progress( currentStatus );
+				if ( isImport ) {
+					currentStatus = setStatusForCurrentAction( 'failed', currentAction );
+					progress( currentStatus );
+				}
 
 				reject();
 			} );
@@ -211,8 +219,10 @@ export const searchAndReplace = async (
 	const endTime = process.hrtime( startTime );
 	const end = endTime[ 1 ] / 1000000; // time in ms
 
-	currentStatus = setStatusForCurrentAction( 'success', currentAction );
-	progress( currentStatus );
+	if ( isImport ) {
+		currentStatus = setStatusForCurrentAction( 'success', currentAction );
+		progress( currentStatus );
+	}
 
 	await trackEvent( 'searchreplace_completed', { time_to_run: end, file_size: fileSize } );
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -66,10 +66,8 @@ export function getReadAndWriteStreams( {
 		fs.copyFileSync( fileName, midputFileName );
 
 		debug( `Copied input file to ${ midputFileName }` );
-		console.log( `Searching ${ chalk.cyan( fileName ) }` );
 
 		debug( `Set output to the original file path ${ fileName }` );
-		console.log( 'Replacing...' );
 
 		outputFileName = fileName;
 
@@ -82,14 +80,13 @@ export function getReadAndWriteStreams( {
 	}
 
 	debug( `Reading input from file: ${ fileName }` );
-	console.log( `Searching file ${ chalk.cyan( fileName ) }` );
 
 	switch ( typeof output ) {
 		case 'string':
 			writeStream = fs.createWriteStream( output );
 			outputFileName = output;
+
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( 'Replacing...' );
 			break;
 		case 'object':
 			writeStream = output;
@@ -106,7 +103,6 @@ export function getReadAndWriteStreams( {
 			outputFileName = tmpOutFile;
 
 			debug( `Outputting to file: ${ outputFileName }` );
-			console.log( 'Replacing...' );
 
 			break;
 	}
@@ -164,27 +160,6 @@ export const searchAndReplace = async (
 	const replacements = flatten( replacementsArr );
 	debug( 'Pairs: ', pairs, 'Replacements: ', replacements );
 
-	// Add a confirmation step for search-replace
-	const yes = await confirm( [
-		{
-			key: 'From',
-			value: `${ chalk.cyan( replacements[ 0 ] ) }`,
-		},
-		{
-			key: 'To',
-			value: `${ chalk.cyan( replacements[ 1 ] ) }`,
-		},
-	], 'Proceed with the following values?' );
-
-	// Bail if user does not wish to proceed
-	if ( ! yes ) {
-		console.log( `${ chalk.red( 'Cancelling' ) }` );
-
-		await trackEvent( 'search_replace_cancelled', { is_import: isImport, in_place: inPlace } );
-
-		process.exit();
-	}
-
 	if ( inPlace ) {
 		const approved = await confirm(
 			[],
@@ -213,17 +188,6 @@ export const searchAndReplace = async (
 		replacedStream
 			.pipe( writeStream )
 			.on( 'finish', () => {
-				if ( ! usingStdOut ) {
-					console.log();
-					console.log( `${ 'Search and Replace Complete!' }` );
-
-					// Only log this message if the output SQL file isn't the original input file
-					const message = `Your new SQL file has been saved to ${ chalk.cyan( outputFileName ) }`;
-
-					inPlace ? '' : console.log( message );
-
-					console.log();
-				}
 				resolve( {
 					inputFileName: fileName,
 					outputFileName,

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -15,6 +15,9 @@ import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
 import * as exit from 'lib/cli/exit';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
+import debugLib from 'debug';
+
+const debug = debugLib( 'vip:vip-import-sql' );
 
 let isMultiSiteSqlDump = false;
 
@@ -29,8 +32,8 @@ export const siteTypeValidations = {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
-		console.log( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
-		console.log( `The SQL dump provided is ${ isMultiSiteSqlDump ? 'from a multisite.' : 'not from a multisite' }\n` );
+		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
+		debug( `The SQL dump provided is ${ isMultiSiteSqlDump ? 'from a multisite.' : 'not from a multisite' }\n` );
 
 		// if site is a multisite but import sql is not
 		if ( isMultiSite && ! isMultiSiteSqlDump ) {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -13,7 +13,6 @@ import { stdout as log } from 'single-line-log';
  * Internal dependencies
  */
 import { trackEvent } from 'lib/tracker';
-import { confirm } from 'lib/cli/prompt';
 import { getReadInterface } from 'lib/validations/line-by-line';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
 import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
@@ -216,12 +215,14 @@ export const postValidation = async ( filename: string, isImport: boolean ) => {
 			console.log( `${ chalk.red( 'Please adjust these error(s) before proceeding with the import.' ) }` );
 			console.log();
 		}
+
 		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
 		progress( currentStatus );
 
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
+
 	currentStatus = setStatusForCurrentAction( 'success', currentAction );
 	progress( currentStatus );
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -228,9 +228,6 @@ export const postValidation = async ( filename: string, isImport: boolean ) => {
 	progress( currentStatus );
 
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
-
-	isImport ? '' : console.log( '\n🎉 You can now submit for import, see here for more details: ' +
-		'https://docs.wpvip.com/how-tos/prepare-for-site-launch/migrate-content-databases/' );
 };
 
 const perLineValidations = ( line: string, runAsImport: boolean ) => {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -24,7 +24,7 @@ const currentAction = 'validate';
 let problemsFound = 0;
 let lineNum = 1;
 
-const errorCheckFormatter = ( isImport, check ) => {
+const errorCheckFormatter = ( check, isImport ) => {
 	if ( check.results.length > 0 ) {
 		problemsFound += 1;
 		console.error( chalk.red( 'Error:' ), `${ check.message } on line(s) ${ check.results.join( ', ' ) }.` );
@@ -34,7 +34,7 @@ const errorCheckFormatter = ( isImport, check ) => {
 	}
 };
 
-const requiredCheckFormatter = ( isImport, check, type ) => {
+const requiredCheckFormatter = ( check, type, isImport ) => {
 	if ( check.results.length > 0 ) {
 		if ( ! isImport ) {
 			console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
@@ -52,7 +52,7 @@ const requiredCheckFormatter = ( isImport, check, type ) => {
 	}
 };
 
-const infoCheckFormatter = ( isImport, check ) => {
+const infoCheckFormatter = ( check, isImport ) => {
 	check.results.forEach( item => {
 		if ( ! isImport ) {
 			console.log( item );
@@ -201,7 +201,7 @@ export const postValidation = async ( filename: string, isImport: boolean ) => {
 	const checkEntires: any = Object.entries( checks );
 
 	for ( const [ type, check ]: [string, CheckType] of checkEntires ) {
-		check.outputFormatter( isImport, check, type );
+		check.outputFormatter( check, type, isImport );
 		isImport ? '' : console.log( '' );
 
 		errorSummary[ type ] = check.results.length;

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -188,7 +188,7 @@ const checks: Checks = {
 	},
 };
 
-export const postValidation = async ( filename: string, isImport: boolean ) => {
+export const postValidation = async ( filename: string, isImport: boolean = false ) => {
 	if ( isImport ) {
 		currentStatus = setStatusForCurrentAction( 'running', currentAction );
 		progress( currentStatus );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -189,8 +189,10 @@ const checks: Checks = {
 };
 
 export const postValidation = async ( filename: string, isImport: boolean ) => {
-	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus );
+	if ( isImport ) {
+		currentStatus = setStatusForCurrentAction( 'running', currentAction );
+		progress( currentStatus );
+	}
 
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
@@ -215,24 +217,28 @@ export const postValidation = async ( filename: string, isImport: boolean ) => {
 		if ( isImport ) {
 			console.log( `${ chalk.red( 'Please adjust these error(s) before proceeding with the import.' ) }` );
 			console.log();
-		}
 
-		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus );
+			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
+			progress( currentStatus );
+		}
 
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
 
-	currentStatus = setStatusForCurrentAction( 'success', currentAction );
-	progress( currentStatus );
+	if ( isImport ) {
+		currentStatus = setStatusForCurrentAction( 'success', currentAction );
+		progress( currentStatus );
+	}
 
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 };
 
 const perLineValidations = ( line: string, runAsImport: boolean ) => {
-	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus );
+	if ( runAsImport ) {
+		currentStatus = setStatusForCurrentAction( 'running', currentAction );
+		progress( currentStatus );
+	}
 
 	if ( lineNum % 500 === 0 ) {
 		runAsImport ? '' : log( `Reading line ${ lineNum } ` );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -17,13 +17,10 @@ import { confirm } from 'lib/cli/prompt';
 import { getReadInterface } from 'lib/validations/line-by-line';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
 import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
-import { formatJobSteps, RunningSprite } from 'lib/cli/format';
 
 // For progress logs
 let currentStatus;
 const currentAction = 'validate';
-
-const runningSprite = new RunningSprite();
 
 let problemsFound = 0;
 let lineNum = 1;
@@ -193,7 +190,7 @@ const checks: Checks = {
 
 export const postValidation = async ( filename: string, isImport: boolean ) => {
 	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus, runningSprite );
+	progress( currentStatus );
 
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
@@ -220,13 +217,13 @@ export const postValidation = async ( filename: string, isImport: boolean ) => {
 			console.log();
 		}
 		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus, runningSprite );
+		progress( currentStatus );
 
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
 	currentStatus = setStatusForCurrentAction( 'success', currentAction );
-	progress( currentStatus, runningSprite );
+	progress( currentStatus );
 
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 
@@ -236,7 +233,7 @@ export const postValidation = async ( filename: string, isImport: boolean ) => {
 
 const perLineValidations = ( line: string, runAsImport: boolean ) => {
 	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus, runningSprite );
+	progress( currentStatus );
 
 	if ( lineNum % 500 === 0 ) {
 		runAsImport ? '' : log( `Reading line ${ lineNum } ` );


### PR DESCRIPTION
## Description

Changes from #639 +
Flipped progress logs to use the sprite/progress logic in `/lib/cli/format.js` added in #614

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql @103 /Users/joannelee/Downloads/test.sql --search-replace="hello.com,goodbye.com"`