### PR TITLE
FORNO-520: Add Abort Media Import subcommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "vip-import-sql-status": "dist/bin/vip-import-sql-status.js",
     "vip-import-media": "dist/bin/vip-import-media.js",
     "vip-import-media-status": "dist/bin/vip-import-media-status.js",
+    "vip-import-media-abort": "dist/bin/vip-import-media-abort.js",
     "vip-import-validate-files": "dist/bin/vip-import-validate-files.js",
     "vip-import-validate-sql": "dist/bin/vip-import-validate-sql.js",
     "vip-search-replace": "dist/bin/vip-search-replace.js",

--- a/src/bin/vip-import-media-abort.js
+++ b/src/bin/vip-import-media-abort.js
@@ -18,7 +18,6 @@ import API from 'lib/api';
 import * as exit from 'lib/cli/exit';
 // eslint-disable-next-line no-duplicate-imports
 import { trackEventWithEnv } from 'lib/tracker';
-import { formatEnvironment } from 'lib/cli/format';
 import { MediaImportProgressTracker } from 'lib/media-import/progress';
 import { mediaImportCheckStatus } from '../lib/media-import/status';
 
@@ -40,14 +39,6 @@ const appQuery = `
 const ABORT_IMPORT_MUTATION = gql`
 	mutation AbortMediaImport( $input: AppEnvironmentAbortMediaImportInput ) {
 		abortMediaImport( input: $input ) {
-			applicationId
-			environmentId
-			mediaImportStatusChange {
-				importId
-				siteId
-				statusFrom
-				statusTo
-			}
 		}
 	}
 `;

--- a/src/bin/vip-import-media-abort.js
+++ b/src/bin/vip-import-media-abort.js
@@ -57,6 +57,10 @@ command( {
 	appQuery,
 	envContext: true,
 	requiredArgs: 0,
+	requireConfirm: `
+${ chalk.red.bold( 'By running this command, the Media Import running on your App will stop and can\'t be resumed.' ) }
+${ chalk.red.bold( 'Are you sure you want to abort this Media Import?' ) }
+`,
 } )
 	.argv( process.argv, async ( arg: string[], { app, env } ) => {
 		const { id: envId, appId } = env;

--- a/src/bin/vip-import-media-abort.js
+++ b/src/bin/vip-import-media-abort.js
@@ -39,6 +39,14 @@ const appQuery = `
 const ABORT_IMPORT_MUTATION = gql`
 	mutation AbortMediaImport( $input: AppEnvironmentAbortMediaImportInput ) {
 		abortMediaImport( input: $input ) {
+			applicationId
+			environmentId
+			mediaImportStatusChange {
+				importId
+				siteId
+				statusFrom
+				statusTo
+			}
 		}
 	}
 `;

--- a/src/bin/vip-import-media-abort.js
+++ b/src/bin/vip-import-media-abort.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * @flow
  * @format

--- a/src/bin/vip-import-media-abort.js
+++ b/src/bin/vip-import-media-abort.js
@@ -1,0 +1,104 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+import chalk from 'chalk';
+
+/**
+* Internal dependencies
+*/
+import { isSupportedApp } from 'lib/media-import/media-file-import';
+import command from 'lib/cli/command';
+import API from 'lib/api';
+import * as exit from 'lib/cli/exit';
+// eslint-disable-next-line no-duplicate-imports
+import { trackEventWithEnv } from 'lib/tracker';
+import { formatEnvironment } from 'lib/cli/format';
+import { MediaImportProgressTracker } from 'lib/media-import/progress';
+import { mediaImportCheckStatus } from '../lib/media-import/status';
+
+const appQuery = `
+	id,
+	name,
+	type,
+	environments{
+		id
+		appId
+		type
+		primaryDomain {
+			id
+			name
+		}
+	}
+`;
+
+const ABORT_IMPORT_MUTATION = gql`
+	mutation AbortMediaImport( $input: AppEnvironmentAbortMediaImportInput ) {
+		abortMediaImport( input: $input ) {
+			applicationId
+			environmentId
+			mediaImportStatusChange {
+				importId
+				siteId
+				statusFrom
+				statusTo
+			}
+		}
+	}
+`;
+
+command( {
+	appContext: true,
+	appQuery,
+	envContext: true,
+	requiredArgs: 0,
+} )
+	.argv( process.argv, async ( arg: string[], { app, env } ) => {
+		const { id: envId, appId } = env;
+		const track = trackEventWithEnv.bind( null, appId, envId );
+
+		if ( ! isSupportedApp( app ) ) {
+			await track( 'import_media_command_error', { errorType: 'unsupported-app' } );
+			exit.withError(
+				'The type of application you specified does not currently support Media imports.'
+			);
+		}
+		const api = await API();
+
+		await track( 'import_media_abort_execute' );
+
+		const progressTracker = new MediaImportProgressTracker( [] );
+		progressTracker.prefix = `
+=============================================================
+Aborting the Media Import running on your App
+`;
+
+		try {
+			await api
+				.mutate( {
+					mutation: ABORT_IMPORT_MUTATION,
+					variables: {
+						input: {
+							applicationId: app.id,
+							environmentId: env.id,
+						},
+					},
+				} );
+			await mediaImportCheckStatus( { app, env, progressTracker } );
+		} catch ( e ) {
+			if ( e.graphQLErrors ) {
+				for ( const err of e.graphQLErrors ) {
+					console.log( chalk.red( 'Error:' ), err.message );
+				}
+				return;
+			}
+			await track( 'import_media_abort_execute_error', {
+				error: `Error: ${ e.message }`,
+			} );
+		}
+	} );

--- a/src/bin/vip-import-media-status.js
+++ b/src/bin/vip-import-media-status.js
@@ -48,7 +48,7 @@ command( {
 		if ( ! isSupportedApp( app ) ) {
 			await track( 'import_media_command_error', { errorType: 'unsupported-app' } );
 			exit.withError(
-				'The type of application you specified does not currently support Media imports.'
+				'The type of application you specified does not currently support this feature'
 			);
 		}
 

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -40,6 +40,13 @@ const appQuery = `
 const START_IMPORT_MUTATION = gql`
 	mutation StartMediaImport( $input: AppEnvironmentStartMediaImportInput ) {
 		startMediaImport( input: $input ) {
+			applicationId
+			environmentId
+			mediaImportStatus {
+				importId
+				siteId
+				status
+			}
 		}
 	}
 `;

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -40,13 +40,6 @@ const appQuery = `
 const START_IMPORT_MUTATION = gql`
 	mutation StartMediaImport( $input: AppEnvironmentStartMediaImportInput ) {
 		startMediaImport( input: $input ) {
-			applicationId
-			environmentId
-			mediaImportStatus {
-				importId
-				siteId
-				status
-			}
 		}
 	}
 `;

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -66,6 +66,12 @@ const examples = [
 		description:
 			'Check the status of the most recent import. If an import is running, this will poll until it is complete.',
 	},
+	// `media abort` subcommand
+	{
+		usage: 'vip import media abort @mysite.production',
+		description:
+			'Abort an ongoing import',
+	},
 ];
 
 function isSupportedUrl( urlToTest ) {

--- a/src/bin/vip-import-media.js
+++ b/src/bin/vip-import-media.js
@@ -93,6 +93,7 @@ Are you sure you want to import the contents of the url?
 `,
 } )
 	.command( 'status', 'Check the status of the latest Media Import' )
+	.command( 'abort', 'Abort the Media Import running for your App' )
 	.option( 'exportFileErrorsToJson', 'Export any file errors encountered to a JSON file instead of a plain text file', false )
 	.option( 'overwriteExistingFiles', 'Overwrite any existing files', false )
 	.option( 'importIntermediateImages', 'Import intermediate image files', false )
@@ -120,7 +121,7 @@ Error:
 		const progressTracker = new MediaImportProgressTracker( [] );
 		progressTracker.prefix = `
 =============================================================
-Processing the files import for your environment...
+Importing Media into your App...
 `;
 
 		console.log();

--- a/src/lib/media-import/status.js
+++ b/src/lib/media-import/status.js
@@ -168,8 +168,11 @@ export async function mediaImportCheckStatus( {
 
 		let statusMessage;
 		switch ( overallStatus ) {
+			case 'INITIALIZING':
+				statusMessage = `INITIALIZING ${ sprite } : We're downloading the files to be imported...`;
+				break;
 			case 'COMPLETED':
-				statusMessage = `COMPLETED ${ sprite } : The Imported files should be visible on your site ${ env.primaryDomain.name }`;
+				statusMessage = `COMPLETED ${ sprite } : The imported files should be visible on your App`;
 				break;
 			default:
 				statusMessage = `${ capitalize( overallStatus ) } ${ sprite }`;


### PR DESCRIPTION
## Description

This PR adds an `abort` sub command on the `vip import media` command.

It permanently stops a running media import for an Application.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Ensure that your local Parker and MMS are running
1. Run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media.js @70.production http://cesarabeid.com/wp-content/uploads.zip`
1. In a new tab run `VIP_PROXY="" API_HOST=http://localhost:4000 node ./dist/bin/vip-import-media-abort.js @70.production`
2. Verify that both show the following
```
=============================================================
Aborting the Media Import running on your App

=============================================================
Status: ABORTED ⚠️
App: test-ms-subdir-01-vipv2-net (PRODUCTION)
=============================================================
```

