### PR TITLE
Enable the renovatebot "Dependency Dashboard"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,5 +23,6 @@
         		"groupSlug": "all-minor-patch-eslint"
 		  }
 	  }
-	]
+	],
+	"dependencyDashboard": true
 }


### PR DESCRIPTION
## Description

No functional changes, just including the following setting in the renovatebot config:

`"dependencyDashboard": true`

See https://docs.renovatebot.com/configuration-options/#dependencydashboard

## Steps to Test

n/a -- post merge, we should see a "Dependency Dashboard" issue created in the repo.

