### PR TITLE
Fix import file path reference to work cross-platform

### DIFF
--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -101,7 +101,7 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 	return new Promise( async ( resolve, reject ) => {
 		const fileSize = await getFileSize( fileName );
 
-		const basename = path.posix.basename( fileName );
+		const basename = path.basename( fileName );
 		// TODO Validate File basename...  encodeURIComponent, maybe...?
 
 		const mimeType = await detectCompressedMimeType( fileName );

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -79,22 +79,24 @@ export type UploadArguments = {
 };
 
 export const getFileMD5Hash = async ( fileName: string ) =>
-	new Promise( resolve =>
+	new Promise( ( resolve, reject ) =>
 		fs
 			.createReadStream( fileName )
 			.pipe( createHash( 'md5' ).setEncoding( 'hex' ) )
 			.on( 'finish', function() {
 				resolve( this.read() );
 			} )
+			.on( 'error', ( error ) => reject( `could not generate file hash: ${ error }` ) )
 	);
 
 export const gzipFile = async ( uncompressedFileName: string, compressedFileName: string ) =>
-	new Promise( resolve =>
+	new Promise( ( resolve, reject ) =>
 		fs
 			.createReadStream( uncompressedFileName )
 			.pipe( createGzip() )
 			.pipe( fs.createWriteStream( compressedFileName ) )
 			.on( 'finish', resolve )
+			.on( 'error', ( error ) => reject( `could not compress file: ${ error }` ) )
 	);
 
 export async function getFileMeta( fileName: string ): Promise<FileMeta> {


### PR DESCRIPTION
## Description
The file path concatenation was working incorrectly in Windows causing the import to silently fail. This changes the file basename reference to one that works cross-platform and also adds error output in the case of failure on the file operation.

Tested on
- [x] MacOS
- [x] Windows (v10 Enterprise)
- [x] Linux (Ubuntu 20.10)

## Steps to Reproduce
1. Check out `master` on a Windows machine.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql.js @<siteid> c:\db.sql`
1. Import should halt after the "Compressing the file to <path> prior to transfer..." step

## Steps to Test
1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql.js @<siteid> c:\db.sql`
1. Verify that import file is uploaded, compressed and started successfully.

![windows](https://user-images.githubusercontent.com/822209/106194083-3bed5c00-6163-11eb-8138-4428b1ed6db9.png)
