### PR TITLE
FORNO-557: Display Media Import Global Errors

### DIFF
--- a/src/lib/media-import/status.js
+++ b/src/lib/media-import/status.js
@@ -116,7 +116,7 @@ function buildErrorMessage( importFailed ) {
 	}
 
 	message += chalk.red( `Error: ${ importFailed.error }` );
-	message += 'If this error persists, please contact support';
+	message += 'If this error persists and you are not sure on how to fix, please contact support';
 	return message;
 }
 

--- a/src/lib/media-import/status.js
+++ b/src/lib/media-import/status.js
@@ -21,18 +21,10 @@ import { RunningSprite } from '../cli/format';
 
 const IMPORT_MEDIA_PROGRESS_POLL_INTERVAL = 1000;
 
-/*
- * TODO: Add support to
- *  failureDetails {
- *		previousStatus
- *		globalErrors
- *	}
- * (when Parker is ready)
- */
 const IMPORT_MEDIA_PROGRESS_QUERY = gql`
-	query App($appId: Int = 1, $envId: Int = 1) {
-		app(id: $appId) {
-			environments(id: $envId ) {
+	query App( $appId: Int, $envId: Int ) {
+		app( id: $appId ) {
+			environments( id: $envId ) {
 			id
 			name
 			type
@@ -43,6 +35,14 @@ const IMPORT_MEDIA_PROGRESS_QUERY = gql`
 				status
 				filesTotal
 				filesProcessed
+				failureDetails {
+					previousStatus
+					globalErrors
+					fileErrors {
+							fileName
+							errors
+					}
+				}
 			}
 		}
 	}
@@ -100,15 +100,23 @@ export function getGlyphForStatus( status: string, runningSprite: RunningSprite 
 }
 
 function buildErrorMessage( importFailed ) {
-	let message = chalk.red( `Error: ${ importFailed.error }` );
+	let message = '=============================================================\n';
 
 	if ( 'FAILED' === importFailed.status ) {
-		message += `
-${ importFailed.filesProcessed }/${ importFailed.filesTotal } files imported.
-
-If this error persists, please contact support.
-`;
+		const globalFailureDetails = importFailed.failureDetails;
+		if ( globalFailureDetails ) {
+			message += `${ chalk.yellow( 'Import failed at phase: ' ) }`;
+			message += `${ chalk.yellowBright( globalFailureDetails.previousStatus ) }\n`;
+			message += chalk.yellow( 'Errors:' );
+			globalFailureDetails.globalErrors.forEach( value => {
+				message += `\n\t- ${ chalk.yellowBright( value ) }`;
+			} );
+			return message;
+		}
 	}
+
+	message += chalk.red( `Error: ${ importFailed.error }` );
+	message += 'If this error persists, please contact support';
 	return message;
 }
 
@@ -189,8 +197,7 @@ ${ maybeExitPrompt }
 					progressTracker.setStatus( mediaImportStatus );
 					overallStatus = 'FAILED';
 					setSuffixAndPrint();
-					/* TODO: Here we will add failure details */
-					return reject( { ...mediaImportStatus, error: 'Import failed' } );
+					return reject( { ...mediaImportStatus, error: 'Import FAILED' } );
 				}
 
 				progressTracker.setStatus( mediaImportStatus );


### PR DESCRIPTION
## Description

This PR funnels the Global Errors for a Media Import and surfaces them onto the CLI .

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Make sure your local GOOP, Parker and MMS are up and connected.
1. Change the site number for Import number 3 to 1000 in MMS
1. Run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media-status.js @1000.production `
1. Verify response:
```

=============================================================
Checking the Media import status for your environment...
Processed Files: 100/300 - 33% ✕
=============================================================
Status: FAILED ✕
App: test1-go-vip (PRODUCTION)
=============================================================
(Press ^C to hide progress. The import will continue in the background.)

=============================================================
Import failed at phase: INITIALIZING

Errors:
        - url is not a URL
        - Timeout
```

