### PR TITLE
fix bug and adds example

### DIFF
--- a/__tests__/lib/dev-environment.js
+++ b/__tests__/lib/dev-environment.js
@@ -12,7 +12,7 @@ import fs from 'fs';
 /**
  * Internal dependencies
  */
-import { getEnvironmentPath, createEnvironment, startEnvironment, generateInstanceData, destroyEnvironment } from 'lib/dev-environment';
+import { getEnvironmentPath, createEnvironment, startEnvironment, generateInstanceData, destroyEnvironment, getParamInstanceData } from 'lib/dev-environment';
 
 jest.mock( 'xdg-basedir', () => ( {} ) );
 jest.mock( 'fs' );
@@ -219,6 +219,23 @@ describe( 'lib/dev-environment', () => {
 			},
 		] )( 'should process options and use defaults', async input => {
 			const result = generateInstanceData( input.slug, input.options );
+
+			expect( result ).toStrictEqual( input.expected );
+		} );
+	} );
+	describe( 'getParamInstanceData', () => {
+		it.each( [
+			{
+				param: 5.6,
+				option: 'wordpress',
+				expected: {
+					image: 'wpvipdev/wordpress',
+					mode: 'image',
+					tag: '5.6',
+				},
+			},
+		] )( 'should process options and use defaults', async input => {
+			const result = getParamInstanceData( input.param, input.option );
 
 			expect( result ).toStrictEqual( input.expected );
 		} );

--- a/src/bin/vip-dev-environment-create.js
+++ b/src/bin/vip-dev-environment-create.js
@@ -30,6 +30,10 @@ const examples = [
 		usage: `${ DEV_ENVIRONMENT_COMMAND } create --slug test`,
 		description: 'Creates a local dev environment named "test", this enables to create multiple independend environments',
 	},
+	{
+		usage: `${ DEV_ENVIRONMENT_COMMAND } create --multisite --wordpress "5.6" --client-code "~/git/my_code"`,
+		description: 'Creates a local dev environment that is multisite and is using WP 5.6 and client code is expected to be in "~/git/my_code"',
+	},
 ];
 
 command()

--- a/src/lib/dev-environment.js
+++ b/src/lib/dev-environment.js
@@ -267,8 +267,10 @@ export function generateInstanceData( slug, options ) {
 	return instanceData;
 }
 
-function getParamInstanceData( param, type ) {
-	if ( param ) {
+export function getParamInstanceData( passedParam, type ) {
+	if ( passedParam ) {
+		// cast to string
+		const param = passedParam + '';
 		if ( param.includes( '/' ) ) {
 			return {
 				mode: 'local',


### PR DESCRIPTION


## Description

Fix bug if the param is number e.g. `vip dev-environment create --wordpress 5.6`

+ 

Adds an example for create command

## Steps to Test

1. Run `vip dev-environment create --wordpress 5.6`
2. Run `vip dev-environment create --help`