### PR TITLE
Adjust renovate to let the team know when PRs need review

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,12 @@
 {
+	"labels": ["[Status] Needs Review"],
 	"extends": [
 		"config:base",
 		":automergeLinters",
 		"schedule:weekly"
 	],
 	"reviewers": [
-		"team:Automattic/vip-platform-devex"
+		"team:Automattic/vip-platform-patisserie"
 	],
 	"packageRules": [
 	  {


### PR DESCRIPTION
## Description

Adjusting the renovate.json config to notify the team if a review is needed.

https://docs.renovatebot.com/configuration-options/

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_