### PR TITLE
Unify prnt table on start command with other commands

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -41,6 +41,8 @@ export async function startEnvironment( slug: string ) {
 	}
 
 	await landoStart( instancePath );
+
+	await printEnvironmentInfo( slug );
 }
 
 export async function stopEnvironment( slug: string ) {

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -53,8 +53,6 @@ export async function landoStart( instancePath: string ) {
 	await app.init();
 
 	await app.start();
-
-	console.log( lando.cli.formatData( landoUtils.startTable( app ), { format: 'table' }, { border: false } ) );
 }
 
 export async function landoStop( instancePath: string ) {


### PR DESCRIPTION

## Description

The start report table was different than info table.

## Steps to Test

`vip dev-env start` and `vip dev-env info` results in the same table in the end.

