### PR TITLE
Dev-environment Support @naming

### DIFF
--- a/__tests__/lib/dev-environment.js
+++ b/__tests__/lib/dev-environment.js
@@ -12,7 +12,13 @@ import fs from 'fs';
 /**
  * Internal dependencies
  */
-import { getEnvironmentPath, createEnvironment, startEnvironment, generateInstanceData, destroyEnvironment, getParamInstanceData } from 'lib/dev-environment';
+import { getEnvironmentPath,
+	createEnvironment,
+	startEnvironment,
+	generateInstanceData,
+	destroyEnvironment,
+	getParamInstanceData,
+	getEnvironmentName } from 'lib/dev-environment';
 
 jest.mock( 'xdg-basedir', () => ( {} ) );
 jest.mock( 'fs' );
@@ -259,6 +265,39 @@ describe( 'lib/dev-environment', () => {
 			const filePath = getEnvironmentPath( name );
 
 			expect( filePath ).toBe( `${ os.tmpdir() }/vip/dev-environment/${ name }` );
+		} );
+	} );
+	describe( 'getEnvironmentName', () => {
+		it.each( [
+			{ // default value
+				options: {},
+				expected: 'vip-local',
+			},
+			{ // use custom name
+				options: {
+					slug: 'foo',
+				},
+				expected: 'foo',
+			},
+			{ // construct name from app and env
+				options: {
+					app: '123',
+					env: 'bar.car',
+				},
+				expected: '123-bar.car',
+			},
+			{ // custom name takes precedence
+				options: {
+					slug: 'foo',
+					app: '123',
+					env: 'bar.car',
+				},
+				expected: 'foo',
+			},
+		] )( 'should get correct name', async input => {
+			const result = getEnvironmentName( input.options );
+
+			expect( result ).toStrictEqual( input.expected );
 		} );
 	} );
 } );

--- a/src/bin/vip-dev-environment-create.js
+++ b/src/bin/vip-dev-environment-create.js
@@ -15,29 +15,37 @@ import chalk from 'chalk';
  * Internal dependencies
  */
 import command from 'lib/cli/command';
-import { defaults, createEnvironment, printEnvironmentInfo } from 'lib/dev-environment';
-import { DEV_ENVIRONMENT_COMMAND } from 'lib/constants/dev-environment';
+import { createEnvironment, printEnvironmentInfo, getEnvironmentName } from 'lib/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 // Command examples
 const examples = [
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } create`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create`,
 		description: 'Creates a local dev environment',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } create --slug test`,
-		description: 'Creates a local dev environment named "test", this enables to create multiple independend environments',
+		usage: `vip @123.production ${ DEV_ENVIRONMENT_SUBCOMMAND } create`,
+		description: 'Creates a local dev environment for prodaction site for id 123',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } create --multisite --wordpress "5.6" --client-code "~/git/my_code"`,
+		usage: `vip @123.production ${ DEV_ENVIRONMENT_SUBCOMMAND } create --slug 'my_site'`,
+		description: 'Creates a local dev environment for prodaction site for id 123 aliased as "my_site"',
+	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --slug test`,
+		description: 'Creates a blank local dev environment with custom name "test", this enables to create multiple independend environments',
+	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress "5.6" --client-code "~/git/my_code"`,
 		description: 'Creates a local dev environment that is multisite and is using WP 5.6 and client code is expected to be in "~/git/my_code"',
 	},
 ];
 
 command()
-	.option( 'slug', `Custom name of the dev environment (default: "${ defaults.environmentSlug }")` )
+	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'title', 'Title for the WordPress site (default: "VIP Dev")' )
 	.option( 'multisite', 'Enable multisite install' )
 	.option( 'php', 'Use a specific PHP version' )
@@ -47,12 +55,12 @@ command()
 	.option( 'client-code', 'Use the client code from a local directory or VIP skeleton (default: use the VIP skeleton)' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const slug = opt.slug || defaults.environmentSlug;
+		const slug = getEnvironmentName( opt );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 
 		const extraCommandParmas = opt.slug ? ` --slug ${ opt.slug }` : '';
-		const startCommand = chalk.bold( DEV_ENVIRONMENT_COMMAND + ' start' + extraCommandParmas );
+		const startCommand = chalk.bold( DEV_ENVIRONMENT_FULL_COMMAND + ' start' + extraCommandParmas );
 
 		try {
 			await createEnvironment( slug, opt );

--- a/src/bin/vip-dev-environment-destroy.js
+++ b/src/bin/vip-dev-environment-destroy.js
@@ -15,28 +15,28 @@ import chalk from 'chalk';
  * Internal dependencies
  */
 import command from 'lib/cli/command';
-import { defaults, destroyEnvironment } from 'lib/dev-environment';
-import { DEV_ENVIRONMENT_COMMAND } from 'lib/constants/dev-environment';
+import { getEnvironmentName, destroyEnvironment } from 'lib/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 // Command examples
 const examples = [
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } destroy`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } destroy`,
 		description: 'Destroys a default local dev environment',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } destroy --slug foo`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } destroy --slug foo`,
 		description: 'Destroys a local dev environment named foo',
 	},
 ];
 
 command()
-	.option( 'slug', `Custom name of the dev environment (default: "${ defaults.environmentSlug }")` )
+	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const slug = opt.slug || defaults.environmentSlug;
+		const slug = getEnvironmentName( opt );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 

--- a/src/bin/vip-dev-environment-info.js
+++ b/src/bin/vip-dev-environment-info.js
@@ -14,25 +14,33 @@ import debugLib from 'debug';
  * Internal dependencies
  */
 import command from 'lib/cli/command';
-import { defaults, printEnvironmentInfo, printAllEnvironmentsInfo, handleCLIException } from 'lib/dev-environment';
-import { DEV_ENVIRONMENT_COMMAND } from 'lib/constants/dev-environment';
+import { getEnvironmentName, printEnvironmentInfo, printAllEnvironmentsInfo, handleCLIException } from 'lib/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 // Command examples
 const examples = [
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } info`,
-		description: 'Return information about a local dev environment',
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info -all`,
+		description: 'Return information about all local dev environments',
+	},
+	{
+		usage: `vip @123 ${ DEV_ENVIRONMENT_SUBCOMMAND } info`,
+		description: 'Return information about dev environment for site 123',
+	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info -slug my_site`,
+		description: 'Return information about a local dev environment named "my_site"',
 	},
 ];
 
 command()
-	.option( 'slug', `Custom name of the dev environment (default: "${ defaults.environmentSlug }")` )
+	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'all', 'Show Info for all local dev environemnts' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const slug = opt.slug || defaults.environmentSlug;
+		const slug = getEnvironmentName( opt );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 
@@ -43,6 +51,6 @@ command()
 				await printEnvironmentInfo( slug );
 			}
 		} catch ( e ) {
-			handleCLIException( e, opt.slug );
+			handleCLIException( e );
 		}
 	} );

--- a/src/bin/vip-dev-environment-start.js
+++ b/src/bin/vip-dev-environment-start.js
@@ -14,30 +14,30 @@ import debugLib from 'debug';
  * Internal dependencies
  */
 import command from 'lib/cli/command';
-import { defaults, startEnvironment, handleCLIException } from 'lib/dev-environment';
-import { DEV_ENVIRONMENT_COMMAND } from 'lib/constants/dev-environment';
+import { getEnvironmentName, startEnvironment, handleCLIException } from 'lib/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 // Command examples
 const examples = [
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } start`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } start`,
 		description: 'Starts a local dev environment',
 	},
 ];
 
 command()
-	.option( 'slug', `Custom name of the dev environment (default: "${ defaults.environmentSlug }")` )
+	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const slug = opt.slug || defaults.environmentSlug;
+		const slug = getEnvironmentName( opt );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 
 		try {
 			await startEnvironment( slug );
 		} catch ( e ) {
-			handleCLIException( e, opt.slug );
+			handleCLIException( e );
 		}
 	} );

--- a/src/bin/vip-dev-environment-stop.js
+++ b/src/bin/vip-dev-environment-stop.js
@@ -15,24 +15,24 @@ import chalk from 'chalk';
  * Internal dependencies
  */
 import command from 'lib/cli/command';
-import { defaults, stopEnvironment, handleCLIException } from 'lib/dev-environment';
-import { DEV_ENVIRONMENT_COMMAND } from 'lib/constants/dev-environment';
+import { getEnvironmentName, stopEnvironment, handleCLIException } from 'lib/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 // Command examples
 const examples = [
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } stop`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } stop`,
 		description: 'Stops a local dev environment',
 	},
 ];
 
 command()
-	.option( 'slug', `Custom name of the dev environment (default: "${ defaults.environmentSlug }")` )
+	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const slug = opt.slug || defaults.environmentSlug;
+		const slug = getEnvironmentName( opt );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 
@@ -42,6 +42,6 @@ command()
 			const message = chalk.green( '✓' ) + ' environment stopped.\n';
 			console.log( message );
 		} catch ( e ) {
-			handleCLIException( e, opt.slug );
+			handleCLIException( e );
 		}
 	} );

--- a/src/bin/vip-dev-environment-wp.js
+++ b/src/bin/vip-dev-environment-wp.js
@@ -14,28 +14,28 @@ import debugLib from 'debug';
  * Internal dependencies
  */
 import command from 'lib/cli/command';
-import { defaults, handleCLIException, runWp } from 'lib/dev-environment';
-import { DEV_ENVIRONMENT_COMMAND } from 'lib/constants/dev-environment';
+import { getEnvironmentName, handleCLIException, runWp } from 'lib/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 // Command examples
 const examples = [
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } wp -- post list`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } wp -- post list`,
 		description: 'Use dev-environment to run `wp post list`',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_COMMAND } wp --slug my_site -- shell`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } wp --slug my_site -- shell`,
 		description: 'Use dev-environment "my_site" to run interactive wp shell',
 	},
 ];
 
 command( { wildcardCommand: true } )
-	.option( 'slug', `Custom name of the dev environment (default: "${ defaults.environmentSlug }")` )
+	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
-		const slug = opt.slug || defaults.environmentSlug;
+		const slug = getEnvironmentName( opt );
 
 		try {
 			// to avoid confusion let's enforce -- as a spliter for arguments for this command and wp itself
@@ -52,6 +52,6 @@ command( { wildcardCommand: true } )
 
 			await runWp( slug, arg );
 		} catch ( e ) {
-			handleCLIException( e, opt.slug );
+			handleCLIException( e );
 		}
 	} );

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -1,1 +1,2 @@
-export const DEV_ENVIRONMENT_COMMAND = 'vip dev-environment';
+export const DEV_ENVIRONMENT_SUBCOMMAND = 'dev-environment';
+export const DEV_ENVIRONMENT_FULL_COMMAND = `vip ${ DEV_ENVIRONMENT_SUBCOMMAND }`;

--- a/src/lib/dev-environment.js
+++ b/src/lib/dev-environment.js
@@ -20,7 +20,7 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
-import { DEV_ENVIRONMENT_COMMAND } from './constants/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from './constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -401,15 +401,34 @@ export function getEnvironmentPath( name: string ) {
 	return path.join( mainEnvironmentPath, 'vip', 'dev-environment', name );
 }
 
-export function handleCLIException( exception: Error, slug: string ) {
+export function handleCLIException( exception: Error ) {
 	const errorPrefix = chalk.red( 'Error:' );
 	if ( 'Environment not found.' === exception.message ) {
-		const extraCommandParmas = slug ? ` --slug ${ slug }` : '';
-		const createCommand = chalk.bold( DEV_ENVIRONMENT_COMMAND + ' create' + extraCommandParmas );
+		const createCommand = chalk.bold( DEV_ENVIRONMENT_FULL_COMMAND + ' create' );
 
 		const message = `Environment doesn't exist.\n\n\nTo create a new environment run:\n\n${ createCommand }\n`;
 		console.log( errorPrefix, message );
 	} else {
 		console.log( errorPrefix, exception.message );
 	}
+}
+
+type EnvironmentNameOptions = {
+	slug: string,
+	app: string,
+	env: string,
+}
+
+export function getEnvironmentName( options: EnvironmentNameOptions ) {
+	if ( options.slug ) {
+		return options.slug;
+	}
+
+	if ( options.app ) {
+		const envSuffix = options.env ? `-${ options.env }` : '';
+
+		return options.app + envSuffix;
+	}
+
+	return defaults.environmentSlug;
 }


### PR DESCRIPTION
## Description

This adds support for `@<siteId>.<envName>` notation for dev-environment subcommands. For now, we only infer the name of the environment. The next step is to use provided data to fetch some information on creation to init some defaults correctly.

## Steps to Test

1. `vip @2891.develop dev-environment create`

