### PR TITLE
Update/create error

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -11,7 +11,7 @@ import { prompt, selectRunMock } from 'enquirer';
  * Internal dependencies
  */
 
-import { getEnvironmentName, processComponentOptionInput, promptForText, promptForComponent } from 'lib/dev-environment/dev-environment-cli';
+import { getEnvironmentName, getEnvironmentStartCommand, processComponentOptionInput, promptForText, promptForComponent } from 'lib/dev-environment/dev-environment-cli';
 
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
@@ -54,6 +54,39 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			},
 		] )( 'should get correct name', async input => {
 			const result = getEnvironmentName( input.options );
+
+			expect( result ).toStrictEqual( input.expected );
+		} );
+	} );
+	describe( 'getEnvironmentStartCommand', () => {
+		it.each( [
+			{ // default value
+				options: {},
+				expected: 'vip dev-environment start',
+			},
+			{ // use custom name
+				options: {
+					slug: 'foo',
+				},
+				expected: 'vip dev-environment start --slug foo',
+			},
+			{ // construct name from app and env
+				options: {
+					app: '123',
+					env: 'bar.car',
+				},
+				expected: 'vip @123.bar.car dev-environment start',
+			},
+			{ // custom name takes precedence
+				options: {
+					slug: 'foo',
+					app: '123',
+					env: 'bar.car',
+				},
+				expected: 'vip dev-environment start --slug foo',
+			},
+		] )( 'should get correct start command', async input => {
+			const result = getEnvironmentStartCommand( input.options );
 
 			expect( result ).toStrictEqual( input.expected );
 		} );

--- a/src/bin/vip-dev-environment-create.js
+++ b/src/bin/vip-dev-environment-create.js
@@ -16,7 +16,7 @@ import chalk from 'chalk';
  */
 import command from 'lib/cli/command';
 import { createEnvironment, printEnvironmentInfo } from 'lib/dev-environment/dev-environment-core';
-import { getEnvironmentName, promptForArguments } from 'lib/dev-environment/dev-environment-cli';
+import { getEnvironmentName, promptForArguments, getEnvironmentStartCommand } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -66,8 +66,7 @@ command()
 			siteSlug: slug,
 		};
 
-		const extraCommandParmas = opt.slug ? ` --slug ${ opt.slug }` : '';
-		const startCommand = chalk.bold( DEV_ENVIRONMENT_FULL_COMMAND + ' start' + extraCommandParmas );
+		const startCommand = chalk.bold( getEnvironmentStartCommand( opt ) );
 
 		try {
 			await createEnvironment( instanceDataWithSlug );
@@ -77,7 +76,7 @@ command()
 			const message = '\n' + chalk.green( '✓' ) + ` environment created.\n\nTo start it please run:\n\n${ startCommand }\n`;
 			console.log( message );
 		} catch ( e ) {
-			let messageToShow = chalk.red( 'Error:' );
+			let messageToShow = chalk.red( 'Error: ' );
 			if ( 'Environment already exists.' === e.message ) {
 				messageToShow += `Environment already exists\n\n\nTo start the environment run:\n\n${ startCommand }\n\n` +
 				`To create another environment use ${ chalk.bold( '--slug' ) } option with a unique name.\n`;

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -13,7 +13,7 @@ import { prompt, Confirm, Select } from 'enquirer';
 /**
  * Internal dependencies
  */
-import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_CONTAINER_IMAGES, DEV_ENVIRONMENT_DEFAULTS, DEV_ENVIRONMENT_PROMPT_INTRO } from '../constants/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND, DEV_ENVIRONMENT_CONTAINER_IMAGES, DEV_ENVIRONMENT_DEFAULTS, DEV_ENVIRONMENT_PROMPT_INTRO } from '../constants/dev-environment';
 
 const DEFAULT_SLUG = 'vip-local';
 
@@ -47,6 +47,23 @@ export function getEnvironmentName( options: EnvironmentNameOptions ) {
 	}
 
 	return DEFAULT_SLUG;
+}
+
+export function getEnvironmentStartCommand( options: EnvironmentNameOptions ) {
+	if ( options.slug ) {
+		return `${ DEV_ENVIRONMENT_FULL_COMMAND } start --slug ${ options.slug }`;
+	}
+
+	if ( options.app ) {
+		let application = `@${ options.app }`;
+		if ( options.env ) {
+			application += `.${ options.env }`;
+		}
+
+		return `vip ${ application } ${ DEV_ENVIRONMENT_SUBCOMMAND } start`;
+	}
+
+	return `${ DEV_ENVIRONMENT_FULL_COMMAND } start`;
 }
 
 export function printTable( data: Object ) {


### PR DESCRIPTION
## Description

When running the `vip dev-environment create` command and the environment already exist we show error:

```
Error: Environment already exists


To start the environment run:

vip dev-environment start
```
This change makes sure the suggested command has the same name that was attempted to be created that is:
`vip @2891.production dev-environment start` or `vip dev-environment start --slug foo`


One thing to note is that I reused some refactoring I have done in https://github.com/Automattic/vip/pull/733 so for convinience reasons this PR is blocked by that PR. So the PR to master now looks kinda huge, but this PR is only for the last commit really. After #733 gets merge the diff will look more correct.

## Steps to Test

Try different combinations of naming with `vip dev-environment create`

