### PR TITLE
SQL Import: Show 'Finishing up' when all steps succeed & tidy statusMessage

### DIFF
--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -128,6 +128,13 @@ export function requoteArgs( args: Array<string> ): Array<string> {
 	} );
 }
 
+export function capitalize( str: string ): string {
+	if ( typeof str !== 'string' || ! str.length ) {
+		return '';
+	}
+	return str[ 0 ].toUpperCase() + str.slice( 1 );
+}
+
 export const RUNNING_SPRITE_GLYPHS = [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ];
 
 export class RunningSprite {

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -15,7 +15,6 @@ const PRINT_INTERVAL = 200; // How often the report is printed. Mainly affects t
 const COMPLETED_STEP_SLUGS = [ 'success', 'skipped' ];
 
 export class ProgressTracker {
-	allStepsSucceeded: boolean;
 	hasFailure: boolean;
 	hasPrinted: boolean;
 	initialized: boolean;
@@ -82,7 +81,7 @@ export class ProgressTracker {
 	}
 
 	getNextStep() {
-		if ( this.allStepsSucceeded ) {
+		if ( this.allStepsSucceeded() ) {
 			return undefined;
 		}
 		const steps = [ ...this.getSteps().values() ];
@@ -109,7 +108,10 @@ export class ProgressTracker {
 			this.stepRunning( nextStep.id );
 			return;
 		}
-		this.allStepsSucceeded = true;
+	}
+
+	allStepsSucceeded() {
+		return ! [ ...this.getSteps().values() ].some( ( { status } ) => status !== 'success' );
 	}
 
 	setStatusForStepId( stepId: string, status: string ) {


### PR DESCRIPTION
## Description

There's a bit of a lag between the job steps completing and the job actually completing.  This adds a "Finishing Up" message like so:

![Screen Shot 2021-02-01 at 1 20 41 AM](https://user-images.githubusercontent.com/1587282/106422476-a5ec5680-642c-11eb-94d1-241f138be106.png)

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js` with various imputs
1. Verify UX is improved

