### PR TITLE
Make dev-env start more resilient

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -30,14 +30,18 @@ const examples = [
 
 command()
 	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'skip-rebuild', 'Only start stopped services' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 
+		const options = {
+			skipRebuild: !! opt.skipRebuild,
+		};
 		try {
-			await startEnvironment( slug );
+			await startEnvironment( slug, options );
 		} catch ( e ) {
 			handleCLIException( e );
 		}

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -17,7 +17,7 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
-import { landoDestroy, landoInfo, landoExec, landoStart, landoStop } from './dev-environment-lando';
+import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild } from './dev-environment-lando';
 import { printTable } from './dev-environment-cli';
 import app from '../api/app';
 import { DEV_ENVIRONMENT_COMPONENTS } from '../constants/dev-environment';
@@ -28,7 +28,11 @@ const landoFileTemplatePath = path.join( __dirname, '..', '..', '..', 'assets', 
 const configDefaultsFilePath = path.join( __dirname, '..', '..', '..', 'assets', 'dev-environment.wp-config-defaults.php' );
 const landoFileName = '.lando.yml';
 
-export async function startEnvironment( slug: string ) {
+type StartEnvironmentOptions = {
+	skipRebuild: boolean
+};
+
+export async function startEnvironment( slug: string, options: StartEnvironmentOptions ) {
 	debug( 'Will start an environment', slug );
 
 	const instancePath = getEnvironmentPath( slug );
@@ -41,7 +45,11 @@ export async function startEnvironment( slug: string ) {
 		throw new Error( 'Environment not found.' );
 	}
 
-	await landoStart( instancePath );
+	if ( options.skipRebuild ) {
+		await landoStart( instancePath );
+	} else {
+		await landoRebuild( instancePath );
+	}
 
 	await printEnvironmentInfo( slug );
 }

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -52,7 +52,7 @@ export async function landoStart( instancePath: string ) {
 	const app = lando.getApp( instancePath );
 	await app.init();
 
-	await app.start();
+	await app.rebuild();
 }
 
 export async function landoStop( instancePath: string ) {

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -52,6 +52,18 @@ export async function landoStart( instancePath: string ) {
 	const app = lando.getApp( instancePath );
 	await app.init();
 
+	await app.start();
+}
+
+export async function landoRebuild( instancePath: string ) {
+	debug( 'Will rebuild lando app on path:', instancePath );
+
+	const lando = new Lando( getLandoConfig() );
+	await lando.bootstrap();
+
+	const app = lando.getApp( instancePath );
+	await app.init();
+
 	await app.rebuild();
 }
 


### PR DESCRIPTION
## Description

There is this a dev-env issue when the crash of docker or Lando itself somehow based on [this issue](https://github.com/lando/lando/issues/971) can cause docker networks to get deleted. `lando start` then can't correctly spin up some services (most common proxy network gets deleted, causing proxy container not starting).

This change replaces the behavior of `vip dev-env start` to internally run the equivalent of `lando rebuild` instead of `lando start`. This way we always (as far as we know) get the correct setup. The downside is slightly longer spin up time, but nothing too bad.

Another benefit is that rebuilding does NOT release volumes (which are so far suggested workaround with `destroy` did), meaning we get to keep the database intact. 

This also introduces `--skip-rebuild` flag that is used to fallback to previous logic of only starting inactive services.

## Steps to Test

1. Stop dev-env `vip dev-env stop`
1. destroy netwroks `docker network prune`
2. Start dev-env `vip dev-env start` 
3. See the environment still works

