### PR TITLE
Guard against empty importStatus data

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -121,6 +121,12 @@ const gates = async ( app, env, fileName ) => {
 		);
 	}
 
+	if ( ! env?.importStatus ) {
+		await track( 'import_sql_command_error', { errorType: 'empty-import-status' } );
+		exit.withError(
+			'Unable to check for existing import or database operations on the site.'
+		);
+	}
 	const {
 		importStatus: { dbOperationInProgress, importInProgress },
 	} = env;

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -124,7 +124,7 @@ const gates = async ( app, env, fileName ) => {
 	if ( ! env?.importStatus ) {
 		await track( 'import_sql_command_error', { error_type: 'empty-import-status' } );
 		exit.withError(
-			'Unable to check for existing import or database operations on the site.'
+			'Could not determine the import status for this environment.'
 		);
 	}
 	const {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -132,14 +132,14 @@ const gates = async ( app, env, fileName ) => {
 	} = env;
 
 	if ( importInProgress ) {
-		await track( 'import_sql_command_error', { errorType: 'existing-import' } );
+		await track( 'import_sql_command_error', { error_type: 'existing-import' } );
 		exit.withError(
 			'There is already an import in progress.\n\nYou can view the status with command:\n    vip import sql status'
 		);
 	}
 
 	if ( dbOperationInProgress ) {
-		await track( 'import_sql_command_error', { errorType: 'existing-dbop' } );
+		await track( 'import_sql_command_error', { error_type: 'existing-dbop' } );
 		exit.withError( 'There is already a database operation in progress. Please try again later.' );
 	}
 };

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -124,7 +124,7 @@ const gates = async ( app, env, fileName ) => {
 	if ( ! env?.importStatus ) {
 		await track( 'import_sql_command_error', { error_type: 'empty-import-status' } );
 		exit.withError(
-			'Could not determine the import status for this environment.'
+			'Could not determine the import status for this environment. Check the app/environment and if the problem persists, contact support for assistance'
 		);
 	}
 	const {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -122,7 +122,7 @@ const gates = async ( app, env, fileName ) => {
 	}
 
 	if ( ! env?.importStatus ) {
-		await track( 'import_sql_command_error', { errorType: 'empty-import-status' } );
+		await track( 'import_sql_command_error', { error_type: 'empty-import-status' } );
 		exit.withError(
 			'Unable to check for existing import or database operations on the site.'
 		);


### PR DESCRIPTION
## Description
Provides a better error message for import commands run against that don't return an import status (no longer active, etc)

## Steps to Test


1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vipvip-import-sql @siteid ./db123.sql
1. Verify the `Error: Unable to check for existing import or database operations on the site.` error is displayed



