### PR TITLE
FORNO-555: Fix `import media status` sub command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "vip-import": "dist/bin/vip-import.js",
     "vip-import-sql": "dist/bin/vip-import-sql.js",
     "vip-import-sql-status": "dist/bin/vip-import-sql-status.js",
+    "vip-import-media": "dist/bin/vip-import-media.js",
+    "vip-import-media-status": "dist/bin/vip-import-media-status.js",
     "vip-import-validate-files": "dist/bin/vip-import-validate-files.js",
     "vip-import-validate-sql": "dist/bin/vip-import-validate-sql.js",
     "vip-search-replace": "dist/bin/vip-search-replace.js",

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -82,9 +82,10 @@ ${ chalk.red.bold( 'import all files and preserve the directory structure as is.
 
 Are you sure you want to import the contents of the url?
 `,
+	skipConfirmPrompt: true,
 } )
-	.option( 'url', 'Valid URL to download a file archive from', '' )
 	.command( 'status', 'Check the status of the current running import' )
+	.option( 'url', 'Valid URL to download a file archive from', '' )
 	.examples( examples )
 	.argv( process.argv, async ( args: string[], opts ) => {
 		const { app, env, url } = opts;

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -46,8 +46,6 @@ const START_IMPORT_MUTATION = gql`
 				importId
 				siteId
 				status
-				filesTotal
-				filesProcessed
 			}
 		}
 	}

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -17,22 +17,11 @@ import chalk from 'chalk';
  */
 import command from 'lib/cli/command';
 import API from 'lib/api';
-import {
-	currentUserCanImportForApp,
-	isSupportedApp,
-	SQL_IMPORT_FILE_SIZE_LIMIT,
-	SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED,
-} from 'lib/site-import/db-file-import';
 // eslint-disable-next-line no-duplicate-imports
 import { trackEventWithEnv } from 'lib/tracker';
-import { formatEnvironment, formatSearchReplaceValues, getGlyphForStatus } from 'lib/cli/format';
+import { formatEnvironment } from 'lib/cli/format';
 import { MediaImportProgressTracker } from 'lib/media-import/progress';
 import { mediaImportCheckStatus } from '../lib/media-import/status';
-
-export type WPSiteListType = {
-	id: string,
-	homeUrl: string,
-};
 
 const appQuery = `
 	id,
@@ -44,20 +33,13 @@ const appQuery = `
 		appId
 		type
 		name
-		launched
 		primaryDomain { name }
-		wpSites {
-			nodes {
-				homeUrl
-				id
-			}
-		}
 	}
 `;
 
 const START_IMPORT_MUTATION = gql`
-	mutation StartMediaImport($input:AppEnvironmentStartMediaImportInput) {
-		startMediaImport(input: $input) {
+	mutation StartMediaImport( $input: AppEnvironmentStartMediaImportInput ) {
+		startMediaImport( input: $input ) {
 			applicationId
 			environmentId
 			mediaImportStatus {
@@ -102,6 +84,7 @@ Are you sure you want to import the contents of the url?
 `,
 } )
 	.option( 'url', 'Valid URL to download a file archive from', '' )
+	.command( 'status', 'Check the status of the current running import' )
 	.examples( examples )
 	.argv( process.argv, async ( args: string[], opts ) => {
 		const { app, env, url } = opts;

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -94,7 +94,7 @@ Are you sure you want to import the contents of the url?
 		const [ url ] = args;
 
 		if ( ! isSupportedUrl( url ) ) {
-			console.log( chalk.red( 'Error:' ), `Invalid URL provided ${ url }\nPlease make sure that it publicly accessible web archive` );
+			console.log( chalk.red( `Error: Invalid URL provided ${ url }\nPlease make sure that it publicly accessible web archive` ) );
 			return;
 		}
 

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -94,7 +94,10 @@ Are you sure you want to import the contents of the url?
 		const [ url ] = args;
 
 		if ( ! isSupportedUrl( url ) ) {
-			console.log( chalk.red( `Error: Invalid URL provided ${ url }\nPlease make sure that it publicly accessible web archive` ) );
+			console.log( chalk.red( `
+Error: 
+	Invalid URL provided: ${ url }
+	Please make sure that it is a publicly accessible web URL containing an archive of the media files to import` ) );
 			return;
 		}
 

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -56,7 +56,7 @@ const debug = debugLib( 'vip:vip-import-media' );
 // Command examples for the `vip import media` help prompt
 const examples = [
 	{
-		usage: 'vip import media @mysite.develop --url https://domain.to/archive.zip',
+		usage: 'vip import media @mysite.develop https://<path_to_publicly_accessible_archive>',
 		description:
 			'Start a media import with the contents of the archive file in the URL',
 	},
@@ -68,28 +68,33 @@ const examples = [
 	},
 ];
 
+function isSupportedUrl( urlToTest ) {
+	const url = new URL( urlToTest );
+	return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
 command( {
 	appContext: true,
 	appQuery,
 	envContext: true,
 	module: 'import-media',
+	requiredArgs: 1,
 	requireConfirm: `
-${ chalk.red.bold( 'NOTE: If the provided archive\'s directory structure begins with `/wp-content/uploads`,' ) }
-${ chalk.red.bold( 'we will extract only the files after that path and import it. Otherwise, we will' ) }
-${ chalk.red.bold( 'import all files and preserve the directory structure as is.' ) }
+${ chalk.yellowBright.bold( 'NOTE: If the provided archive\'s directory structure begins with `/wp-content/uploads`,' ) }
+${ chalk.yellowBright.bold( 'we will extract only the files after that path and import it. Otherwise, we will' ) }
+${ chalk.yellowBright.bold( 'import all files and preserve the directory structure as is.' ) }
 
 Are you sure you want to import the contents of the url?
 `,
-	skipConfirmPrompt: true,
 } )
 	.command( 'status', 'Check the status of the current running import' )
-	.option( 'url', 'Valid URL to download a file archive from', '' )
 	.examples( examples )
 	.argv( process.argv, async ( args: string[], opts ) => {
-		const { app, env, url } = opts;
+		const { app, env } = opts;
+		const [ url ] = args;
 
-		if ( ! url ) {
-			console.log( chalk.red( 'Error:' ), 'No URL provided' );
+		if ( ! isSupportedUrl( url ) ) {
+			console.log( chalk.red( 'Error:' ), `Invalid URL provided ${ url }\nPlease make sure that it publicly accessible web archive` );
 			return;
 		}
 

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -16,7 +16,7 @@ command( )
 	.command( 'validate-files', 'Validate your media file library' )
 	.example( 'vip import sql @mysite.develop <file.sql>', 'Import the given SQL file to your site' )
 	.command( 'media', 'Import media files to your application from a compressed archive' )
-	.example( 'vip import media @mysite.develop <file.zip>', 'Import contents of the given archive file into the media library of your site' )
+	.example( 'vip import media @mysite.develop https://<path_to_publicly_accessible_archive>', 'Import contents of the given archive file into the media library of your site' )
 	.argv( process.argv, async () => {
 		await trackEvent( 'vip_import_command_execute' );
 	} );

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -92,7 +92,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 	} );
 
 	// Show help if no args passed
-	if ( !! customCommands.length && ! this.sub.length && _opts.module !== 'import-media' ) {
+	if ( !! customCommands.length && ! this.sub.length ) {
 		await trackEvent( 'command_help_view' );
 
 		this.showHelp();
@@ -410,6 +410,9 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 				info.push( { key: 'From backup', value: new Date( backup.createdAt ).toUTCString() } );
 				info.push( { key: 'Replacements', value: '\n' + formatData( replacements, 'table' ) } );
+				break;
+			case 'import-media':
+				info.push( { key: 'Archive URL', value: this.sub } );
 				break;
 			default:
 		}

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -92,7 +92,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 	} );
 
 	// Show help if no args passed
-	if ( !! customCommands.length && ! this.sub.length ) {
+	if ( !! customCommands.length && ! this.sub.length && _opts.module !== 'import-media' ) {
 		await trackEvent( 'command_help_view' );
 
 		this.showHelp();


### PR DESCRIPTION
## Description

This PR re-adds the `import media status` sub-command. It converts the `--url` option for the `import media` command to a required argument.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media.js -h`
1. Should show the subcommand

```
  Usage: vip import-media.js [options] [command]
  
  Commands:
    status  Check the status of the current running import
```
5. Run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media.js`
6. Should show the help menu again
7. Run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media.js @70.production  https://beruberuberu-test.go-vip.co/wp-content/uploads/wp-content.tar.gz`

```
===================================
+ App: test-ms-subdir-01-vipv2-net (id: 70)
+ Environment: production (id: 70)
+ Archive URL: https://beruberuberu-test.go-vip.co/wp-content/uploads/wp-content.tar.gz
===================================
✔ 
NOTE: If the provided archive's directory structure begins with `/wp-content/uploads`,
we will extract only the files after that path and import it. Otherwise, we will
import all files and preserve the directory structure as is.

Are you sure you want to import the contents of the url?
 (y/N) · false
```
8. If you provide a local file the following error should be displayed
```
Error: 
	Invalid URL provided: ${ url }
	Please make sure that it is a publicly accessible web URL containing an archive of the media files to import
```