### PR TITLE
SQL Import: Add ability to skip local validation

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -311,7 +311,7 @@ If you are confident the file does not contain unsupported statements, you can r
 			}
 		}
 
-		progressTracker.stepSuccess( 'validate' );
+		progressTracker.stepRunning( 'upload' );
 
 		// Call the Public API
 		const api = await API();

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -306,7 +306,7 @@ Processing the SQL import for your environment...
 				console.log( '' );
 				return failWithError( `${ validateErr.message }
 
-If you are confident the file does not contain unsupported statements, you can retry the command with the --skip-validate option.
+If you are confident the file does not contain unsupported statements, you can retry the command with the ${ chalk.yellow( '--skip-validate' ) } option.
 ` );
 			}
 		}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -300,6 +300,7 @@ Processing the SQL import for your environment...
 			try {
 				progressTracker.stepRunning( 'validate' );
 				await fileLineValidations( appId, envId, fileNameToUpload, validations );
+				progressTracker.stepSuccess( 'validate' );
 			} catch ( validateErr ) {
 				progressTracker.stepFailed( 'validate' );
 				console.log( '' );

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -366,6 +366,15 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 				this.sub && info.push( { key: 'SQL File', value: `${ chalk.blueBright( this.sub ) }` } );
 
+				options.skipValidate =
+					options.hasOwnProperty( 'skipValidate' ) &&
+					!! options.skipValidate &&
+					! [ 'false', 'no' ].includes( options.skipValidate );
+
+				if ( options.skipValidate ) {
+					info.push( { key: 'Pre-Upload Validations', value: chalk.red( 'SKIPPED!' ) } );
+				}
+
 				// Show S-R params if the `search-replace` flag is set
 				const searchReplace = options.searchReplace;
 


### PR DESCRIPTION
## Description

Add a new option to the import sql command:
`--skip-validate`

When truthy or passed without a value, this option foregoes the line-by-line validation prior to uploading the file and submitting for import.

See discussion: https://a8c.slack.com/archives/CKUJZT08Y/p1612980186308600

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql` with and without `--skip-validate`
    * If not present or a falsey value is provided, file is validated as before
    * If present with an empty or truthy value (e.g. `--skip-validate=true`) file is not validated and is submitted as-is
   
Search & Replace options should still work as before regardless of the new param.