### PR TITLE
Append app & env ids to output

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -334,7 +334,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		const info: Array<Tuple> = [];
 
 		if ( options.app ) {
-			info.push( { key: 'App', value: options.app.name } );
+			info.push( { key: 'App', value: `${ options.app.name } (id: ${ options.app.id })` } );
 		}
 
 		if ( options.env ) {

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -338,7 +338,8 @@ args.argv = async function( argv, cb ): Promise<any> {
 		}
 
 		if ( options.env ) {
-			info.push( { key: 'Environment', value: getEnvIdentifier( options.env ) } );
+			const envName = getEnvIdentifier( options.env )
+			info.push( { key: 'Environment', value: `${ envName } (id: ${ options.env.id })` } );
 		}
 
 		let message = 'Are you sure?';

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -338,7 +338,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		}
 
 		if ( options.env ) {
-			const envName = getEnvIdentifier( options.env )
+			const envName = getEnvIdentifier( options.env );
 			info.push( { key: 'Environment', value: `${ envName } (id: ${ options.env.id })` } );
 		}
 


### PR DESCRIPTION
## Description

Display the app id and the env id for a site so users can easily reference the site's ID.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql @103 /Users/joannelee/Downloads/test.sql`
1. Verify app & env ids show
