### PR TITLE
Fix bug when comparing env data to selected environment

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -262,7 +262,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 				return {};
 			}
 
-			const env = options.app.environments.find( cur => cur.type === options.env );
+			const env = options.app.environments.find( cur => getEnvIdentifier( cur ) === options.env );
 
 			if ( ! env ) {
 				await trackEvent( 'command_childcontext_param_error', {


### PR DESCRIPTION
## Description

We use the `getEnvironmentIdentifier` to identify environments but in this case, we were not comparing the unique identifier. Instead, we were comparing the env type only. This fixes it.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

The test cases can be found in BB8-7140

1. Run the test case in ^ and verify it's failing
1. Checkout this PR
1. Run `npm link`
1. Re-run the test case in ^ and verify it's fixed
2. Enjoy

