### PR TITLE
[dev-env] handle multisite = false correctly

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -49,7 +49,7 @@ const examples = [
 command()
 	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'title', 'Title for the WordPress site (default: "VIP Dev")' )
-	.option( 'multisite', 'Enable multisite install' )
+	.option( 'multisite', 'Enable multisite install', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'php', 'Use a specific PHP version' )
 	.option( 'wordpress', 'Use a specific WordPress version or local directory (default: last stable)' )
 	.option( 'mu-plugins', 'Use a specific mu-plugins changeset or local directory (default: "auto": last commit in master)' )

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -153,7 +153,7 @@ export async function promptForArguments( providedOptions: NewInstanceOptions, a
 	const instanceData = {
 		wpTitle: providedOptions.title || await promptForText( 'WordPress site title', name || DEV_ENVIRONMENT_DEFAULTS.title ),
 		phpVersion: providedOptions.php || await promptForText( 'PHP version', DEV_ENVIRONMENT_DEFAULTS.phpVersion ),
-		multisite: providedOptions.multisite || await promptForBoolean( multisiteText, multisiteDefault ),
+		multisite: 'multisite' in providedOptions ? providedOptions.multisite : await promptForBoolean( multisiteText, multisiteDefault ),
 		wordpress: {},
 		muPlugins: {},
 		jetpack: {},


### PR DESCRIPTION
## Description

If the `--multisite false` or `--multisite=false` is provided we should interpret it as **not** multisite and not prompt for it in the wizard. 

`--multisite` or `--multisite no` or `--multisite=true` or `--multisite=whatever` should result in true and no prompt.

No `--multisite` at all should prompt,

## Steps to Test

Try the options above when creating dev-env



