### PR TITLE
Multisite sql dump detection

### DIFF
--- a/__tests__/lib/validations/is-multi-site-sql-dump.js
+++ b/__tests__/lib/validations/is-multi-site-sql-dump.js
@@ -17,6 +17,7 @@ describe( 'is-multi-site-sql-dump', () => {
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_2_posts' ) ).toBeTruthy();
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_23_posts' ) ).toBeTruthy();
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_2345235_posts' ) ).toBeTruthy();
+			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_blogs' ) ).toBeTruthy();
 		} );
 		it( 'returns false for non-multi site table creations', () => {
 			expect( sqlDumpLineIsMultiSite( 'CREATE TABLE wp_posts' ) ).toBeFalsy();

--- a/src/lib/validations/is-multi-site-sql-dump.js
+++ b/src/lib/validations/is-multi-site-sql-dump.js
@@ -13,10 +13,10 @@
 import { getReadInterface } from 'lib/validations/line-by-line';
 import * as exit from 'lib/cli/exit';
 
-const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d+_[a-z0-9_]*)/i;
+const SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX = /^CREATE TABLE `?(wp_\d+_[a-z0-9_]*|wp_blogs)/i;
 
 export function sqlDumpLineIsMultiSite( line: string ): boolean {
-	// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options
+	// determine if we're on a CREATE TABLE statement line what has eg. wp_\d_options OR wp_blogs
 	if ( SQL_DUMP_CREATE_TABLE_IS_MULTISITE_REGEX.test( line ) ) {
 		return true;
 	}


### PR DESCRIPTION

## Description

Updates multisite sql dump detection.

If the sql dump does not have subsites yet the detection would fail as we weould be looking for  wp_<subsite_id>_<table> . I kept that but also added that if we find wp_blogs table, it is considered multisite.

The reason to keep the original is for when users wants to upload only one subsite data they would only use sql dump with tables matching the first pattern not wp_blogs table.

## Steps to Test

The unittest coverage is in place.

Other than that running `vip @2891 import sql /tmp/test.sql ` with file valid multisite sql dump should pass for multisite and fail for singlesite and vice versa.
