### PR TITLE
Fix search replace output for SQL import command

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -210,9 +210,25 @@ command( {
 
 		// Run Search and Replace if the --search-replace flag was provided
 		if ( searchReplace && searchReplace.length ) {
-			const params = searchReplace.split( ',' );
+			const message = param => {
+				console.log( `        s-r: ${ chalk.blue( param[ 0 ] ) } -> ${ chalk.blue( param[ 1 ] ) }` );
+			}
 
-			console.log( `        s-r: ${ chalk.blue( params[ 0 ] ) } -> ${ chalk.blue( params [ 1 ] ) }\n` );
+			// Only one pair of S-R values specified
+			if ( typeof searchReplace === 'string' ) {
+				const urlPair = searchReplace.split( ',' );
+
+				message( urlPair );
+				console.log();
+			} else {
+				// Multiple pairs of S-R values specified
+				searchReplace.forEach( pair => {
+					const urls = pair.split( ',' )
+
+					message( urls );
+				} )
+				console.log();
+			}
 
 			const { outputFileName } = await searchAndReplace( fileName, searchReplace, {
 				isImport: true,

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -30,7 +30,7 @@ import { searchAndReplace } from 'lib/search-and-replace';
 import API from 'lib/api';
 import * as exit from 'lib/cli/exit';
 import { fileLineValidations } from 'lib/validations/line-by-line';
-import { formatEnvironment, getGlyphForStatus } from 'lib/cli/format';
+import { formatEnvironment, formatSearchReplaceValues, getGlyphForStatus } from 'lib/cli/format';
 import { ProgressTracker } from 'lib/cli/progress';
 import { isFile } from '../lib/client-file-uploader';
 
@@ -213,16 +213,15 @@ command( {
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name } (${ formatEnvironment( opts.env.type ) })` );
-		if ( searchReplace && searchReplace.length ) {
-			const searchReplaceList =
-				typeof searchReplace === 'string' ? [ searchReplace ] : searchReplace;
-			const searchAndReplaceMessages = searchReplaceList.map( entry => {
-				const [ from = '', to = '' ] = entry.split( ',' );
-				return `        s-r: ${ chalk.blue( from.trim() ) } -> ${ chalk.blue( to.trim() ) }`;
-			} );
-			console.log( searchAndReplaceMessages.join( '\n' ) );
+
+		if ( searchReplace?.length ) {
+			const output = ( from, to ) => {
+				const message = `        s-r: ${ chalk.blue( from ) } -> ${ chalk.blue( to ) }`;
+				console.log( message );
+			}
+			
+			formatSearchReplaceValues( searchReplace, output );
 		}
-		console.log();
 
 		// NO `console.log` after this point! It will break the progress printing.
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -212,7 +212,7 @@ command( {
 		if ( searchReplace && searchReplace.length ) {
 			const message = param => {
 				console.log( `        s-r: ${ chalk.blue( param[ 0 ] ) } -> ${ chalk.blue( param[ 1 ] ) }` );
-			}
+			};
 
 			// Only one pair of S-R values specified
 			if ( typeof searchReplace === 'string' ) {
@@ -223,10 +223,10 @@ command( {
 			} else {
 				// Multiple pairs of S-R values specified
 				searchReplace.forEach( pair => {
-					const urls = pair.split( ',' )
+					const urls = pair.split( ',' );
 
 					message( urls );
-				} )
+				} );
 				console.log();
 			}
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -218,8 +218,8 @@ command( {
 			const output = ( from, to ) => {
 				const message = `        s-r: ${ chalk.blue( from ) } -> ${ chalk.blue( to ) }`;
 				console.log( message );
-			}
-			
+			};
+
 			formatSearchReplaceValues( searchReplace, output );
 		}
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -214,12 +214,13 @@ command( {
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name } (${ formatEnvironment( opts.env.type ) })` );
 		if ( searchReplace && searchReplace.length ) {
-			const searchAndReplaceParams = searchReplace.split( ',' );
-			console.log(
-				`        s-r: ${ chalk.blue( searchAndReplaceParams[ 0 ] ) } -> ${ chalk.blue(
-					searchAndReplaceParams[ 1 ]
-				) }`
-			);
+			const searchReplaceList =
+				typeof searchReplace === 'string' ? [ searchReplace ] : searchReplace;
+			const searchAndReplaceMessages = searchReplaceList.map( entry => {
+				const [ from = '', to = '' ] = entry.split( ',' );
+				return `        s-r: ${ chalk.blue( from.trim() ) } -> ${ chalk.blue( to.trim() ) }`;
+			} );
+			console.log( searchAndReplaceMessages.join( '\n' ) );
 		}
 		console.log();
 
@@ -242,24 +243,6 @@ Processing the SQL import for your environment...
 
 		// Run Search and Replace if the --search-replace flag was provided
 		if ( searchReplace && searchReplace.length ) {
-			const message = param => {
-				console.log( `        s-r: ${ chalk.blue( param[ 0 ] ) } -> ${ chalk.blue( param[ 1 ] ) }` );
-			};
-
-			// Only one pair of S-R values specified
-			if ( typeof searchReplace === 'string' ) {
-				const urlPair = searchReplace.split( ',' );
-
-				message( urlPair );
-			} else {
-				// Multiple pairs of S-R values specified
-				searchReplace.forEach( pair => {
-					const urls = pair.split( ',' );
-
-					message( urls );
-				} );
-			}
-
 			progressTracker.stepRunning( 'replace' );
 
 			const { outputFileName } = await searchAndReplace( fileName, searchReplace, {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -352,7 +352,26 @@ args.argv = async function( argv, cb ): Promise<any> {
 					const primaryDomainName = options.env.primaryDomain.name;
 					info.push( { key: 'Primary Domain Name', value: primaryDomainName } );
 				}
+
 				this.sub && info.push( { key: 'SQL File', value: this.sub } );
+
+				 // Show S-R params if the `search-replace` flag is set
+					const searchReplace = options.searchReplace;
+
+					let replacementPairs;
+
+					if ( searchReplace ) {
+						// Only one pair of S-R values specified
+						if ( typeof searchReplace === 'string' ) {
+							const params = searchReplace.split( ',' );
+							
+							replacementPairs = [ assignSRValues( params ) ];
+						}
+	
+						// Format data into a user-friendly table
+						info.push( { key: 'Replacements', value: '\n' + formatData( replacementPairs, 'table' ) } );
+					}
+	
 				break;
 			case 'sync':
 				const { backup, canSync, errors } = options.env.syncPreview;

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -359,13 +359,33 @@ args.argv = async function( argv, cb ): Promise<any> {
 					const searchReplace = options.searchReplace;
 
 					let replacementPairs;
-
+					let multiplePairs = [];
+	
+					const assignSRValues = params =>{
+						const pairs = {
+							From: `${ params[ 0 ] }`,
+							To: `${ params[ 1 ] }`,
+						}
+	
+						return pairs;
+					}
+	
 					if ( searchReplace ) {
 						// Only one pair of S-R values specified
 						if ( typeof searchReplace === 'string' ) {
 							const params = searchReplace.split( ',' );
 							
 							replacementPairs = [ assignSRValues( params ) ];
+						} else {
+							// Multiple pairs of S-R values specified
+							searchReplace.map( pair => {
+								const urls = pair.split( ',' );
+	
+								const format = assignSRValues( urls );
+	
+								multiplePairs.push( format );
+							} )
+							replacementPairs = obj;
 						}
 	
 						// Format data into a user-friendly table

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -18,7 +18,7 @@ import { confirm } from './prompt';
 /* eslint-enable no-duplicate-imports */
 import API from 'lib/api';
 import app from 'lib/api/app';
-import { formatData } from './format';
+import { formatData, formatSearchReplaceValues } from './format';
 import pkg from 'root/package.json';
 import { trackEvent } from 'lib/tracker';
 import pager from 'lib/cli/pager';
@@ -368,38 +368,20 @@ args.argv = async function( argv, cb ): Promise<any> {
 				// Show S-R params if the `search-replace` flag is set
 				const searchReplace = options.searchReplace;
 
-				let replacementPairs;
-				const multiplePairs = [];
-
-				const assignSRValues = params =>{
+				const assignSRValues = ( from, to ) =>{
 					const pairs = {
-						From: `${ params[ 0 ] }`,
-						To: `${ params[ 1 ] }`,
+						From: `${ from }`,
+						To: `${ to }`,
 					};
 
 					return pairs;
 				};
 
 				if ( searchReplace ) {
-					// Only one pair of S-R values specified
-					if ( typeof searchReplace === 'string' ) {
-						const params = searchReplace.split( ',' );
-
-						replacementPairs = [ assignSRValues( params ) ];
-					} else {
-						// Multiple pairs of S-R values specified
-						searchReplace.map( pair => {
-							const urls = pair.split( ',' );
-
-							const format = assignSRValues( urls );
-
-							multiplePairs.push( format );
-						} );
-						replacementPairs = multiplePairs;
-					}
+					const searchReplaceValues = formatSearchReplaceValues( searchReplace, assignSRValues );
 
 					// Format data into a user-friendly table
-					info.push( { key: 'Replacements', value: '\n' + formatData( replacementPairs, 'table' ) } );
+					info.push( { key: 'Replacements', value: '\n' + formatData( searchReplaceValues, 'table' ) } );
 				}
 
 				break;

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -355,43 +355,43 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 				this.sub && info.push( { key: 'SQL File', value: this.sub } );
 
-				 // Show S-R params if the `search-replace` flag is set
-					const searchReplace = options.searchReplace;
+				// Show S-R params if the `search-replace` flag is set
+				const searchReplace = options.searchReplace;
 
-					let replacementPairs;
-					let multiplePairs = [];
-	
-					const assignSRValues = params =>{
-						const pairs = {
-							From: `${ params[ 0 ] }`,
-							To: `${ params[ 1 ] }`,
-						}
-	
-						return pairs;
+				let replacementPairs;
+				const multiplePairs = [];
+
+				const assignSRValues = params =>{
+					const pairs = {
+						From: `${ params[ 0 ] }`,
+						To: `${ params[ 1 ] }`,
+					};
+
+					return pairs;
+				};
+
+				if ( searchReplace ) {
+					// Only one pair of S-R values specified
+					if ( typeof searchReplace === 'string' ) {
+						const params = searchReplace.split( ',' );
+
+						replacementPairs = [ assignSRValues( params ) ];
+					} else {
+						// Multiple pairs of S-R values specified
+						searchReplace.map( pair => {
+							const urls = pair.split( ',' );
+
+							const format = assignSRValues( urls );
+
+							multiplePairs.push( format );
+						} );
+						replacementPairs = multiplePairs;
 					}
-	
-					if ( searchReplace ) {
-						// Only one pair of S-R values specified
-						if ( typeof searchReplace === 'string' ) {
-							const params = searchReplace.split( ',' );
-							
-							replacementPairs = [ assignSRValues( params ) ];
-						} else {
-							// Multiple pairs of S-R values specified
-							searchReplace.map( pair => {
-								const urls = pair.split( ',' );
-	
-								const format = assignSRValues( urls );
-	
-								multiplePairs.push( format );
-							} )
-							replacementPairs = obj;
-						}
-	
-						// Format data into a user-friendly table
-						info.push( { key: 'Replacements', value: '\n' + formatData( replacementPairs, 'table' ) } );
-					}
-	
+
+					// Format data into a user-friendly table
+					info.push( { key: 'Replacements', value: '\n' + formatData( replacementPairs, 'table' ) } );
+				}
+
 				break;
 			case 'sync':
 				const { backup, canSync, errors } = options.env.syncPreview;

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -174,7 +174,9 @@ export const formatSearchReplaceValues = ( values, message ) => {
 	const searchReplaceValues = typeof values === 'string' ? [ values ] : values;
 
 	const formattedOutput = searchReplaceValues.map( pairs => {
-		const [ from, to ] = pairs.split( ',' );
+		// Turn each S-R pair into its own array, then trim away whitespace
+		const [ from, to ] = pairs.split( ',' )
+			.map( pair => pair.trim() );
 
 		const output = message( from, to );
 

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -167,3 +167,18 @@ export function getGlyphForStatus( status: string, runningSprite: RunningSprite 
 			return chalk.green( '✕' );
 	}
 }
+
+// Format Search and Replace values to output
+export const formatSearchReplaceValues = ( values, message ) => {
+	// Convert single pair S-R values to arrays
+	const searchReplaceValues = typeof values === 'string' ? [ values ] : values;
+
+	const formattedOutput = searchReplaceValues.map( pairs => {
+		const [ from, to ] = pairs.split( ',' );
+
+		const output = message( from, to );
+
+		return output;
+	} )
+	return formattedOutput;
+}

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -179,6 +179,6 @@ export const formatSearchReplaceValues = ( values, message ) => {
 		const output = message( from, to );
 
 		return output;
-	} )
+	} );
 	return formattedOutput;
-}
+};


### PR DESCRIPTION
## Description

#655 adds the logic to display the Search and Replace values if the S-R flag is passed to the import sql command.
We need to account for multiple pairs of S-R values coming in, and not just one pair.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Test w/ one S-R pair and verify output in both the initial summary and the one after the confirmation prompt:
`node ./dist/bin/vip-import-sql @103 /Users/joannelee/Downloads/test.sql --search-replace="http://hi.com,https://bye.com"`
1. Test w/ two S-R pairs and verify output: `node ./dist/bin/vip-import-sql @103 /Users/joannelee/Downloads/test.sql -s="hi.com,bye.com" -s="hello.com,bye.com"`
1. Test w/ no S-R flag: `node ./dist/bin/vip-import-sql @103 /Users/joannelee/Downloads/test.sql`
