### PR TITLE
Refactor Import status reporting to support k8s

### DIFF
--- a/src/bin/vip-import-sql-status.js
+++ b/src/bin/vip-import-sql-status.js
@@ -27,6 +27,7 @@ environments{
 	id
 	appId
 	type
+	isK8sResident
 	primaryDomain {
 		id
 		name


### PR DESCRIPTION
## Description
This updates the status query/reporting logic to work for sites on k8s tenancy. We no longer have the `jobs` property available to us on the GraphQL query so we need to adapt this to use `importStatus`  


## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run an import: `/dist/bin/vip-import-sql.js @<site_id>.<env> <file.sql>`
1. Verify the import reports the progress correctly
