### PR TITLE
Add environment launched status to the import sql command

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -40,6 +40,7 @@ const appQuery = `
 		appId
 		type
 		name
+		launched
 		syncProgress { status }
 		primaryDomain { name }
 		importStatus {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -348,10 +348,21 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 		switch ( _opts.module ) {
 			case 'import-sql':
-				if ( options.env && options.env.primaryDomain ) {
-					const primaryDomainName = options.env.primaryDomain.name;
+				const site = options.env;
+				if ( site && site.primaryDomain ) {
+					const primaryDomainName = site.primaryDomain.name;
 					info.push( { key: 'Primary Domain Name', value: primaryDomainName } );
 				}
+
+				// Site launched details
+				const launchedQuery = site.hasOwnProperty( 'launched' );
+
+				if ( launchedQuery ) {
+					const launched = site.launched ? '✅ Yes' : `${ chalk.red( 'x' ) } No`;
+
+					info.push( { key: 'Launched?', value: `${ chalk.cyan( launched ) }` } );
+				}
+
 				this.sub && info.push( { key: 'SQL File', value: this.sub } );
 				break;
 			case 'sync':

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -355,9 +355,9 @@ args.argv = async function( argv, cb ): Promise<any> {
 				}
 
 				// Site launched details
-				const launchedQuery = site.hasOwnProperty( 'launched' );
+				const haveLaunchedField = site.hasOwnProperty( 'launched' );
 
-				if ( launchedQuery ) {
+				if ( haveLaunchedField ) {
 					const launched = site.launched ? '✅ Yes' : `${ chalk.red( 'x' ) } No`;
 
 					info.push( { key: 'Launched?', value: `${ chalk.cyan( launched ) }` } );


### PR DESCRIPTION
## Description

Exposing the `launched` query field of an environment and displaying that when the `import sql` command is run so users know if their site is launched or not before running an import.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql @103 /Users/joannelee/Downloads/test.sql`
1. Verify you see the launch details before the confirmation prompt

