### PR TITLE
Bumping vip-search-replace to v1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,9 @@
       }
     },
     "@automattic/vip-search-replace": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@automattic/vip-search-replace/-/vip-search-replace-1.0.8.tgz",
-      "integrity": "sha512-wCu1Tv+Qh/TpuJZyEHM5KDzznZ/i/WgUniO0MvCXAv8BoZfOojulXgC++CLTDjlbLo6WoT/jhRlnOW9kCa+fqw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@automattic/vip-search-replace/-/vip-search-replace-1.0.9.tgz",
+      "integrity": "sha512-8T9/D5RwUAGYL19o42/MeIbPgaFE0mEPdCTPrdBVlsKxbzZvfnMDNqe3sbvX+oxG2AEYSB3v2O4NvcT0LGnFgA==",
       "requires": {
         "debug": "^4.2.0",
         "follow-redirects": "^1.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,9 @@
       }
     },
     "@automattic/vip-search-replace": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@automattic/vip-search-replace/-/vip-search-replace-1.0.7.tgz",
-      "integrity": "sha512-alCPMhNk8EzGY2MbydrthQwQecjE8LStPfXhbS3b9r6M0VDBoQyqFYcD/zQN0WLs9u549HY+2GAJtK/8M9monA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@automattic/vip-search-replace/-/vip-search-replace-1.0.8.tgz",
+      "integrity": "sha512-wCu1Tv+Qh/TpuJZyEHM5KDzznZ/i/WgUniO0MvCXAv8BoZfOojulXgC++CLTDjlbLo6WoT/jhRlnOW9kCa+fqw==",
       "requires": {
         "debug": "^4.2.0",
         "follow-redirects": "^1.13.0"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.6",
-    "@automattic/vip-search-replace": "^1.0.7",
+    "@automattic/vip-search-replace": "^1.0.8",
     "args": "5.0.1",
     "chalk": "3.0.0",
     "cli-table": "github:automattic/cli-table#7b14232",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.6",
-    "@automattic/vip-search-replace": "^1.0.8",
+    "@automattic/vip-search-replace": "^1.0.9",
     "args": "5.0.1",
     "chalk": "3.0.0",
     "cli-table": "github:automattic/cli-table#7b14232",


### PR DESCRIPTION
## Description

Bumps @automattic/vip-search-replace to v1.0.9
Fixes issue where search and replace would hang.


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_