### PR TITLE
FORNO-691: Add importIntermediateImages flag

### DIFF
--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -95,9 +95,10 @@ Are you sure you want to import the contents of the url?
 	.command( 'status', 'Check the status of the current running import' )
 	.option( 'exportFileErrorsToJson', 'Export any file errors encountered to a JSON file instead of a plain text file', false )
 	.option( 'overwriteExistingFiles', 'Overwrite any existing files', false )
+	.option( 'importIntermediateImages', 'Import intermediate image files', false )
 	.examples( examples )
 	.argv( process.argv, async ( args: string[], opts ) => {
-		const { app, env, exportFileErrorsToJson, overwriteExistingFiles } = opts;
+		const { app, env, exportFileErrorsToJson, overwriteExistingFiles, importIntermediateImages } = opts;
 		const [ url ] = args;
 
 		if ( ! isSupportedUrl( url ) ) {
@@ -136,6 +137,7 @@ Processing the files import for your environment...
 							environmentId: env.id,
 							archiveUrl: url,
 							overwriteExistingFiles,
+							importIntermediateImages,
 						},
 					},
 				} );


### PR DESCRIPTION
## Ticket
[FORNO-691 | Add ability to import intermediate image files (CLI)](https://vipjira.atlassian.net/browse/FORNO-691)

## PR Dependencies
https://github.com/Automattic/vip-go-media-management-service/pull/115
https://github.com/Automattic/vip-go-api-public/pull/1126

## Description
We are adding `importIntermediateImages` or `-i` flag to the `vip import-media` command. This will send `importIntermediateImages: true` to Parker's `start-media-import` mutation.

## How to test
_(WIP)_
1. Pull the PR.
2. Pull the latest master of GOOP.
3. Start GOOP using `docker-compose up` in GOOP repo.
3. Pull and checkout the dependency PR branch in Parker.
3. Start Parker using `docker-compose up` in Parker repo.
4. Create a authorization token using `./bin/generate-token.sh` in Parker.
5. Change [this](https://github.com/Automattic/vip/blob/master/src/lib/api.js#L35) line to make it look like the following:
```javascript
Authorization: 'Bearer <Generated Token>`
``` 
8. Run `npm run build`
9. Run the following command:
```bash
VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media.js @1000.production test.zip -o -i
```