### PR TITLE
Prevent calling isVip when logout command is being executed

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -52,7 +52,7 @@ const rootCmd = async function() {
 			.command( 'sync', 'Sync production to a development environment' )
 			.command( 'wp', 'Run WP CLI commands against an environment' );
 
-		if ( await checkIsVIP() ) {
+		if ( ! isLogoutCommand && await checkIsVIP() ) {
 			// temporarily hiding for non-vip, to avoid confusion untill we get full featured subcommand
 			cmd.command( 'dev-environment', 'Use local dev-environment' );
 		}


### PR DESCRIPTION
## Description

Currently, we always call `await checkIsVIP()` when using `logout or help` command. If you are using an invalid token, and try to logout, it will fail as the checkIsVIP check fails with 401. In this case, there is no way to logout successfully. This PR fixes this by preventing call to `await checkIsVIP()` when logout command is ran.