### PR TITLE
Handle relative file paths

### DIFF
--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -45,3 +45,5 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up your local dev environment.\n\n' +
 	'Sensible default values were pre-selected for convenience. ' +
 	'You may also choose to create multiple environments with different settings using the --slug option.\n\n';
+
+export const DEV_ENVIRONMENT_COMPONENTS = [ 'wordpress', 'muPlugins', 'jetpack', 'clientCode' ];

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -10,7 +10,6 @@ import chalk from 'chalk';
 import formatters from 'lando/lib/formatters';
 import { prompt, Confirm, Select } from 'enquirer';
 import debugLib from 'debug';
-import path from 'path';
 
 /**
  * Internal dependencies
@@ -23,6 +22,7 @@ import {
 	DEV_ENVIRONMENT_PROMPT_INTRO,
 	DOCKER_HUB_WP_IMAGES,
 	DOCKER_HUB_JETPACK_IMAGES,
+	DEV_ENVIRONMENT_COMPONENTS,
 } from '../constants/dev-environment';
 import fetch from 'node-fetch';
 
@@ -159,8 +159,7 @@ export async function promptForArguments( providedOptions: NewInstanceOptions, a
 		clientCode: {},
 	};
 
-	const components = [ 'wordpress', 'muPlugins', 'jetpack', 'clientCode' ];
-	for ( const component of components ) {
+	for ( const component of DEV_ENVIRONMENT_COMPONENTS ) {
 		const option = providedOptions[ component ];
 		instanceData[ component ] = option
 			? processComponentOptionInput( option, component )
@@ -239,7 +238,7 @@ export async function promptForComponent( component: string ) {
 		const directoryPath = await promptForText( `	What is a path to your local ${ componentDisplayName }`, '' );
 		return {
 			mode: modeResult,
-			dir: path.resolve( directoryPath ),
+			dir: directoryPath,
 		};
 	}
 	if ( 'inherit' === modeResult ) {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -10,6 +10,7 @@ import chalk from 'chalk';
 import formatters from 'lando/lib/formatters';
 import { prompt, Confirm, Select } from 'enquirer';
 import debugLib from 'debug';
+import path from 'path';
 
 /**
  * Internal dependencies
@@ -235,10 +236,10 @@ export async function promptForComponent( component: string ) {
 
 	const modeResult = await select.run();
 	if ( 'local' === modeResult ) {
-		const path = await promptForText( `	What is a path to your local ${ componentDisplayName }`, '' );
+		const directoryPath = await promptForText( `	What is a path to your local ${ componentDisplayName }`, '' );
 		return {
 			mode: modeResult,
-			dir: path,
+			dir: path.resolve( directoryPath ),
 		};
 	}
 	if ( 'inherit' === modeResult ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -89,7 +89,7 @@ export async function createEnvironment( instanceData: NewInstanceData ) {
 
 	const cleanedInstanceData = cleanInstanceData( instanceData );
 
-	await prepareLandoEnv( instanceData, cleanedInstanceData );
+	await prepareLandoEnv( cleanedInstanceData, instancePath );
 }
 
 export async function destroyEnvironment( slug: string, removeFiles: boolean ) {


### PR DESCRIPTION
## Description

Adds conversion for relative paths provided for dev-env components locations.

## Steps to Test

Try different ways of providing path in the `vip dev-env create` wizzard - e.g:
```
vip dev-env create --slug test
This is a wizard to help you set up your local dev environment.

Sensible default values were pre-selected for convenience. You may also choose to create multiple environments with different settings using the --slug option.


✔ WordPress site title · VIP Dev
✔ PHP version · 7.4
✔ Multisite (y/N) · false
✔ How would you like to source WordPress · image
✔       Which version would you like · 5.7.2
✔ How would you like to source vip-go-mu-plugins · local
✔       What is a path to your local vip-go-mu-plugins · ~/git/automattic/vip-go-mu-plugins/
✔ How would you like to source Jetpack · inherit
✔ How would you like to source site-code · local
✔       What is a path to your local site-code · /home/pavel/git/automattic/vip-go-skeleton
```

