### PR TITLE
Fix error blocking data sync on CLI sites

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -386,7 +386,9 @@ args.argv = async function( argv, cb ): Promise<any> {
 					return { from, to };
 				} );
 
-				info.push( { key: 'From backup', value: new Date( backup.createdAt ).toUTCString() } );
+				if ( backup ) {
+					info.push( { key: 'From backup', value: new Date( backup.createdAt ).toUTCString() } );
+				}
 				info.push( { key: 'Replacements', value: '\n' + formatData( replacements, 'table' ) } );
 				break;
 			case 'import-media':


### PR DESCRIPTION
## Description

We currently don't provide backup meta from the k8s site when doing a sync. This change prevents the error from failing when this information isn't available.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-sync.js --app=<id>` for a site running on new infrastructure
1. Confirm the data sync proceeds without errors.

