### PR TITLE
Update development "npm link" message to use debug

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -19,12 +19,12 @@ import Token from 'lib/token';
 import { trackEvent, aliasUser } from 'lib/tracker';
 import { rollbar } from 'lib/rollbar';
 
-if ( config && config.environment !== 'production' ) {
-	console.log( `${ chalk.bgYellow( 'WARNING:' ) } RUNNING DEV VERSION OF @automattic/vip` );
-	console.log( 'You should `npm link` your locally checked out copy of this repo as part of your development setup.' );
-}
-
 const debug = debugLib( '@automattic/vip:bin:vip' );
+
+if ( config && config.environment !== 'production' ) {
+	debug( `${ chalk.bgYellow( 'WARNING:' ) } RUNNING DEV VERSION OF @automattic/vip` );
+	debug( 'You should `npm link` your locally checked out copy of this repo as part of your development setup.' );
+}
 
 // Config
 const tokenURL = 'https://dashboard.wpvip.com/me/cli/token';


### PR DESCRIPTION
## Description

Since this is a development-facing message, only include it in debug output.  `console.log` breaks features like search / replace which rely on a clean stdout.

see this in action with:
`vip search-replace -s "from.example.com,to.example.com" /path/to/a/sql.file.sql | less`

Note the debug statements at the top of the buffer.

## Steps to Test

* `npm run build`
* `npm link`
* `vip search-replace -s "from.example.com,to.example.com /path/to/a/sql.file.sql | less`
    * there should be no debug statements at the top