### PR TITLE
Handle numbered slugs correctly

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -212,7 +212,7 @@ export function getEnvironmentPath( name: string ) {
 
 	const mainEnvironmentPath = xdgBasedir.data || os.tmpdir();
 
-	return path.join( mainEnvironmentPath, 'vip', 'dev-environment', name );
+	return path.join( mainEnvironmentPath, 'vip', 'dev-environment', name + '' );
 }
 
 export async function getApplicationInformation( appId: number, envType: string | null ) {


### PR DESCRIPTION


## Description

Previously using `--slug` with numeric value would through error.

## Steps to Test

Both variants `vip @123 dev-env <command>` and `vip dev-env <command> --slug 123` works fine. 

