### PR TITLE
SQL Validation: Add stricter checking for the TRIGGER statement

### DIFF
--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -156,7 +156,8 @@ const checks: Checks = {
 		recommendation: 'Remove these lines',
 	},
 	trigger: {
-		matcher: /TRIGGER/,
+		// Match `CREATE (DEFINER=`root`@`host`) TRIGGER`
+		matcher: /^CREATE (DEFINER=`?(\w*)(`@`)?(\w*\.*%?)*`?)?(| )TRIGGER/i,
 		matchHandler: lineNumber => lineNumber,
 		outputFormatter: errorCheckFormatter,
 		results: [],

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -157,7 +157,7 @@ const checks: Checks = {
 	},
 	trigger: {
 		// Match `CREATE (DEFINER=`root`@`host`) TRIGGER`
-		matcher: /^CREATE (DEFINER=`?(\w*)(`@`)?(\w*\.*%?)*`?)?(| )TRIGGER/,
+		matcher: /^CREATE (DEFINER=`?(\w*)(`@`)?(\w*\.*%?)*`?)?(| )TRIGGER/i,
 		matchHandler: lineNumber => lineNumber,
 		outputFormatter: errorCheckFormatter,
 		results: [],

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -157,7 +157,7 @@ const checks: Checks = {
 	},
 	trigger: {
 		// Match `CREATE (DEFINER=`root`@`host`) TRIGGER`
-		matcher: /^CREATE (DEFINER=`?(\w*)(`@`)?(\w*\.*%?)*`?)?(| )TRIGGER/i,
+		matcher: /^CREATE (DEFINER=`?(\w*)(`@`)?(\w*\.*%?)*`?)?(| )TRIGGER/,
 		matchHandler: lineNumber => lineNumber,
 		outputFormatter: errorCheckFormatter,
 		results: [],

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -157,7 +157,7 @@ const checks: Checks = {
 	},
 	trigger: {
 		// Match `CREATE (DEFINER=`root`@`host`) TRIGGER`
-		matcher: /^CREATE (DEFINER=`?(\w*)(`@`)?(\w*\.*%?)*`?)?(| )TRIGGER/i,
+		matcher: /^CREATE (\(?DEFINER=`?(\w*)(`@`)?(\w*\.*%?)*`?\)?)?(| )TRIGGER/i,
 		matchHandler: lineNumber => lineNumber,
 		outputFormatter: errorCheckFormatter,
 		results: [],


### PR DESCRIPTION
## Description

Adding stricter SQL validation for the `TRIGGER` statement to avoid false positives.

Before, we were checking for:
`TRIGGER` (case sensitive)

This PR:
`CREATE TRIGGER` (case sensitive)
or
```
CREATE DEFINER=`root`@`host` TRIGGER`
```
(case sensitive)

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-validate-sql.js <sql file>`
1. Should only catch instances stated above

Tried testing w/:

```
CREATE TRIGGER
CREATE DEFINER=`root`@`%` TRIGGER
CREATE DEFINER=`root`@`host` TRIGGER
CREATE DEFINER=`root`@`127.0.0.1` TRIGGER
CREATE DEFINER=`youruser`@`host` TRIGGER
```

Please let me know if there's any instances I missed! Thank you!
