### PR TITLE
SQL Import: Apply a lower file size limit for launched envs

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -125,10 +125,11 @@ const gates = async ( app, env, fileName ) => {
 			launched: !! env?.launched,
 		} );
 		exit.withError(
-			`The sql import file size (${ fileSize } bytes) exceeds the limit (${ maxFileSize } bytes).\n` +
-				env.launched
-				? 'Note: This limit is lower for launched environments to maintain site stability.\n'
-				: '' + 'Please split it into multiple files or contact support for assistance.'
+			`The sql import file size (${ fileSize } bytes) exceeds the limit (${ maxFileSize } bytes).` +
+				( env.launched
+					? ' Note: This limit is lower for launched environments to maintain site stability.'
+					: '' ) +
+				'\n\nPlease split it into multiple files or contact support for assistance.'
 		);
 	}
 

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -334,7 +334,10 @@ If you are confident the file does not contain unsupported statements, you can r
 			progressTracker.stepSuccess( 'upload' );
 			await track( 'import_sql_upload_complete' );
 		} catch ( uploadError ) {
-			await track( 'import_sql_command_error', { error_type: 'upload_failed', uploadError } );
+			await track( 'import_sql_command_error', {
+				error_type: 'upload_failed',
+				upload_error: uploadError,
+			} );
 
 			progressTracker.stepFailed( 'upload' );
 			return failWithError( uploadError );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -267,7 +267,9 @@ Processing the SQL import for your environment...
 
 			if ( typeof outputFileName !== 'string' ) {
 				progressTracker.stepFailed( 'replace' );
-				return failWithError( 'Unable to determine location of the intermediate search & replace file.' );
+				return failWithError(
+					'Unable to determine location of the intermediate search & replace file.'
+				);
 			}
 
 			fileNameToUpload = outputFileName;
@@ -277,10 +279,7 @@ Processing the SQL import for your environment...
 		}
 
 		// SQL file validations
-		const validations = [
-			staticSqlValidations,
-			siteTypeValidations,
-		];
+		const validations = [ staticSqlValidations, siteTypeValidations ];
 
 		if ( skipValidate ) {
 			progressTracker.stepSkipped( 'validate' );
@@ -294,7 +293,9 @@ Processing the SQL import for your environment...
 				console.log( '' );
 				return failWithError( `${ validateErr.message }
 
-If you are confident the file does not contain unsupported statements, you can retry the command with the ${ chalk.yellow( '--skip-validate' ) } option.
+If you are confident the file does not contain unsupported statements, you can retry the command with the ${ chalk.yellow(
+		'--skip-validate'
+	) } option.
 ` );
 			}
 		}

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -16,11 +16,7 @@ import debugLib from 'debug';
  * Internal dependencies
  */
 import command from 'lib/cli/command';
-import {
-	currentUserCanImportForApp,
-	isSupportedApp,
-	SQL_IMPORT_FILE_SIZE_LIMIT,
-} from 'lib/site-import/db-file-import';
+import { currentUserCanImportForApp, isSupportedApp } from 'lib/site-import/db-file-import';
 import { importSqlCheckStatus } from 'lib/site-import/status';
 import { checkFileAccess, getFileSize, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
 import { trackEventWithEnv } from 'lib/tracker';
@@ -111,14 +107,6 @@ const gates = async ( app, env, fileName ) => {
 	if ( ! fileSize ) {
 		await track( 'import_sql_command_error', { error_type: 'sqlfile-empty' } );
 		exit.withError( `File '${ fileName }' is empty.` );
-	}
-
-	if ( fileSize > SQL_IMPORT_FILE_SIZE_LIMIT ) {
-		await track( 'import_sql_command_error', { error_type: 'sqlfile-toobig' } );
-		exit.withError(
-			`The sql import file size (${ fileSize } bytes) exceeds the limit (${ SQL_IMPORT_FILE_SIZE_LIMIT } bytes).` +
-				'Please split it into multiple files or contact support for assistance.'
-		);
 	}
 
 	if ( ! env?.importStatus ) {

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -22,10 +22,6 @@ import debugLib from 'debug';
  */
 import API from 'lib/api';
 import { MB_IN_BYTES } from 'lib/constants/file-size';
-import {
-	SQL_IMPORT_FILE_SIZE_LIMIT,
-	SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED,
-} from 'lib/site-import/db-file-import';
 
 const debug = debugLib( 'vip:lib/client-file-uploader' );
 
@@ -175,17 +171,6 @@ export async function uploadImportSqlFileToS3( {
 		) }%)`;
 
 		debug( `** Compression resulted in a ${ calculation } smaller file 📦 **\n` );
-	}
-
-	const maxFileSize = env.launched
-		? SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED
-		: SQL_IMPORT_FILE_SIZE_LIMIT;
-
-	if ( fileMeta.fileSize > maxFileSize ) {
-		throw `The sql import file size (${ fileMeta.fileSize } bytes) exceeds the limit (${ maxFileSize } bytes).\n` +
-			env.launched
-			? 'Note: This limit is lower for launched environments to maintain site stability.\n'
-			: '' + 'Please split it into multiple files or contact support for assistance.';
 	}
 
 	const result =

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -22,6 +22,10 @@ import debugLib from 'debug';
  */
 import API from 'lib/api';
 import { MB_IN_BYTES } from 'lib/constants/file-size';
+import {
+	SQL_IMPORT_FILE_SIZE_LIMIT,
+	SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED,
+} from 'lib/site-import/db-file-import';
 
 const debug = debugLib( 'vip:lib/client-file-uploader' );
 
@@ -171,6 +175,17 @@ export async function uploadImportSqlFileToS3( {
 		) }%)`;
 
 		debug( `** Compression resulted in a ${ calculation } smaller file 📦 **\n` );
+	}
+
+	const maxFileSize = env.launched
+		? SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED
+		: SQL_IMPORT_FILE_SIZE_LIMIT;
+
+	if ( fileMeta.fileSize > maxFileSize ) {
+		throw `The sql import file size (${ fileMeta.fileSize } bytes) exceeds the limit (${ maxFileSize } bytes).\n` +
+			env.launched
+			? 'Note: This limit is lower for launched environments to maintain site stability.\n'
+			: '' + 'Please split it into multiple files or contact support for assistance.';
 	}
 
 	const result =

--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -9,7 +9,7 @@
 import { GB_IN_BYTES, MB_IN_BYTES } from 'lib/constants/file-size';
 
 export const SQL_IMPORT_FILE_SIZE_LIMIT = 10 * GB_IN_BYTES;
-export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 500 * MB_IN_BYTES;
+export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 350 * MB_IN_BYTES;
 
 export interface AppForImport {
 	id: Number;

--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -6,9 +6,10 @@
 /**
  * Internal dependencies
  */
-import { GB_IN_BYTES } from 'lib/constants/file-size';
+import { GB_IN_BYTES, MB_IN_BYTES } from 'lib/constants/file-size';
 
 export const SQL_IMPORT_FILE_SIZE_LIMIT = 10 * GB_IN_BYTES;
+export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 500 * MB_IN_BYTES;
 
 export interface AppForImport {
 	id: Number;


### PR DESCRIPTION
## Description

Apply a different file size limit for SQL files for launched sites (to maintain site stability).

When a file is deemed too large for safely importing into a launched site (currently 350 MiB), show an error:

<img width="1215" alt="Screen Shot 2021-03-16 at 12 48 30 PM" src="https://user-images.githubusercontent.com/1587282/111348117-42259200-8656-11eb-9f31-7a3e3befbf58.png">

Unlaunched sites will continue to be subject to the previous file limit and will show the same error (minus the bit about launched sites).

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js` with a known good import file smaller than the new limit
1. Verify it is not incorrectly gated by this change
1. Copy the known good import file to a temporary location
1. Expand the file size to be greater than the limit (`truncate -s 400M /tmp/your/test/file.sql`)
1. Run `./dist/bin/vip-import-sql.js` with the expanded file against a **launched** test site
1. Verify it **is blocked** by this change and an appropriate error shown
1. Run `./dist/bin/vip-import-sql.js` with the expanded file against an **unlaunched** test site
1. Verify it **is not blocked** by this change
1. Expand the file size to be greater than the unlaunched limit (`truncate -s 11000M /tmp/your/test/file.sql`)
1. Run `./dist/bin/vip-import-sql.js` with the expanded file against an **unlaunched** test site
1. Verify it **continues to be blocked** with this change in place
