### PR TITLE
Fix: SQL file validation output disappearing

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -223,9 +223,16 @@ command( {
 			formatSearchReplaceValues( searchReplace, output );
 		}
 
-		// NO `console.log` after this point! It will break the progress printing.
-
 		let fileNameToUpload = fileName;
+
+		// SQL file validations
+		const validations = [];
+		validations.push( staticSqlValidations );
+		validations.push( siteTypeValidations );
+
+		await fileLineValidations( appId, envId, fileNameToUpload, validations );
+
+		// NO `console.log` after this point! It will break the progress printing.
 
 		const progressTracker = new ProgressTracker( SQL_IMPORT_PREFLIGHT_PROGRESS_STEPS );
 		const setProgressTrackerPrefixAndSuffix = () => {
@@ -263,13 +270,6 @@ Processing the SQL import for your environment...
 		} else {
 			progressTracker.stepSkipped( 'replace' );
 		}
-
-		// SQL file validations
-		const validations = [];
-		validations.push( staticSqlValidations );
-		validations.push( siteTypeValidations );
-
-		await fileLineValidations( appId, envId, fileNameToUpload, validations );
 
 		progressTracker.stepSuccess( 'validate' );
 


### PR DESCRIPTION
## Description

The SQL file validation logs were disappearing when running an import. This tries to fix it by moving up the check (before initiating the progress)

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Get a problematic SQL. A file with `ENGINE=MyISAM` should do.
1. Try to run an import with the SQL file. It should fail but nothing is displayed to your screen.
1. Check out PR.
1. Run `npm link`
1. Run the import another time. It should fail but the error is displayed this time.
1. Run an import with a correct SQL file. Everything should work as expected.

