### PR TITLE
Make sure failed analytics tracking request don't make the whole command fail

### DIFF
--- a/__tests__/lib/analytics/clients/tracks.js
+++ b/__tests__/lib/analytics/clients/tracks.js
@@ -113,5 +113,16 @@ describe( 'lib/analytics/tracks', () => {
 
 			return tracksClient.trackEvent( eventName, {} );
 		} );
+
+		it( 'should not reject promise when tracking fails', async () => {
+			const tracksClient = new Tracks( 123, 'vip', 'existingprefix_', {} );
+
+			const eventName = 'existingprefix_clickButton';
+
+			buildNock().replyWithError( 'Connection reset' );
+
+			// We expect that the promise resolves to false instead of rejecting and throwing errors with async/await
+			await expect( tracksClient.trackEvent( eventName, {} ) ).resolves.toBe( false );
+		} );
 	} );
 } );

--- a/src/lib/analytics/clients/tracks.js
+++ b/src/lib/analytics/clients/tracks.js
@@ -46,7 +46,7 @@ export default class Tracks implements AnalyticsClient {
 		};
 	}
 
-	trackEvent( name: string, eventProps = {} ): Promise<any> {
+	async trackEvent( name: string, eventProps = {} ): Promise<any> {
 		if ( ! name.startsWith( this.eventPrefix ) ) {
 			name = this.eventPrefix + name;
 		}
@@ -93,7 +93,14 @@ export default class Tracks implements AnalyticsClient {
 
 		debug( 'trackEvent()', params );
 
-		return this.send( params );
+		try {
+			return await this.send( params );
+		} catch ( error ) {
+			debug( error );
+		}
+
+		// Resolve to false instead of rejecting
+		return Promise.resolve( false );
 	}
 
 	send( extraParams: {} ): Promise<any> {


### PR DESCRIPTION
## Description

Issues have been reported when users have their network block outgoing requests to our analytics endpoint. The analytics feature can be disabled via an [environment variable](https://github.com/Automattic/vip#analytics), but our default behavior shouldn't be to throw errors when that fails.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Block outgoing requests to `https://public-api.wordpress.com/rest/v1.1/tracks/record`
4. Run `DEBUG=* ./dist/bin/vip-app-list.js`
5. Verify that the command didn't error out

