### PR TITLE
FORNO-659 Add overwriteExisting flag to media-import cmd

### DIFF
--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -94,9 +94,10 @@ Are you sure you want to import the contents of the url?
 } )
 	.command( 'status', 'Check the status of the current running import' )
 	.option( 'exportFileErrorsToJson', 'Export any file errors encountered to a JSON file instead of a plain text file', false )
+	.option( 'overwriteExisting', 'Overwrite any existing files', false )
 	.examples( examples )
 	.argv( process.argv, async ( args: string[], opts ) => {
-		const { app, env, exportFileErrorsToJson } = opts;
+		const { app, env, exportFileErrorsToJson, overwriteExisting } = opts;
 		const [ url ] = args;
 
 		if ( ! isSupportedUrl( url ) ) {
@@ -134,6 +135,7 @@ Processing the files import for your environment...
 							applicationId: app.id,
 							environmentId: env.id,
 							archiveUrl: url,
+							overwriteExistingFiles: overwriteExisting,
 						},
 					},
 				} );

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -56,13 +56,13 @@ const debug = debugLib( 'vip:vip-import-media' );
 // Command examples for the `vip import media` help prompt
 const examples = [
 	{
-		usage: 'vip import media @mysite.develop https://<path_to_publicly_accessible_archive>',
+		usage: 'vip import media @mysite.production https://<path_to_publicly_accessible_archive>',
 		description:
 			'Start a media import with the contents of the archive file in the URL',
 	},
 	// `media status` subcommand
 	{
-		usage: 'vip import media status @mysite.develop',
+		usage: 'vip import media status @mysite.production',
 		description:
 			'Check the status of the most recent import. If an import is running, this will poll until it is complete.',
 	},

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -94,10 +94,10 @@ Are you sure you want to import the contents of the url?
 } )
 	.command( 'status', 'Check the status of the current running import' )
 	.option( 'exportFileErrorsToJson', 'Export any file errors encountered to a JSON file instead of a plain text file', false )
-	.option( 'overwriteExisting', 'Overwrite any existing files', false )
+	.option( 'overwriteExistingFiles', 'Overwrite any existing files', false )
 	.examples( examples )
 	.argv( process.argv, async ( args: string[], opts ) => {
-		const { app, env, exportFileErrorsToJson, overwriteExisting } = opts;
+		const { app, env, exportFileErrorsToJson, overwriteExistingFiles } = opts;
 		const [ url ] = args;
 
 		if ( ! isSupportedUrl( url ) ) {
@@ -135,7 +135,7 @@ Processing the files import for your environment...
 							applicationId: app.id,
 							environmentId: env.id,
 							archiveUrl: url,
-							overwriteExistingFiles: overwriteExisting,
+							overwriteExistingFiles,
 						},
 					},
 				} );

--- a/src/bin/vip-import.js
+++ b/src/bin/vip-import.js
@@ -16,7 +16,7 @@ command( )
 	.command( 'validate-files', 'Validate your media file library' )
 	.command( 'media', 'Import media files to your application from a compressed web archive' )
 	.example( 'vip import sql @mysite.develop <file.sql>', 'Import the given SQL file to your site' )
-	.example( 'vip import media @mysite.develop https://<path_to_publicly_accessible_archive>', 'Import contents of the given archive file into the media library of your site' )
+	.example( 'vip import media @mysite.production https://<path_to_publicly_accessible_archive>', 'Import contents of the given archive file into the media library of your site' )
 	.argv( process.argv, async () => {
 		await trackEvent( 'vip_import_command_execute' );
 	} );


### PR DESCRIPTION
## Ticket
[FORNO-659 | Media Import: Add flag to force overwrite of existing files to CLI](https://vipjira.atlassian.net/browse/FORNO-659)

## PR Dependencies
https://github.com/Automattic/vip-go-api-public/pull/1115

## Description
We are adding `overwriteExisting` or `-o` flag to the `vip import-media` command. This will send `overwriteExistingFiles: true` to Parker's `start-media-import` mutation.

## How to test
_(WIP)_
1. Pull the PR.
2. Pull the latest master of GOOP.
3. Start GOOP using `docker-compose up` in GOOP repo.
3. Pull and checkout the dependency PR branch in Parker.
3. Start Parker using `docker-compose up` in Parker repo.
4. Create a authorization token using `./bin/generate-token.sh` in Parker.
5. Change [this](https://github.com/Automattic/vip/blob/master/src/lib/api.js#L35) line to make it look like the following:
```javascript
Authorization: 'Bearer <Generated Token>`
``` 
8. Run `npm run build`
9. Run the following command:
```bash
VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media.js @1000.production test.zip -o
```