### PR TITLE
Update DB Engine check to reduce false positives

### DIFF
--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -227,7 +227,7 @@ const checks: Checks = {
 		recommendation: '',
 	},
 	engineInnoDB: {
-		matcher: /ENGINE=(?!(InnoDB))/i,
+		matcher: / ENGINE=(?!(InnoDB))/i,
 		matchHandler: lineNumber => lineNumber,
 		outputFormatter: errorCheckFormatter,
 		results: [],


### PR DESCRIPTION
## Description
There are some cases where the `ENGINE=InnoDB` check was triggering a false positive, such as querystrings e.g. `?engine=adwords`

Fixes #805 

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Create a test SQL import file containing a previously-flagged string https://github.com/Automattic/vip/blob/master/src/lib/validations/sql.js#L230
1. Run `./dist/bin/vip-import-validate-sql.js <testfile.sql>`
1. Verify the check passes

