### PR TITLE
SQL Import: Fix validation error output

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -276,7 +276,6 @@ Processing the SQL import for your environment...
 			progressTracker.stopPrinting();
 
 			console.log( '' );
-			console.log( '' );
 
 			exit.withError( validateErr.message );
 		}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -269,9 +269,16 @@ Processing the SQL import for your environment...
 		validations.push( staticSqlValidations );
 		validations.push( siteTypeValidations );
 
-		await fileLineValidations( appId, envId, fileNameToUpload, validations );
-
 		progressTracker.stepSuccess( 'validate' );
+
+		try {
+			await fileLineValidations( appId, envId, fileNameToUpload, validations );
+		} catch ( validateErr ) {
+			progressTracker.stepFailed( 'validate' );
+			progressTracker.stopPrinting();
+
+			exit.withError( `File validation failed: ${ validateErr }` );
+		}
 
 		// Call the Public API
 		const api = await API();

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -269,16 +269,19 @@ Processing the SQL import for your environment...
 		validations.push( staticSqlValidations );
 		validations.push( siteTypeValidations );
 
-		progressTracker.stepSuccess( 'validate' );
-
 		try {
 			await fileLineValidations( appId, envId, fileNameToUpload, validations );
 		} catch ( validateErr ) {
 			progressTracker.stepFailed( 'validate' );
 			progressTracker.stopPrinting();
 
-			exit.withError( `File validation failed: ${ validateErr }` );
+			console.log( '' );
+			console.log( '' );
+
+			exit.withError( validateErr.message );
 		}
+
+		progressTracker.stepSuccess( 'validate' );
 
 		// Call the Public API
 		const api = await API();

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -285,6 +285,7 @@ Processing the SQL import for your environment...
 		];
 
 		try {
+			progressTracker.stepRunning( 'validate' );
 			await fileLineValidations( appId, envId, fileNameToUpload, validations );
 		} catch ( validateErr ) {
 			progressTracker.stepFailed( 'validate' );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -252,8 +252,8 @@ Processing the SQL import for your environment...
 			setProgressTrackerPrefixAndSuffix();
 			progressTracker.stopPrinting();
 			progressTracker.print( { clearAfter: true } );
-			exit.withError( failureError);
-		}
+			exit.withError( failureError );
+		};
 
 		progressTracker.startPrinting( setProgressTrackerPrefixAndSuffix );
 

--- a/src/lib/cli/exit.js
+++ b/src/lib/cli/exit.js
@@ -13,8 +13,6 @@ import chalk from 'chalk';
  */
 
 export function withError( message: string ) {
-	let updatedMessage = message;
-
 	console.log( message.toString().replace( /^(Error: )*/, chalk.red( 'Error: ' ) ) );
 	process.exit( 1 );
 }

--- a/src/lib/cli/exit.js
+++ b/src/lib/cli/exit.js
@@ -13,6 +13,8 @@ import chalk from 'chalk';
  */
 
 export function withError( message: string ) {
-	console.log( chalk.red( message.toString().replace( /^(Error: )*/, 'Error: ' ) ) );
+	let updatedMessage = message;
+
+	console.log( message.toString().replace( /^(Error: )*/, chalk.red( 'Error: ' ) ) );
 	process.exit( 1 );
 }

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -172,7 +172,7 @@ export function getGlyphForStatus( status: string, runningSprite: RunningSprite 
 		case 'unknown':
 			return chalk.yellow( '✕' );
 		case 'skipped':
-			return chalk.green( '✕' );
+			return chalk.green( '-' );
 	}
 }
 

--- a/src/lib/cli/progress.js
+++ b/src/lib/cli/progress.js
@@ -11,7 +11,7 @@ import { stdout as singleLogLine } from 'single-line-log';
  */
 import { getGlyphForStatus, RunningSprite } from 'lib/cli/format';
 
-const PRINT_INTERVAL = 200; // How often the report is printed. Mainly affects the "spinner" animation.
+const PRINT_INTERVAL = process.env.DEBUG ? 5000 : 200; // How often the report is printed. Mainly affects the "spinner" animation.
 const COMPLETED_STEP_SLUGS = [ 'success', 'skipped' ];
 
 export class ProgressTracker {

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -74,9 +74,9 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 	readInterface.close();
 
-	await Promise.all( validations.map( async validation => {
+	return await Promise.all( validations.map( async validation => {
 		if ( validation.hasOwnProperty( 'postLineExecutionProcessing' ) && typeof validation.postLineExecutionProcessing === 'function' ) {
-			await validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
+			return await validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
 		}
 	} ) );
 }

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -74,9 +74,9 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 	await new Promise( resolve => readInterface.on( 'close', resolve ) );
 	readInterface.close();
 
-	return await Promise.all( validations.map( async validation => {
+	return Promise.all( validations.map( async validation => {
 		if ( validation.hasOwnProperty( 'postLineExecutionProcessing' ) && typeof validation.postLineExecutionProcessing === 'function' ) {
-			return await validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
+			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
 		}
 	} ) );
 }

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -38,13 +38,15 @@ export const siteTypeValidations = {
 		// if site is a multisite but import sql is not
 		if ( isMultiSite && ! isMultiSiteSqlDump ) {
 			await track( 'import_sql_command_error', { error_type: 'multisite-but-not-multisite-sql-dump' } );
-			exit.withError( 'You have provided a non-multisite SQL dump file for import into a multisite.' );
+
+			throw new Error( 'You have provided a non-multisite SQL dump file for import into a multisite.' );
 		}
 
 		// if site is a single site but import sql is for a multi site
 		if ( ! isMultiSite && isMultiSiteSqlDump ) {
 			await track( 'import_sql_command_error', { error_type: 'not-multisite-with-multisite-sql-dump' } );
-			exit.withError( 'You have provided a multisite SQL dump file for import into a single site (non-multisite).' );
+
+			throw new Error( 'You have provided a multisite SQL dump file for import into a single site (non-multisite).' );
 		}
 	},
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -52,9 +52,7 @@ const requiredCheckFormatter = ( check, type, isImport ) => {
 	const infos = [];
 
 	if ( check.results.length > 0 ) {
-		if ( ! isImport ) {
-			infos.push( `✅ ${ check.message } was found ${ check.results.length } times.` );
-		}
+		infos.push( `✅ ${ check.message } was found ${ check.results.length } times.` );
 
 		if ( type === 'createTable' ) {
 			if ( ! isImport ) {
@@ -80,9 +78,7 @@ const infoCheckFormatter = ( check, isImport ) => {
 	const infos = [];
 
 	check.results.forEach( item => {
-		if ( ! isImport ) {
-			infos.push( item );
-		}
+		infos.push( item );
 	} );
 
 	return {
@@ -276,8 +272,10 @@ export const postValidation = async ( filename: string, isImport: boolean = fals
 		return process.exit( 1 );
 	}
 
-	console.log( formattedInfos.join( '\n' ) );
-	console.log( '' );
+	if ( ! isImport ) {
+		console.log( formattedInfos.join( '\n' ) );
+		console.log( '' );
+	}
 
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -19,43 +19,90 @@ import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-
 let problemsFound = 0;
 let lineNum = 1;
 
+class SqlValidationError extends Error {
+  constructor( message, validationErrors ) {
+    super( message );
+
+    this.name = this.constructor.name;
+		this.validationErrors = validationErrors;
+
+    Error.captureStackTrace( this, this.constructor );
+  }
+}
+
+function formatError( message ) {
+	return `${ chalk.red( 'SQL Error:' )} ${ message }`;
+}
+
+function formatRecommendation( message ) {
+	return `${ chalk.yellow( 'Recommendation:' )} ${ message }`;
+}
+
 const errorCheckFormatter = ( check, isImport ) => {
+	const errors = [];
+	const infos = [];
+
 	if ( check.results.length > 0 ) {
 		problemsFound += 1;
-		console.error( chalk.red( 'Error:' ), `${ check.message } on line(s) ${ check.results.join( ', ' ) }.` );
-		console.error( chalk.yellow( 'Recommendation:' ), `${ check.recommendation }` );
+		errors.push( {
+			error: formatError( `${ check.message } on line(s) ${ check.results.join( ', ' ) }.` ),
+			recommendation: formatRecommendation( check.recommendation ),
+		} );
 	} else {
-		isImport ? '' : console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
+		infos.push( `✅ ${ check.message } was found ${ check.results.length } times.` );
 	}
+
+	return {
+		errors,
+		infos,
+	};
 };
 
 const requiredCheckFormatter = ( check, type, isImport ) => {
+	const errors = [];
+	const infos = [];
+
 	if ( check.results.length > 0 ) {
 		if ( ! isImport ) {
-			console.log( `✅ ${ check.message } was found ${ check.results.length } times.` );
+			infos.push( `✅ ${ check.message } was found ${ check.results.length } times.` );
 		}
 
 		if ( type === 'createTable' ) {
 			if ( ! isImport ) {
-				checkTablePrefixes( check.results );
+				checkTablePrefixes( check.results, errors, infos );
 			}
 		}
 	} else {
 		problemsFound += 1;
-		console.error( chalk.red( 'Error:' ), `${ check.message } was not found.` );
-		console.error( chalk.yellow( 'Recommendation:' ), `${ check.recommendation }` );
+
+		errors.push( {
+			error: formatError( `${ check.message } was not found.` ),
+			recommendation: formatRecommendation( check.recommendation ),
+		} );
 	}
+
+	return {
+		errors,
+		infos,
+	};
 };
 
 const infoCheckFormatter = ( check, isImport ) => {
+	const infos = [];
+
 	check.results.forEach( item => {
 		if ( ! isImport ) {
-			console.log( item );
+			infos.push( item );
 		}
 	} );
+
+	return {
+		errors: [],
+		infos,
+	};
 };
 
-function checkTablePrefixes( tables ) {
+function checkTablePrefixes( tables, errors, infos ) {
 	const wpTables = [], notWPTables = [], wpMultisiteTables = [];
 	tables.forEach( tableName => {
 		if ( tableName.match( /^wp_(\d+_)/ ) ) {
@@ -67,14 +114,19 @@ function checkTablePrefixes( tables ) {
 		}
 	} );
 	if ( wpTables.length > 0 ) {
-		console.log( ` - wp_ prefix tables found: ${ wpTables.length } ` );
+		infos.push( ` - wp_ prefix tables found: ${ wpTables.length } ` );
 	}
 	if ( notWPTables.length > 0 ) {
 		problemsFound += 1;
-		console.error( chalk.red( 'Error:' ), `tables without wp_ prefix found: ${ notWPTables.join( ',' ) } ` );
+
+		errors.push( {
+			error: formatError( `tables without wp_ prefix found: ${ notWPTables.join( ',' ) }` ),
+			recommendation: formatRecommendation( 'Please make sure all table names are prefixed with `wp_`' ),
+		} );
 	}
+
 	if ( wpMultisiteTables.length > 0 ) {
-		console.log( ` - wp_n_ prefix tables found: ${ wpMultisiteTables.length } ` );
+		infos.push( ` - wp_n_ prefix tables found: ${ wpMultisiteTables.length } ` );
 	}
 }
 
@@ -186,15 +238,22 @@ const checks: Checks = {
 export const postValidation = async ( filename: string, isImport: boolean = false ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
 
-	isImport ? '' : log( `Finished processing ${ lineNum } lines.` );
-	isImport ? '' : console.log( '\n' );
+	if ( ! isImport ) {
+		log( `Finished processing ${ lineNum } lines.` );
+		console.log( '\n' );
+	}
 
 	const errorSummary = {};
-	const checkEntires: any = Object.entries( checks );
+	const checkEntries: any = Object.entries( checks );
 
-	for ( const [ type, check ]: [string, CheckType] of checkEntires ) {
-		check.outputFormatter( check, type, isImport );
-		isImport ? '' : console.log( '' );
+	let formattedErrors = [];
+	let formattedInfos = [];
+
+	for ( const [ type, check ]: [string, CheckType] of checkEntries ) {
+		const formattedOutput = check.outputFormatter( check, type, isImport );
+
+		formattedErrors = formattedErrors.concat( formattedOutput.errors );
+		formattedInfos = formattedInfos.concat( formattedOutput.infos );
 
 		errorSummary[ type ] = check.results.length;
 	}
@@ -202,16 +261,34 @@ export const postValidation = async ( filename: string, isImport: boolean = fals
 	errorSummary.problems_found = problemsFound;
 
 	if ( problemsFound > 0 ) {
-		console.error( `** Total of ${ chalk.red( problemsFound ) } errors found ** ` );
+		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
+
+		const errorOutput = [
+			`SQL validation failed due to ${ chalk.red( problemsFound ) } error(s)`,
+			'',
+		];
+
+		formattedErrors.forEach( error => {
+			errorOutput.push( error.error );
+
+			if ( error.recommendation ) {
+				errorOutput.push( error.recommendation );
+			}
+
+			errorOutput.push( '' );
+		} );
 
 		if ( isImport ) {
-			console.log( `${ chalk.red( 'Please adjust these error(s) before proceeding with the import.' ) }` );
-			console.log();
+			throw new Error( errorOutput.join( '\n' ) );
 		}
 
-		await trackEvent( 'import_validate_sql_command_failure', { is_import: isImport, error: errorSummary } );
+		console.error( errorOutput.join( '\n' ) );
+
 		return process.exit( 1 );
 	}
+
+	console.log( formattedInfos.join( '\n' ) );
+	console.log( '' );
 
 	await trackEvent( 'import_validate_sql_command_success', { is_import: isImport } );
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -19,17 +19,6 @@ import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-
 let problemsFound = 0;
 let lineNum = 1;
 
-class SqlValidationError extends Error {
-  constructor( message, validationErrors ) {
-    super( message );
-
-    this.name = this.constructor.name;
-		this.validationErrors = validationErrors;
-
-    Error.captureStackTrace( this, this.constructor );
-  }
-}
-
 function formatError( message ) {
 	return `${ chalk.red( 'SQL Error:' )} ${ message }`;
 }

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -20,11 +20,11 @@ let problemsFound = 0;
 let lineNum = 1;
 
 function formatError( message ) {
-	return `${ chalk.red( 'SQL Error:' )} ${ message }`;
+	return `${ chalk.red( 'SQL Error:' ) } ${ message }`;
 }
 
 function formatRecommendation( message ) {
-	return `${ chalk.yellow( 'Recommendation:' )} ${ message }`;
+	return `${ chalk.yellow( 'Recommendation:' ) } ${ message }`;
 }
 
 const errorCheckFormatter = ( check, isImport ) => {


### PR DESCRIPTION
Wrap import validation in try-catch we can stop the progress tracker and properly exit on error.

TODO: return errors instead of console logging them.

## Steps to Test

1. `npm run build`
2. `./dist/bin/vip-import-sql.js @309 --search-replace=example.com,also.example.com __fixtures__/validations/bad-sql-dump.sql`

Should cleanly error out.

Try a successful import as well.