### PR TITLE
SQL Imports: Another iteration on the UX and underlying API

### DIFF
--- a/src/bin/vip-import-sql-status.js
+++ b/src/bin/vip-import-sql-status.js
@@ -17,6 +17,7 @@ import * as exit from 'lib/cli/exit';
 import { isSupportedApp } from 'lib/site-import/db-file-import';
 import { importSqlCheckStatus } from 'lib/site-import/status';
 import command from 'lib/cli/command';
+import { ProgressTracker } from 'lib/cli/progress';
 
 const appQuery = `
 id,
@@ -47,7 +48,9 @@ command( {
 
 	await track( 'import_sql_check_status_command_execute' );
 
-	console.log( `Checking the sql import status for env ID: ${ env.id }, app ID: ${ env.appId }` );
+	const progressTracker = new ProgressTracker( [] );
+	progressTracker.prefix = `=============================================================
+Checking the sql import status for env ID: ${ env.id }, app ID: ${ env.appId }:\n`;
 
-	await importSqlCheckStatus( { app, env } );
+	await importSqlCheckStatus( { app, env, progressTracker } );
 } );

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -131,6 +131,8 @@ export function requoteArgs( args: Array<string> ): Array<string> {
 export const RUNNING_SPRITE_GLYPHS = [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ];
 
 export class RunningSprite {
+	i: number;
+
 	constructor() {
 		this.i = 0;
 	}
@@ -150,6 +152,7 @@ export class RunningSprite {
 
 export function getGlyphForStatus( status: string, runningSprite: RunningSprite ) {
 	switch ( status ) {
+		default:
 		case 'pending':
 			return '○';
 		case 'running':
@@ -163,12 +166,4 @@ export function getGlyphForStatus( status: string, runningSprite: RunningSprite 
 		case 'skipped':
 			return chalk.green( '✕' );
 	}
-}
-
-export function formatJobSteps( steps: Object[], runningSprite: RunningSprite ) {
-	return steps.reduce(
-		( carry, step ) =>
-			carry + `- ${ step.name }: ${ getGlyphForStatus( step.status, runningSprite ) }\n`,
-		''
-	);
 }

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -15,21 +15,24 @@ const PRINT_INTERVAL = 100; // 🐇💨
 const COMPLETED_STEP_SLUGS = [ 'success', 'skipped' ];
 
 export class ProgressTracker {
-	allStepsSucceeded: boolean
-	hasFailure: boolean
-	hasPrinted: boolean
-	initialized: boolean
-	printInterval: IntervalID
+	allStepsSucceeded: boolean;
+	hasFailure: boolean;
+	hasPrinted: boolean;
+	initialized: boolean;
+	printInterval: IntervalID;
 
 	// Track the state of each step
-	stepsFromCaller: Map<string, Object>
-	stepsFromServer: Map<string, Object>
+	stepsFromCaller: Map<string, Object>;
+	stepsFromServer: Map<string, Object>;
 
 	// Spinnerz go brrrr
-	runningSprite: RunningSprite
+	runningSprite: RunningSprite;
 
-	prefix: string
-	suffix: string
+	// This gets printed before the step status
+	prefix: string;
+
+	// This gets printed after the step status
+	suffix: string;
 
 	constructor( steps: Object[] ) {
 		this.runningSprite = new RunningSprite();

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -52,11 +52,22 @@ export class ProgressTracker {
 	}
 
 	setStepsFromServer( steps: Object[] ) {
-		this.stepsFromServer = this.mapSteps( steps.map( ( { name, status }, index ) => ( {
+		const formattedSteps = steps.map( ( { name, status }, index ) => ( {
 			id: `server-${ index }-${ name }`,
 			name,
 			status,
-		} ) ) );
+		} ) );
+
+		if ( ! steps.some( ( { status } ) => status === 'running' ) ) {
+			const firstPendingStepIndex = steps.findIndex( ( { status } ) => status === 'pending' );
+
+			if ( firstPendingStepIndex !== -1 ) {
+				// "Promote" the first "pending" to "running"
+				formattedSteps[ firstPendingStepIndex ].status = 'running';
+			}
+		}
+
+		this.stepsFromServer = this.mapSteps( formattedSteps );
 	}
 
 	getNextStep() {

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -11,7 +11,7 @@ import { stdout as singleLogLine } from 'single-line-log';
  */
 import { getGlyphForStatus, RunningSprite } from 'lib/cli/format';
 
-const PRINT_INTERVAL = 100; // 🐇💨
+const PRINT_INTERVAL = 200; // How often the report is printed. Mainly affects the "spinner" animation.
 const COMPLETED_STEP_SLUGS = [ 'success', 'skipped' ];
 
 export class ProgressTracker {

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -22,7 +22,6 @@ import debugLib from 'debug';
  */
 import API from 'lib/api';
 import { MB_IN_BYTES } from 'lib/constants/file-size';
-import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
 
 const debug = debugLib( 'vip:lib/client-file-uploader' );
 
@@ -130,18 +129,12 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 }
 
 export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArguments ) {
-	currentStatus = setStatusForCurrentAction( 'running', currentAction );
-	progress( currentStatus );
-
 	const fileMeta = await getFileMeta( fileName );
 
 	let tmpDir;
 	try {
 		tmpDir = await getWorkingTempDir();
 	} catch ( e ) {
-		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus );
-
 		throw `Unable to create temporary working directory: ${ e }`;
 	}
 
@@ -161,9 +154,7 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.basename = fileMeta.basename.replace( /(.gz)?$/i, '.gz' );
 		fileMeta.fileName = path.join( tmpDir, fileMeta.basename );
 
-		debug(
-			`Compressing the file to ${ chalk.cyan( fileMeta.fileName ) } prior to transfer...`
-		);
+		debug( `Compressing the file to ${ chalk.cyan( fileMeta.fileName ) } prior to transfer...` );
 
 		await gzipFile( uncompressedFileName, fileMeta.fileName );
 		fileMeta.isCompressed = true;
@@ -184,9 +175,6 @@ export async function uploadImportSqlFileToS3( { app, env, fileName }: UploadArg
 		fileMeta.fileSize < MULTIPART_THRESHOLD
 			? await uploadUsingPutObject( { app, env, fileMeta } )
 			: await uploadUsingMultipart( { app, env, fileMeta } );
-
-	currentStatus = setStatusForCurrentAction( 'success', currentAction );
-	progress( currentStatus );
 
 	return {
 		fileMeta,
@@ -248,16 +236,10 @@ export async function uploadUsingPutObject( {
 	try {
 		parsedResponse = await parser.parseStringPromise( result );
 	} catch ( e ) {
-		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus );
-
 		throw `Invalid response from cloud service. ${ e }`;
 	}
 
 	const { Code, Message } = parsedResponse.Error || {};
-
-	currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-	progress( currentStatus );
 
 	throw `Unable to upload to cloud storage. ${ JSON.stringify( { Code, Message } ) }`;
 }
@@ -290,10 +272,6 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 
 	if ( parsedResponse.Error ) {
 		const { Code, Message } = parsedResponse.Error;
-
-		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus );
-
 		throw `Unable to create cloud storage object. Error: ${ JSON.stringify( { Code, Message } ) }`;
 	}
 
@@ -302,10 +280,6 @@ export async function uploadUsingMultipart( { app, env, fileMeta }: UploadUsingA
 		parsedResponse.InitiateMultipartUploadResult &&
 		parsedResponse.InitiateMultipartUploadResult.UploadId
 	) {
-
-		currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-		progress( currentStatus );
-
 		throw `Unable to get Upload ID from cloud storage. Error: ${ multipartUploadResult }`;
 	}
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -133,12 +133,6 @@ export const searchAndReplace = async (
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {
-	// Track progress for imports
-	if ( isImport ) {
-		currentStatus = setStatusForCurrentAction( 'running', currentAction );
-		progress( currentStatus );
-	}
-
 	await trackEvent( 'searchreplace_started', { is_import: isImport, in_place: inPlace } );
 
 	const startTime = process.hrtime();
@@ -146,11 +140,6 @@ export const searchAndReplace = async (
 
 	// if we don't have any pairs to replace with, return the input file
 	if ( ! pairs || ! pairs.length ) {
-		if ( isImport ) {
-			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-			progress( currentStatus );
-		}
-
 		throw new Error( 'No search and replace parameters provided.' );
 	}
 
@@ -172,13 +161,10 @@ export const searchAndReplace = async (
 
 		// Bail if user does not wish to proceed
 		if ( ! approved ) {
-			if ( isImport ) {
-				currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-				progress( currentStatus );
-			}
-
-			await trackEvent( 'search_replace_in_place_cancelled', { is_import: isImport, in_place: inPlace } );
-
+			await trackEvent( 'search_replace_in_place_cancelled', {
+				is_import: isImport,
+				in_place: inPlace,
+			} );
 			process.exit();
 		}
 	}
@@ -207,22 +193,12 @@ export const searchAndReplace = async (
 					)
 				);
 
-				if ( isImport ) {
-					currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-					progress( currentStatus );
-				}
-
 				reject();
 			} );
 	} );
 
 	const endTime = process.hrtime( startTime );
 	const end = endTime[ 1 ] / 1000000; // time in ms
-
-	if ( isImport ) {
-		currentStatus = setStatusForCurrentAction( 'success', currentAction );
-		progress( currentStatus );
-	}
 
 	await trackEvent( 'searchreplace_completed', { time_to_run: end, file_size: fileSize } );
 

--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -159,6 +159,10 @@ Status: ${ overallStatus } ${ getGlyphForStatus(
 	overallStatus,
 	progressTracker.runningSprite
 ) }\n`;
+		if ( overallStatus === 'running' ) {
+			progressTracker.suffix +=
+				'\n(Press ^C to hide progress. The import will continue in the background.)\n';
+		}
 	};
 
 	const setSuffixAndPrint = () => {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -15,11 +15,6 @@ import { stdout as log } from 'single-line-log';
 import { trackEvent } from 'lib/tracker';
 import { getReadInterface } from 'lib/validations/line-by-line';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
-import { progress, setStatusForCurrentAction } from 'lib/cli/progress';
-
-// For progress logs
-let currentStatus;
-const currentAction = 'validate';
 
 let problemsFound = 0;
 let lineNum = 1;
@@ -189,11 +184,6 @@ const checks: Checks = {
 };
 
 export const postValidation = async ( filename: string, isImport: boolean = false ) => {
-	if ( isImport ) {
-		currentStatus = setStatusForCurrentAction( 'running', currentAction );
-		progress( currentStatus );
-	}
-
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
 	isImport ? '' : log( `Finished processing ${ lineNum } lines.` );
@@ -217,29 +207,16 @@ export const postValidation = async ( filename: string, isImport: boolean = fals
 		if ( isImport ) {
 			console.log( `${ chalk.red( 'Please adjust these error(s) before proceeding with the import.' ) }` );
 			console.log();
-
-			currentStatus = setStatusForCurrentAction( 'failed', currentAction );
-			progress( currentStatus );
 		}
 
 		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
 		return process.exit( 1 );
 	}
 
-	if ( isImport ) {
-		currentStatus = setStatusForCurrentAction( 'success', currentAction );
-		progress( currentStatus );
-	}
-
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 };
 
 const perLineValidations = ( line: string, runAsImport: boolean ) => {
-	if ( runAsImport ) {
-		currentStatus = setStatusForCurrentAction( 'running', currentAction );
-		progress( currentStatus );
-	}
-
 	if ( lineNum % 500 === 0 ) {
 		runAsImport ? '' : log( `Reading line ${ lineNum } ` );
 	}


### PR DESCRIPTION
## Description

Building on #655, This change accomplishes a few things:

* Move the responsibility for updating the step state to the upper level (e.g. no progress setting scattered throughout client-file-uploader, search & replace, & sql validation functionality)
* Simplify the code needed in the upper level (e.g. only needing to set the success and failure status with the lib handling more of the mechanics)
* Combine the output of the "preflight" steps that are hard-coded in the client with the importing status that comes from the server. (Try as I might, I could not get the single-log-line lib to play nicely unless all the input was combined prior to writing to stdout.)
    * Utilize a `prefix` and `suffix` to enable printing lines before and after the single-log-line writes.
* Make the `ProgressTracker` an object instance and consolidate state inside it
* Pull in enhancements from https://github.com/Automattic/vip/pull/650

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js` (with required fields)
    * Verify the output is an improved experience
1. While an import is running run `./dist/bin/vip-import-sql-status.js`
    * Verify the output is an improved experience
1. Attempt to cause failures
    * They should be handled gracefully and attempt to show actionable steps