### PR TITLE
Fix and test for multi-site tables that have more than one digit

### DIFF
--- a/__tests__/lib/validations/is-multi-site-sql-dump.js
+++ b/__tests__/lib/validations/is-multi-site-sql-dump.js
@@ -18,5 +18,8 @@ describe( 'is-multi-site-sql-dump', () => {
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_23_posts' ) ).toBeTruthy();
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_2345235_posts' ) ).toBeTruthy();
 		} );
+		it( 'returns false for non-multi site table creations', () => {
+			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_posts' ) ).toBeFalsy();
+		} );
 	} );
 } );

--- a/__tests__/lib/validations/is-multi-site-sql-dump.js
+++ b/__tests__/lib/validations/is-multi-site-sql-dump.js
@@ -1,0 +1,22 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
+
+describe( 'is-multi-site-sql-dump', () => {
+	describe( 'sqlDumpLineIsMultiSite', () => {
+		it( 'return true when a multisite table line is detected', () => {
+			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_2_posts' ) ).toBeTruthy();
+			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_23_posts' ) ).toBeTruthy();
+			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_2345235_posts' ) ).toBeTruthy();
+		} );
+	} );
+} );

--- a/src/lib/validations/is-multi-site-sql-dump.js
+++ b/src/lib/validations/is-multi-site-sql-dump.js
@@ -13,7 +13,7 @@
 import { getReadInterface } from 'lib/validations/line-by-line';
 import * as exit from 'lib/cli/exit';
 
-const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d_[a-z0-9_]*)/i;
+const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d+_[a-z0-9_]*)/i;
 
 export function sqlDumpLineIsMultiSite( line: string ): boolean {
 	// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options


### PR DESCRIPTION
## Description

Previously create table statements like `CREATE TABLE wp_23_posts` would not be caught by the regular expression.
This PR fixes that issue and adds tests to validate it.

## Steps to Test

`npm t`

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_