### PR TITLE
Add fixtures dir to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 src
 
 # Tests
+__fixtures__
 __tests__
 jest.config.js
 jest.setup.js


### PR DESCRIPTION
## Description

No need to waste the mb's.

## Steps to Test

* spot check
* `npm pack` should not include fixtures in the built file