### PR TITLE
Dev-environment: Fixes path location for template file

### DIFF
--- a/src/lib/dev-environment.js
+++ b/src/lib/dev-environment.js
@@ -60,7 +60,7 @@ export const defaults = {
 	};
 } );
 
-const landoFileTemplatePath = 'assets/dev-environment.lando.template.yml.ejs';
+const landoFileTemplatePath = path.join( __dirname, '..', '..', 'assets', 'dev-environment.lando.template.yml.ejs' );
 const landoFileName = '.lando.yml';
 
 export async function startEnvironment( slug ) {


### PR DESCRIPTION

## Description

Fixes the template file reference.

## Steps to Test

1. `npm pack`
1. `npm install -g automattic-...`
1. Outside of folder where you clone this repo run: `vip dev-environment create`
1. No "File not found" error
