### PR TITLE
Test for SET @@SESSION.sql_log_bin in sql static validations

### DIFF
--- a/__fixtures__/validations/bad-sql-dump.sql
+++ b/__fixtures__/validations/bad-sql-dump.sql
@@ -30,3 +30,5 @@ INSERT INTO wp_options (option_name, option_value, autoload)
     VALUES 
         ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
         ('home', 'https://super-empoyees.com', 'yes');
+
+SET @@SESSION.SQL_LOG_BIN= 0;

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -60,6 +60,9 @@ describe( 'lib/validations/sql', () => {
 		it( 'instances of ALTER USER statements', () => {
 			expect( output ).toContain( 'ALTER USER statement on line(s) 25' );
 		} );
+		it( 'instances of SET @@SESSION.sql_log_bin statements', () => {
+			expect( output ).toContain( 'SET @@SESSION.sql_log_bin statement on line(s) 34' );
+		} );
 		it( 'no instances of DROP TABLE IF EXISTS statements', () => {
 			expect( output ).toContain( 'DROP TABLE was not found' );
 		} );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -124,7 +124,7 @@ const checks: Checks = {
 		outputFormatter: errorCheckFormatter,
 		results: [],
 		message: 'SET @@SESSION.sql_log_bin statement',
-		excerpt: '\'SET @@SESSION.sql_log_bin=0\' statement should not be present (case-insensitive)',
+		excerpt: '\'SET @@SESSION.sql_log_bin\' statement should not be present (case-insensitive)',
 		recommendation: 'Remove these lines',
 	},
 	trigger: {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -118,6 +118,15 @@ const checks: Checks = {
 		excerpt: '\'CREATE DATABASE\' statement should not  be present (case-insensitive)',
 		recommendation: 'Remove these lines',
 	},
+	binaryLogging: {
+		matcher: /SET @@SESSION.sql_log_bin/i,
+		matchHandler: lineNumber => lineNumber,
+		outputFormatter: errorCheckFormatter,
+		results: [],
+		message: 'SET @@SESSION.sql_log_bin statement',
+		excerpt: '\'SET @@SESSION.sql_log_bin=0\' statement should not be present (case-insensitive)',
+		recommendation: 'Remove these lines',
+	},
 	trigger: {
 		matcher: /TRIGGER/,
 		matchHandler: lineNumber => lineNumber,


### PR DESCRIPTION
## Description

This adds a test for `SET @@SESSION.sql_log_bin` usually added by `mysqldump` to SQL files. More info https://dev.mysql.com/doc/refman/8.0/en/set-sql-log-bin.html

## Steps to Test

An automated test case was added.
