### PR TITLE
FORNO-557: Fix fs promises module 

### DIFF
--- a/src/lib/media-import/status.js
+++ b/src/lib/media-import/status.js
@@ -8,7 +8,7 @@
  */
 import chalk from 'chalk';
 import gql from 'graphql-tag';
-import * as fs from 'fs/promises';
+import { promises as fsp } from 'fs';
 import * as path from 'path';
 
 /**
@@ -248,7 +248,7 @@ ${ maybeExitPrompt }
 			const formattedData = buildFileErrors( fileErrors, exportFileErrorsToJson );
 			const errorsFile = `media-import-${ app.name }-${ Date.now() }${ !! exportFileErrorsToJson ? '.json' : '.txt' }`;
 			try {
-				await fs.writeFile( errorsFile, formattedData );
+				await fsp.writeFile( errorsFile, formattedData );
 				progressTracker.suffix += `\n${ chalk.yellow( `All errors have been exported to ${ chalk.bold( path.resolve( errorsFile ) ) }` ) }\n\n`;
 			} catch ( writeFileErr ) {
 				progressTracker.suffix += `\n${ chalk.red( `Could not export errors to file\n${ writeFileErr }` ) }\n\n`;


### PR DESCRIPTION
## Description

There is no dedicated module for `fs/promises` in node v12 LTS. Therefore, the media import status command with file errors is throwing :

```
  ✕  Unexpected error: Please contact VIP Support with the following error:
  Error: Cannot find module 'fs/promises'
```

This PR fixes the issue by directly accessing the `promises` class from the legacy `fs` module

## Steps to Test

1. Check out PR.
1. Switch to node version 10.x or 12.5 LTS using `nvm`
1. Run `npm run build`
1. Ensure your local GOOP, Parker and MMS are up and connected
1. Change import 4 site ID to 70 in your local MMS DB and rebuild it
1. Run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip import media status @70.production -E`
1. Verify the response and the file errors:

```
=============================================================
Checking the Media import status for your environment...
Processed Files: 100/300 - 33% ✓
=============================================================
Status: COMPLETED ✓ : The Imported files should be visible on your site testingmapped.com
App: test-ms-subdir-01-vipv2-net (PRODUCTION)
=============================================================

⚠️ 1 file error(s) found
All errors have been exported to /Users/saroshaga/Projects/Automattic/vip/media-import-test-ms-subdir-01-vipv2-net-1617941496320.json

```
