### PR TITLE
Subsite SQL Import into Launched Sites

### DIFF
--- a/__tests__/bin/vip-import-sql.js
+++ b/__tests__/bin/vip-import-sql.js
@@ -1,15 +1,11 @@
 /**
- * @format
- */
-
-/**
  * External dependencies
  */
 
 /**
  * Internal dependencies
  */
-import { validationsAndGetTableNames, gates } from 'bin/vip-import-sql';
+import { validateAndGetTableNames, gates } from 'bin/vip-import-sql';
 import * as isMultiSite from 'lib/validations/is-multi-site';
 import * as featureFlags from 'lib/api/feature-flags';
 import * as exit from 'lib/cli/exit';
@@ -22,7 +18,7 @@ const mockExit = jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
 const exitWithErrorSpy = jest.spyOn( exit, 'withError' );
 
 describe( 'vip-import-sql', () => {
-	describe( 'validationsAndGetTableNames', () => {
+	describe( 'validateAndGetTableNames', () => {
 		it( 'returns an empty array when skipValidate is true', async () => {
 			const params = {
 				skipValidate: true,
@@ -30,7 +26,7 @@ describe( 'vip-import-sql', () => {
 				envId: 1,
 				fileNameToUpload: '__fixtures__/client-file-uploader/db-dump-ipsum-67mb.sql',
 			};
-			const result = await validationsAndGetTableNames( params );
+			const result = await validateAndGetTableNames( params );
 			expect( result ).toEqual( [] );
 		} );
 		it( 'returns an array of table names that are contained within the input file', async () => {
@@ -40,7 +36,7 @@ describe( 'vip-import-sql', () => {
 				envId: 1,
 				fileNameToUpload: '__fixtures__/client-file-uploader/db-dump-ipsum-67mb.sql',
 			};
-			const result = await validationsAndGetTableNames( params );
+			const result = await validateAndGetTableNames( params );
 			const expected = [
 				'wp_commentmeta',
 				'wp_comments',

--- a/__tests__/bin/vip-import-sql.js
+++ b/__tests__/bin/vip-import-sql.js
@@ -1,0 +1,89 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { validationsAndGetTableNames, gates } from 'bin/vip-import-sql';
+import * as isMultiSite from 'lib/validations/is-multi-site';
+import * as featureFlags from 'lib/api/feature-flags';
+import * as exit from 'lib/cli/exit';
+
+jest.mock( 'lib/tracker' );
+jest.mock( 'lib/validations/site-type' );
+jest.mock( 'lib/validations/is-multi-site' );
+jest.mock( 'lib/api/feature-flags' );
+const mockExit = jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
+const exitWithErrorSpy = jest.spyOn( exit, 'withError' );
+
+describe( 'vip-import-sql', () => {
+	describe( 'validationsAndGetTableNames', () => {
+		it( 'returns an empty array when skipValidate is true', async () => {
+			const params = {
+				skipValidate: true,
+				appId: 1,
+				envId: 1,
+				fileNameToUpload: '__fixtures__/client-file-uploader/db-dump-ipsum-67mb.sql',
+			};
+			const result = await validationsAndGetTableNames( params );
+			expect( result ).toEqual( [] );
+		} );
+		it( 'returns an array of table names that are contained within the input file', async () => {
+			const params = {
+				skipValidate: false,
+				appId: 1,
+				envId: 1,
+				fileNameToUpload: '__fixtures__/client-file-uploader/db-dump-ipsum-67mb.sql',
+			};
+			const result = await validationsAndGetTableNames( params );
+			const expected = [
+				'wp_commentmeta',
+				'wp_comments',
+				'wp_links',
+				'wp_options',
+				'wp_postmeta',
+				'wp_posts',
+				'wp_term_relationships',
+				'wp_term_taxonomy',
+				'wp_termmeta',
+				'wp_terms',
+				'wp_usermeta',
+				'wp_users',
+			];
+			expect( result ).toEqual( expected );
+		} );
+	} );
+	describe( 'gates', () => {
+		it( 'exits if featureDisabled (not isVIP) and site is multisite', async () => {
+			isMultiSite.isMultiSiteInSiteMeta.mockImplementation( () => true );
+			featureFlags.get.mockImplementation( () => {
+				const res = {
+					data: {
+						me: {
+							isVIP: false,
+						},
+					},
+				};
+				return res;
+			} );
+			const app = {};
+			const env = {
+				importStatus: {
+					dbOperationInProgress: false,
+					importInProgress: false,
+				},
+			};
+			const fileName = '__fixtures__/client-file-uploader/db-dump-ipsum-67mb.sql';
+			await gates( app, env, fileName );
+			expect( exitWithErrorSpy ).toHaveBeenCalledWith(
+				'The feature you are attempting to use is not currently enabled.'
+			);
+			expect( mockExit ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/__tests__/lib/cli/apiConfig.js
+++ b/__tests__/lib/cli/apiConfig.js
@@ -1,0 +1,79 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { checkFeatureEnabled, exitWhenFeatureDisabled } from 'lib/cli/apiConfig';
+import * as featureFlags from 'lib/api/feature-flags';
+
+jest.mock( 'lib/tracker' );
+const getFeatureSpy = jest.spyOn( featureFlags, 'get' );
+
+describe( 'apiConfig', () => {
+	describe( 'checkFeatureEnabled', () => {
+		it( 'return true when the public API returns isVIP = true', async () => {
+			getFeatureSpy.mockImplementation( () => {
+				const res = {
+					data: {
+						me: {
+							isVIP: true,
+						},
+					},
+				};
+				return res;
+			} );
+			const check = await checkFeatureEnabled( 'any' );
+			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
+			expect( check ).toBe( true );
+			getFeatureSpy.mockClear();
+		} );
+		it( 'returns false when the public API return isVIP = false', async () => {
+			getFeatureSpy.mockImplementation( () => {
+				const res = {
+					data: {
+						me: {
+							isVIP: false,
+						},
+					},
+				};
+				return res;
+			} );
+			const check = await checkFeatureEnabled( 'any' );
+			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
+			expect( check ).toBe( false );
+			getFeatureSpy.mockClear();
+		} );
+		it( 'returns false when the public API has no response', async () => {
+			getFeatureSpy.mockImplementation( () => undefined );
+			const check = await checkFeatureEnabled( 'any' );
+			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
+			expect( check ).toBe( false );
+			getFeatureSpy.mockClear();
+		} );
+	} );
+	describe( 'exitWhenFeatureDisabled', () => {
+		it( 'exits the process when isVIP is false', async () => {
+			const mockExit = jest.spyOn( process, 'exit' ).mockImplementation( () => {} );
+			getFeatureSpy.mockImplementation( () => {
+				const res = {
+					data: {
+						me: {
+							isVIP: false,
+						},
+					},
+				};
+				return res;
+			} );
+			await exitWhenFeatureDisabled( 'any' );
+			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
+			expect( mockExit ).toHaveBeenCalled();
+			getFeatureSpy.mockClear();
+		} );
+	} );
+} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -3928,6 +3928,46 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
+    "cli-columns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+      "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
+      "requires": {
+        "string-width": "^2.0.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@automattic/vip-search-replace": "^1.0.13",
     "args": "5.0.1",
     "chalk": "3.0.0",
+    "cli-columns": "^3.1.2",
     "cli-table": "github:automattic/cli-table#7b14232",
     "configstore": "5.0.1",
     "debug": "4.3.1",

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -240,7 +240,8 @@ command( {
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name } (${ formattedEnvironment })` );
 		if ( isMultiSite ) {
-			console.log( `multisite: ${ isMultiSite.toString() }` );
+			// eslint-disable-next-line no-multi-spaces
+			console.log(   `multisite: ${ isMultiSite.toString() }` );
 		}
 
 		if ( searchReplace?.length ) {
@@ -279,17 +280,17 @@ If you are confident the file does not contain unsupported statements, you can r
 			console.log( 'Below are a list of Tables that will be imported by this process:' );
 			console.log( columns( tableNamesInSqlFile ) );
 			// tableNamesInSqlFile.map( tableName => console.log( ` - ${ tableName }` ) );
-			const response = await prompt(
+			const promptResponse = await prompt(
 				{
 					type: 'input',
 					name: 'confirmedEnvironment',
 					message: `You are about to import the above tables into a ${
-						launched ? 'launched' : 'unlaunched'
+						launched ? 'launched' : 'un-launched'
 					} ${ formattedEnvironment } site. Type '${ formattedEnvironment }' to continue`,
 				}
 			);
 
-			if ( response.confirmedEnvironment !== unFormattedEnvironment ) {
+			if ( promptResponse.confirmedEnvironment !== unFormattedEnvironment ) {
 				await track( 'import_sql_unexpected_tables' );
 				exit.withError( 'Please review the contents of your SQL dump' );
 			}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -330,7 +330,7 @@ const displayPlaybook = async ( {
 	let siteArray = [];
 	if ( isMultiSite ) {
 		// eslint-disable-next-line no-multi-spaces
-		console.log( `multisite: ${ isMultiSite.toString() }` );
+		console.log( `  multisite: ${ isMultiSite.toString() }` );
 		siteArray = await getMultiSiteList( { env, track } );
 	}
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -24,7 +24,7 @@ import {
 import { importSqlCheckStatus } from 'lib/site-import/status';
 import { checkFileAccess, getFileSize, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
 import { trackEventWithEnv } from 'lib/tracker';
-import { staticSqlValidations } from 'lib/validations/sql';
+import { staticSqlValidations, getTableNames } from 'lib/validations/sql';
 import { siteTypeValidations } from 'lib/validations/site-type';
 import { searchAndReplace } from 'lib/search-and-replace';
 import API from 'lib/api';
@@ -322,6 +322,8 @@ If you are confident the file does not contain unsupported statements, you can r
 	) } option.
 ` );
 			}
+			// this can only be called after static validation of the SQL file
+			const tableNamesInSqlFile = getTableNames();
 		}
 
 		progressTracker.stepRunning( 'upload' );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -79,11 +79,11 @@ const SQL_IMPORT_PREFLIGHT_PROGRESS_STEPS = [
 
 const gates = async ( app, env, fileName, opts ) => {
 	const { id: envId, appId } = env;
-	const { subsite } = opts;
+	const { blogIds } = opts;
 	const track = trackEventWithEnv.bind( null, appId, envId );
 
 	// EXIT unless feature enabled, exit if disabled
-	if ( subsite ) {
+	if ( blogIds ) {
 		// currently checks isVIP, but featureName should match feature in public API
 		exitWhenFeatureDisabled( 'subsite-sql-imports' );
 	}
@@ -208,10 +208,10 @@ command( {
 		'Specify the replacement output file for Search and Replace',
 		'process.stdout'
 	)
-	.option( 'subsite', 'Perform this import into a mulitsite subsite' )
+	.option( 'blog-ids', 'A comma delimited list of blog IDs to perform this import into.' )
 	.examples( examples )
 	.argv( process.argv, async ( arg: string[], opts ) => {
-		const { app, env, searchReplace, skipValidate, subsite } = opts;
+		const { app, env, searchReplace, skipValidate, blogIds } = opts;
 		const { id: envId, appId } = env;
 		const [ fileName ] = arg;
 
@@ -232,8 +232,8 @@ command( {
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name } (${ formatEnvironment( opts.env.type ) })` );
-		if ( subsite ) {
-			console.log( `    subsite: ${ subsite }` );
+		if ( blogIds ) {
+			console.log( ` blog ID(s): ${ blogIds }` );
 		}
 
 		if ( searchReplace?.length ) {
@@ -351,6 +351,9 @@ If you are confident the file does not contain unsupported statements, you can r
 				environmentId: env.id,
 				basename: basename,
 				md5: md5,
+				options: {
+					blogIds,
+				},
 			};
 
 			debug( { basename, md5, result } );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -489,9 +489,6 @@ Processing the SQL import for your environment...
 				environmentId: env.id,
 				basename: basename,
 				md5: md5,
-				options: {
-					isMultiSite,
-				},
 			};
 
 			debug( { basename, md5, result } );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -9,6 +9,7 @@
  * External dependencies
  */
 import gql from 'graphql-tag';
+import columns from 'cli-columns';
 import chalk from 'chalk';
 import debugLib from 'debug';
 
@@ -269,12 +270,11 @@ If you are confident the file does not contain unsupported statements, you can r
 			const tableNamesInSqlFile = getTableNames();
 
 			// output the table names
+			console.log();
 			console.log( 'Below are a list of Tables that will be imported by this process:' );
-			tableNamesInSqlFile.map( tableName => console.log( ` - ${ tableName }\n` ) );
-			const approved = await confirm(
-				[],
-				'Are the tables displayed complete with what you expect from this import?'
-			);
+			console.log( columns( tableNamesInSqlFile ) );
+			// tableNamesInSqlFile.map( tableName => console.log( ` - ${ tableName }` ) );
+			const approved = await confirm( [], 'Do you want to confirm and import all these tables?' );
 			if ( ! approved ) {
 				await track( 'import_sql_unexpected_tables' );
 				exit.withError( 'Please review the contents of your SQL dump' );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -215,22 +215,22 @@ const examples = [
 const promptToContinue = async ( {
 	launched,
 	formattedEnvironment,
-	unFormattedEnvironment,
 	track,
+	domain,
 } ): Promise<void> => {
 	console.log();
-	const promptToMatch = unFormattedEnvironment.toUpperCase();
+	const promptToMatch = domain.toUpperCase();
 	const promptResponse = await prompt( {
 		type: 'input',
-		name: 'confirmedEnvironment',
+		name: 'confirmedDomain',
 		message: `You are about to import the above tables into a ${
 			launched ? 'launched' : 'un-launched'
-		} ${ formattedEnvironment } site.\nType '${ chalk.blueBright(
+		} ${ formattedEnvironment } site ${ chalk.yellow( domain ) }.\nType '${ chalk.yellow(
 			promptToMatch
 		) }' (without the quotes) to continue:\n`,
 	} );
 
-	if ( promptResponse.confirmedEnvironment !== promptToMatch ) {
+	if ( promptResponse.confirmedDomain !== promptToMatch ) {
 		await track( 'import_sql_unexpected_tables' );
 		exit.withError( 'The input did not match the expected environment label. Import aborted.' );
 	}
@@ -454,7 +454,12 @@ command( {
 		} );
 
 		// PROMPT TO PROCEED WITH THE IMPORT
-		await promptToContinue( { launched, formattedEnvironment, unFormattedEnvironment, track } );
+		await promptToContinue( {
+			launched,
+			formattedEnvironment,
+			track,
+			domain,
+		} );
 
 		/**
 		 * =========== WARNING =============

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -217,17 +217,20 @@ const promptToContinue = async ( {
 	track,
 } ): Promise<void> => {
 	console.log();
+	const promptToMatch = unFormattedEnvironment.toUpperCase();
 	const promptResponse = await prompt( {
 		type: 'input',
 		name: 'confirmedEnvironment',
 		message: `You are about to import the above tables into a ${
 			launched ? 'launched' : 'un-launched'
-		} ${ formattedEnvironment } site. Type '${ formattedEnvironment }' to continue`,
+		} ${ formattedEnvironment } site.\nType '${ chalk.blueBright(
+			promptToMatch
+		) }' (without the quotes) to continue:\n`,
 	} );
 
-	if ( promptResponse.confirmedEnvironment !== unFormattedEnvironment ) {
+	if ( promptResponse.confirmedEnvironment !== promptToMatch ) {
 		await track( 'import_sql_unexpected_tables' );
-		exit.withError( 'Please review the contents of your SQL dump' );
+		exit.withError( 'The input did not match the expected environment label. Import aborted.' );
 	}
 };
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -279,21 +279,22 @@ If you are confident the file does not contain unsupported statements, you can r
 			console.log();
 			console.log( 'Below are a list of Tables that will be imported by this process:' );
 			console.log( columns( tableNamesInSqlFile ) );
-			// tableNamesInSqlFile.map( tableName => console.log( ` - ${ tableName }` ) );
-			const promptResponse = await prompt(
-				{
-					type: 'input',
-					name: 'confirmedEnvironment',
-					message: `You are about to import the above tables into a ${
-						launched ? 'launched' : 'un-launched'
-					} ${ formattedEnvironment } site. Type '${ formattedEnvironment }' to continue`,
-				}
-			);
+		}
 
-			if ( promptResponse.confirmedEnvironment !== unFormattedEnvironment ) {
-				await track( 'import_sql_unexpected_tables' );
-				exit.withError( 'Please review the contents of your SQL dump' );
+		// PROMPT TO PROCEED WITH THE IMPORT
+		const promptResponse = await prompt(
+			{
+				type: 'input',
+				name: 'confirmedEnvironment',
+				message: `You are about to import the above tables into a ${
+					launched ? 'launched' : 'un-launched'
+				} ${ formattedEnvironment } site. Type '${ formattedEnvironment }' to continue`,
 			}
+		);
+
+		if ( promptResponse.confirmedEnvironment !== unFormattedEnvironment ) {
+			await track( 'import_sql_unexpected_tables' );
+			exit.withError( 'Please review the contents of your SQL dump' );
 		}
 
 		/**

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -252,7 +252,6 @@ export async function validateAndGetTableNames( {
 	fileNameToUpload,
 }: validateAndGetTableNamesInputType ): Promise<Array<string>> {
 	const validations = [ staticSqlValidations, siteTypeValidations ];
-	let tableNamesInSqlFile = [];
 	if ( skipValidate ) {
 		console.log( 'Skipping SQL file validation.' );
 	} else {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -97,7 +97,6 @@ const debug = debugLib( 'vip:vip-import-sql' );
 
 const SQL_IMPORT_PREFLIGHT_PROGRESS_STEPS = [
 	{ id: 'replace', name: 'Performing Search and Replace' },
-	{ id: 'validate', name: 'Validating SQL' },
 	{ id: 'upload', name: 'Uploading file' },
 	{ id: 'queue_import', name: 'Queueing Import' },
 ];
@@ -425,7 +424,6 @@ command( {
 
 		// Log summary of import details
 		const domain = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;
-		const unFormattedEnvironment = opts.env.type.toLowerCase();
 		const formattedEnvironment = formatEnvironment( opts.env.type );
 		const launched = opts.env.launched;
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -33,6 +33,7 @@ import { fileLineValidations } from 'lib/validations/line-by-line';
 import { formatEnvironment, formatSearchReplaceValues, getGlyphForStatus } from 'lib/cli/format';
 import { ProgressTracker } from 'lib/cli/progress';
 import { isFile } from '../lib/client-file-uploader';
+import { checkFeatureEnabled } from '../lib/cli/apiConfig';
 
 const appQuery = `
 	id,
@@ -200,9 +201,10 @@ command( {
 		'Specify the replacement output file for Search and Replace',
 		'process.stdout'
 	)
+	.option( 'subsite', 'Perform this import into a mulitsite subsite' )
 	.examples( examples )
 	.argv( process.argv, async ( arg: string[], opts ) => {
-		const { app, env, searchReplace, skipValidate } = opts;
+		const { app, env, searchReplace, skipValidate, subsite } = opts;
 		const { id: envId, appId } = env;
 		const [ fileName ] = arg;
 
@@ -223,6 +225,9 @@ command( {
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
 		console.log( `       site: ${ app.name } (${ formatEnvironment( opts.env.type ) })` );
+		if ( subsite ) {
+			console.log( `    subsite: ${ subsite }` );
+		}
 
 		if ( searchReplace?.length ) {
 			const output = ( from, to ) => {
@@ -299,7 +304,7 @@ Processing the SQL import for your environment...
 		} else {
 			try {
 				progressTracker.stepRunning( 'validate' );
-				await fileLineValidations( appId, envId, fileNameToUpload, validations );
+				await fileLineValidations( appId, envId, fileNameToUpload, validations, opts );
 				progressTracker.stepSuccess( 'validate' );
 			} catch ( validateErr ) {
 				progressTracker.stepFailed( 'validate' );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -12,6 +12,7 @@ import gql from 'graphql-tag';
 import columns from 'cli-columns';
 import chalk from 'chalk';
 import debugLib from 'debug';
+import { prompt } from 'enquirer';
 
 /**
  * Internal dependencies
@@ -197,6 +198,7 @@ command( {
 	requiredArgs: 1,
 	module: 'import-sql',
 	requireConfirm: 'Are you sure you want to import the contents of the provided SQL file?',
+	skipConfirmPrompt: true,
 } )
 	.command( 'status', 'Check the status of the current running import' )
 	.option(
@@ -229,11 +231,14 @@ command( {
 
 		// Log summary of import details
 		const domain = env?.primaryDomain?.name ? env.primaryDomain.name : `#${ env.id }`;
+		const unFormattedEnvironment = opts.env.type.toLowerCase();
+		const formattedEnvironment = formatEnvironment( opts.env.type );
+		const launched = opts.env.launched;
 
 		console.log();
 		console.log( `  importing: ${ chalk.blueBright( fileName ) }` );
 		console.log( `         to: ${ chalk.cyan( domain ) }` );
-		console.log( `       site: ${ app.name } (${ formatEnvironment( opts.env.type ) })` );
+		console.log( `       site: ${ app.name } (${ formattedEnvironment })` );
 		if ( isMultiSite ) {
 			console.log( `multisite: ${ isMultiSite.toString() }` );
 		}
@@ -274,8 +279,17 @@ If you are confident the file does not contain unsupported statements, you can r
 			console.log( 'Below are a list of Tables that will be imported by this process:' );
 			console.log( columns( tableNamesInSqlFile ) );
 			// tableNamesInSqlFile.map( tableName => console.log( ` - ${ tableName }` ) );
-			const approved = await confirm( [], 'Do you want to confirm and import all these tables?' );
-			if ( ! approved ) {
+			const response = await prompt(
+				{
+					type: 'input',
+					name: 'confirmedEnvironment',
+					message: `You are about to import the above tables into a ${
+						launched ? 'launched' : 'unlaunched'
+					} ${ formattedEnvironment } site. Type '${ formattedEnvironment }' to continue`,
+				}
+			);
+
+			if ( response.confirmedEnvironment !== unFormattedEnvironment ) {
 				await track( 'import_sql_unexpected_tables' );
 				exit.withError( 'Please review the contents of your SQL dump' );
 			}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -235,19 +235,19 @@ const promptToContinue = async ( {
 	}
 };
 
-export type validationsAndGetTableNamesInputType = {
+export type validateAndGetTableNamesInputType = {
 	skipValidate: boolean,
 	appId: number,
 	envId: number,
 	fileNameToUpload: string,
 };
 
-export async function validationsAndGetTableNames( {
+export async function validateAndGetTableNames( {
 	skipValidate,
 	appId,
 	envId,
 	fileNameToUpload,
-}: validationsAndGetTableNamesInputType ): Promise<Array<string>> {
+}: validateAndGetTableNamesInputType ): Promise<Array<string>> {
 	const validations = [ staticSqlValidations, siteTypeValidations ];
 	let tableNamesInSqlFile = [];
 	if ( skipValidate ) {
@@ -334,8 +334,7 @@ const displayPlaybook = async ( {
 	}
 
 	if ( ! tableNames.length ) {
-		console.log();
-		console.log( 'Since validation was skipped, no playbook information could be displayed' );
+		debug( 'Validation was skipped, no playbook information will be displayed' );
 	} else {
 		// output the table names
 		console.log();
@@ -430,7 +429,7 @@ command( {
 		let fileNameToUpload = fileName;
 
 		// SQL file validations
-		const tableNames = await validationsAndGetTableNames( {
+		const tableNames = await validateAndGetTableNames( {
 			skipValidate,
 			appId,
 			envId,

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -254,22 +254,18 @@ export async function validateAndGetTableNames( {
 	const validations = [ staticSqlValidations, siteTypeValidations ];
 	if ( skipValidate ) {
 		console.log( 'Skipping SQL file validation.' );
-	} else {
-		try {
-			await fileLineValidations( appId, envId, fileNameToUpload, validations );
-		} catch ( validateErr ) {
-			console.log( '' );
-			exit.withError( `${ validateErr.message }
-
-If you are confident the file does not contain unsupported statements, you can retry the command with the ${ chalk.yellow(
-		'--skip-validate'
-	) } option.
-` );
-		}
-		// this can only be called after static validation of the SQL file
-		tableNamesInSqlFile = getTableNames();
+		return [];
 	}
-	return tableNamesInSqlFile;
+	try {
+		await fileLineValidations( appId, envId, fileNameToUpload, validations );
+	} catch ( validateErr ) {
+		console.log( '' );
+		exit.withError( `${ validateErr.message }
+If you are confident the file does not contain unsupported statements, you can retry the command with the ${ chalk.yellow( '--skip-validate' ) } option.
+` );
+	}
+	// this can only be called after static validation of the SQL file
+	return getTableNames();
 }
 
 const displayPlaybook = ( {

--- a/src/lib/api/feature-flags.js
+++ b/src/lib/api/feature-flags.js
@@ -1,0 +1,25 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+
+export async function get() {
+	const api = await API();
+	const res = await api.query( {
+		query: gql`
+			query isVIP {
+				me {
+					isVIP
+				}
+			}
+		`,
+	} );
+	return res;
+}

--- a/src/lib/cli/apiConfig.js
+++ b/src/lib/cli/apiConfig.js
@@ -1,0 +1,53 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import { trackEvent } from 'lib/tracker';
+import API from 'lib/api';
+import * as exit from './exit';
+
+export async function checkFeatureEnabled( featureName: string, exitOnFalse: boolean = false ): Promise<boolean> {
+	// TODO: eventually let's look at more feature flags coming from the public api,
+	// for now, let's see if the user of the CLI is VIP
+	await trackEvent( 'checkFeatureEnabled_start', { featureName } );
+
+	const api = await API();
+	const isVIP = await new Promise( async resolve => {
+		try {
+			const res = await api.query( {
+				// $FlowFixMe: gql template is not supported by flow
+				query: gql`
+                    query isVIP {
+                        me {
+                            isVIP
+                        }
+                    }
+                `,
+			} );
+			resolve( res.data.me.isVIP );
+		} catch ( err ) {
+			const message = err.toString();
+			await trackEvent( 'checkFeatureEnabled_fetch_error', {
+				featureName,
+				error: message,
+			} );
+
+			exit.withError( 'Failed to determine if feature is enabled' );
+		}
+	} );
+
+	if ( exitOnFalse === true && isVIP === false ) {
+		exit.withError( 'The feature you are attempting to use is not currently enabled.' );
+	}
+
+	return isVIP === true;
+}

--- a/src/lib/cli/apiConfig.js
+++ b/src/lib/cli/apiConfig.js
@@ -57,5 +57,5 @@ export async function checkFeatureEnabled(
 }
 
 export async function exitWhenFeatureDisabled( featureName: string ): Promise<boolean> {
-	await checkFeatureEnabled( featureName, true );
+	return checkFeatureEnabled( featureName, true );
 }

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -414,7 +414,8 @@ args.argv = async function( argv, cb ): Promise<any> {
 			default:
 		}
 
-		const yes = await confirm( info, message );
+		const skipPrompt = _opts.skipConfirmPrompt || false;
+		const yes = await confirm( info, message, skipPrompt );
 		if ( ! yes ) {
 			await trackEvent( 'command_confirm_cancel' );
 

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -24,6 +24,7 @@ import { trackEvent } from 'lib/tracker';
 import pager from 'lib/cli/pager';
 import { parseEnvAliasFromArgv } from './envAlias';
 import { rollbar } from '../rollbar';
+import * as exit from './exit';
 
 function uncaughtError( err ) {
 	// Error raised when trying to write to an already closed stream
@@ -54,9 +55,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 	// If we have both an --app/--env and an alias, we need to give a warning
 	if ( parsedAlias.app && ( options.app || options.env ) ) {
-		console.error( chalk`{red Please only use an environment alias, or the --app and --env parameters, but not both}` );
-
-		process.exit();
+		exit.withError( 'Please only use an environment alias, or the --app and --env parameters, but not both' );
 	}
 
 	// If there is an alias, use it to populate the app/env options
@@ -68,11 +67,8 @@ args.argv = async function( argv, cb ): Promise<any> {
 	const validationError = validateOpts( options );
 	if ( validationError ) {
 		const error = validationError.toString();
-
 		await trackEvent( 'command_validation_error', { error } );
-
-		console.log( error );
-		process.exit( 1 );
+		exit.withError( error );
 	}
 
 	// If there's a sub-command, run that instead

--- a/src/lib/cli/prompt.js
+++ b/src/lib/cli/prompt.js
@@ -13,15 +13,18 @@ import { keyValue } from './format';
 import type { Tuple } from './format';
 /* eslint-enable no-duplicate-imports */
 
-export async function confirm( values: Array<Tuple>, message: string ): Promise<boolean> {
+export async function confirm( values: Array<Tuple>, message: string, skipPrompt: boolean = false ): Promise<boolean> {
 	console.log( keyValue( values ) );
 
-	const c = await prompt( {
-		type: 'confirm',
-		name: 'confirm',
-		message: message,
-		default: false,
-	} );
+	if ( ! skipPrompt ) {
+		const c = await prompt( {
+			type: 'confirm',
+			name: 'confirm',
+			message: message,
+			default: false,
+		} );
+		return c.confirm;
+	}
 
-	return c.confirm;
+	return true;
 }

--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -11,20 +11,25 @@ import { GB_IN_BYTES } from 'lib/constants/file-size';
 export const SQL_IMPORT_FILE_SIZE_LIMIT = 10 * GB_IN_BYTES;
 
 export interface AppForImport {
-	id: Number;
+	id: number;
 	environments: Array<any>;
 	name: string;
 	organization: Object;
 	type: string;
 }
 
+export type ImportStatusType = {
+	dbOperationInProgress: boolean,
+	importInProgress: boolean,
+};
 export interface EnvForImport {
-	id: Number;
-	appId: Number;
+	id: number;
+	appId: number;
 	name: string;
 	type: string;
 	primaryDomain: Object;
 	syncProgress: Object;
+	importStatus: ImportStatusType;
 }
 
 export function currentUserCanImportForApp( app: AppForImport ): boolean {

--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -31,6 +31,7 @@ export interface EnvForImport {
 	primaryDomain: Object;
 	syncProgress: Object;
 	importStatus: ImportStatusType;
+	launched: boolean;
 }
 
 export function currentUserCanImportForApp( app: AppForImport ): boolean {

--- a/src/lib/validations/is-multi-site.js
+++ b/src/lib/validations/is-multi-site.js
@@ -73,7 +73,5 @@ export async function isMultiSiteInSiteMeta( appId: number, envId: number ): Pro
 		}
 	}
 
-	// we should exit with an error here instead of returning false
-	exit.withError( 'We were unable to determine if your application was a multisite.' );
 	return false;
 }

--- a/src/lib/validations/is-multi-site.js
+++ b/src/lib/validations/is-multi-site.js
@@ -75,4 +75,5 @@ export async function isMultiSiteInSiteMeta( appId: number, envId: number ): Pro
 
 	// we should exit with an error here instead of returning false
 	exit.withError( 'We were unable to determine if your application was a multisite.' );
+	return false;
 }

--- a/src/lib/validations/is-multi-site.js
+++ b/src/lib/validations/is-multi-site.js
@@ -15,27 +15,37 @@ import API from 'lib/api';
 import { trackEventWithEnv } from 'lib/tracker';
 import * as exit from 'lib/cli/exit';
 
+let isMultiSite;
+
 export async function isMultiSiteInSiteMeta( appId: number, envId: number ): Promise<boolean> {
 	const track = trackEventWithEnv.bind( null, appId, envId );
+
+	// if we've already been through this, avoid doing it again within the same process
+	if ( 'boolean' === typeof isMultiSite ) {
+		return isMultiSite;
+	}
+
 	const api = await API();
 	let res;
 	try {
 		res = await api.query( {
-			query: gql`query AppMultiSiteCheck( $appId: Int, $envId: Int) {
-				app(id: $appId) {
-					id
-					name
-					repo
-					environments(id: $envId) {
+			query: gql`
+				query AppMultiSiteCheck($appId: Int, $envId: Int) {
+					app(id: $appId) {
 						id
-						appId
 						name
-						type
-						isMultisite
-						isSubdirectoryMultisite
+						repo
+						environments(id: $envId) {
+							id
+							appId
+							name
+							type
+							isMultisite
+							isSubdirectoryMultisite
+						}
 					}
 				}
-			}`,
+			`,
 			variables: {
 				appId,
 				envId,
@@ -52,14 +62,17 @@ export async function isMultiSiteInSiteMeta( appId: number, envId: number ): Pro
 	if ( Array.isArray( res?.data?.app?.environments ) ) {
 		const environments = res.data.app.environments;
 		if ( ! environments.length ) {
-			return false;
+			isMultiSite = false;
+			return isMultiSite;
 		}
 		// we asked for one result with one appId and one envId, so...
 		const thisEnv = environments[ 0 ];
 		if ( thisEnv.isMultiSite || thisEnv.isSubdirectoryMultisite ) {
-			return true;
+			isMultiSite = true;
+			return isMultiSite;
 		}
 	}
 
-	return false;
+	// we should exit with an error here instead of returning false
+	exit.withError( 'We were unable to determine if your application was a multisite.' );
 }

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -54,7 +54,7 @@ export async function getReadInterface( filename: string ) {
 	} );
 }
 
-export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject>, opts: Object ) {
+export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject> ) {
 	const isImport = true;
 	const readInterface = await getReadInterface( fileName );
 
@@ -76,7 +76,7 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 
 	return Promise.all( validations.map( async validation => {
 		if ( validation.hasOwnProperty( 'postLineExecutionProcessing' ) && typeof validation.postLineExecutionProcessing === 'function' ) {
-			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId, opts } );
+			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
 		}
 	} ) );
 }

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -54,7 +54,7 @@ export async function getReadInterface( filename: string ) {
 	} );
 }
 
-export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject> ) {
+export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject>, opts: Object ) {
 	const isImport = true;
 	const readInterface = await getReadInterface( fileName );
 
@@ -76,7 +76,7 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 
 	return Promise.all( validations.map( async validation => {
 		if ( validation.hasOwnProperty( 'postLineExecutionProcessing' ) && typeof validation.postLineExecutionProcessing === 'function' ) {
-			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
+			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId, opts } );
 		}
 	} ) );
 }

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -35,7 +35,7 @@ export const siteTypeValidations = {
 	}: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const track = trackEventWithEnv.bind( null, appId, envId );
-		const { subsite: subsiteId } = opts;
+		const { blogIds } = opts;
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
 		debug(
@@ -45,7 +45,7 @@ export const siteTypeValidations = {
 		);
 
 		// if site is a multisite but import sql is not
-		if ( ! subsiteId ) {
+		if ( ! blogIds ) {
 			if ( isMultiSite && ! isMultiSiteSqlDump ) {
 				await track( 'import_sql_command_error', {
 					error_type: 'multisite-but-not-multisite-sql-dump',

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -78,7 +78,7 @@ export const siteTypeValidations = {
 					error_type: 'subsite-import-without-subsite-sql-dump',
 				} );
 				throw new Error(
-					'You have requested a subsite SQL import but have no provided a subsite compatiable SQL dump.'
+					'You have requested a subsite SQL import but have not provided a subsite compatiable SQL dump.'
 				);
 			}
 		}

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -6,6 +6,7 @@
 /**
  * External dependencies
  */
+import debugLib from 'debug';
 
 /**
  * Internal dependencies
@@ -15,7 +16,6 @@ import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
 import * as exit from 'lib/cli/exit';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
-import debugLib from 'debug';
 
 const debug = debugLib( 'vip:vip-import-sql' );
 
@@ -31,11 +31,9 @@ export const siteTypeValidations = {
 	postLineExecutionProcessing: async ( {
 		appId,
 		envId,
-		opts,
 	}: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const track = trackEventWithEnv.bind( null, appId, envId );
-		const { blogIds } = opts;
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
 		debug(
@@ -45,7 +43,7 @@ export const siteTypeValidations = {
 		);
 
 		// if site is a multisite but import sql is not
-		if ( ! blogIds ) {
+		if ( ! isMultiSite ) {
 			if ( isMultiSite && ! isMultiSiteSqlDump ) {
 				await track( 'import_sql_command_error', {
 					error_type: 'multisite-but-not-multisite-sql-dump',

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -28,25 +28,34 @@ export const siteTypeValidations = {
 			isMultiSiteSqlDump = true;
 		}
 	},
-	postLineExecutionProcessing: async ( { appId, envId }: PostLineExecutionProcessingParams ) => {
+	postLineExecutionProcessing: async ( { appId, envId, opts }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const track = trackEventWithEnv.bind( null, appId, envId );
+		const { subsite: subsiteId } = opts;
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
 		debug( `The SQL dump provided is ${ isMultiSiteSqlDump ? 'from a multisite.' : 'not from a multisite' }\n` );
 
 		// if site is a multisite but import sql is not
-		if ( isMultiSite && ! isMultiSiteSqlDump ) {
-			await track( 'import_sql_command_error', { error_type: 'multisite-but-not-multisite-sql-dump' } );
+		if ( ! subsiteId ) {
+			if ( isMultiSite && ! isMultiSiteSqlDump ) {
+				await track( 'import_sql_command_error', { error_type: 'multisite-but-not-multisite-sql-dump' } );
 
-			throw new Error( 'You have provided a non-multisite SQL dump file for import into a multisite.' );
-		}
+				throw new Error( 'You have provided a non-multisite SQL dump file for import into a multisite.' );
+			}
 
-		// if site is a single site but import sql is for a multi site
-		if ( ! isMultiSite && isMultiSiteSqlDump ) {
-			await track( 'import_sql_command_error', { error_type: 'not-multisite-with-multisite-sql-dump' } );
+			// if site is a single site but import sql is for a multi site
+			if ( ! isMultiSite && isMultiSiteSqlDump ) {
+				await track( 'import_sql_command_error', { error_type: 'not-multisite-with-multisite-sql-dump' } );
 
-			throw new Error( 'You have provided a multisite SQL dump file for import into a single site (non-multisite).' );
+				throw new Error( 'You have provided a multisite SQL dump file for import into a single site (non-multisite).' );
+			}
+		} else {
+			// validations for when the intended import of for a multisite subsite
+
+			// if !isMultiSite throw error
+
+			// if ! isMultiSiteSqlDump throw error
 		}
 	},
 };

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -304,10 +304,40 @@ export const getTableNames = () => {
 };
 
 const checkForTableName = line => {
-	const matches = line.match( /(?<=^CREATE\sTABLE\s)`?(?:wp_[\d+_]?\w+)`?/ );
+	const matches = line.match( /(?<=^CREATE\sTABLE\s)`?(?:(wp_[\d+_]?\w+))`?/ );
+	const chalkColors = [
+		// commenting out common terminal bg colors
+		// commenting out red, yellow, green as they are indicators of failure, warning, success
+		// 'black',
+		// 'red',
+		// 'green',
+		// 'yellow',
+		'blue',
+		'magenta',
+		'cyan',
+		// 'white',
+		// 'blackBright', default color for primary site
+		'redBright',
+		'greenBright',
+		'yellowBright',
+		'blueBright',
+		'magentaBright',
+		'cyanBright',
+		'whiteBright',
+	];
 	if ( matches ) {
+		const tableName = matches[ 1 ];
+		let color;
+		// just get the first digit, so 3 will have the same color as 34
+		const tableIntMatch = tableName.match( /\d/ );
+		if ( ! tableIntMatch || tableName === 'wp_a8c_cron_control_jobs' ) {
+			color = 'blackBright';
+		} else {
+			// minus 1 since subsite indices start at 2
+			color = chalkColors[ tableIntMatch[ 0 ] - 1 ];
+		}
 		// we should only have one match if we have any since we're looking at the start of the string
-		tableNames.push( matches[ 0 ] );
+		tableNames.push( chalk[ color ]( tableName ) );
 	}
 };
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -305,39 +305,12 @@ export const getTableNames = () => {
 
 const checkForTableName = line => {
 	const matches = line.match( /(?<=^CREATE\sTABLE\s)`?(?:(wp_[\d+_]?\w+))`?/ );
-	const chalkColors = [
-		// commenting out common terminal bg colors
-		// commenting out red, yellow, green as they are indicators of failure, warning, success
-		// 'black',
-		// 'red',
-		// 'green',
-		// 'yellow',
-		'blue',
-		'magenta',
-		'cyan',
-		// 'white',
-		// 'blackBright', default color for primary site
-		'redBright',
-		'greenBright',
-		'yellowBright',
-		'blueBright',
-		'magentaBright',
-		'cyanBright',
-		'whiteBright',
-	];
 	if ( matches ) {
 		const tableName = matches[ 1 ];
-		let color;
-		// just get the first digit, so 3 will have the same color as 34
+		// get table index matching for blog_id grouping
 		const tableIntMatch = tableName.match( /\d/ );
-		if ( ! tableIntMatch || tableName === 'wp_a8c_cron_control_jobs' ) {
-			color = 'blackBright';
-		} else {
-			// minus 1 since subsite indices start at 2
-			color = chalkColors[ tableIntMatch[ 0 ] - 1 ];
-		}
 		// we should only have one match if we have any since we're looking at the start of the string
-		tableNames.push( chalk[ color ]( tableName ) );
+		tableNames.push( tableName );
 	}
 };
 


### PR DESCRIPTION
## Description

* get isVIP from the public API so we can gate feature availability to staff during development
* displays the tables that will be imported as part of the SQL import process
* Prompts the user once, and adds friction by requiring the domain of the import

![image](https://user-images.githubusercontent.com/1752747/110743113-84d60d00-8205-11eb-82ec-3ee42e855645.png)

### Test Plan

#### Jest

`npm t` for automated tests.

#### Manual Test plan

1. Checkout this branch
1. Execute an import for an unlaunched non-multisite app `npm run build && ./dist/bin/vip-import-sql.js @{id}.develop ~/your-sql-dump.sql`
1. Note that the list of tables that will be imported are listed and that you must type the domain name of the app as confirmation.
2. Execute an import for a launched multisite app `npm run build && ./dist/bin/vip-import-sql.js @{id}.production ~/multisite-dump.sql`
3. Note that the list of tables that will be imported are listed and separated by blog_id and that confirmation to proceed requires you to type the domain name.
4. Logout of the CLI
5. Login as a non isVIP user
6. Retry the imported into a launched multisite and note that you cannot proceed 

Closes #691 
Closes #693 
Closes #695 
Closes #696 


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.3.2)_