### PR TITLE
Retrieve the status and steps regardless of the site type.

### DIFF
--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -275,15 +275,13 @@ ${ maybeExitPrompt }
 
 						importJob.progress = { status: jobStatus, steps: jobSteps };
 					}
-				} else {
-					if ( ! importJob ) {
-						return resolve( 'No import job found' );
-					}
-
-					( {
-						progress: { status: jobStatus, steps: jobSteps },
-					} = importJob );
+				} else if ( ! importJob ) {
+					return resolve( 'No import job found' );
 				}
+
+				( {
+					progress: { status: jobStatus, steps: jobSteps },
+				} = importJob );
 
 				createdAt = importJob.createdAt;
 				completedAt = importJob.completedAt;

--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -279,10 +279,8 @@ ${ maybeExitPrompt }
 					return resolve( 'No import job found' );
 				}
 
-				( {
-					progress: { status: jobStatus, steps: jobSteps },
-				} = importJob );
-
+				jobStatus = importJob.progress.status;
+				jobSteps = importJob.progress.steps;
 				createdAt = importJob.createdAt;
 				completedAt = importJob.completedAt;
 


### PR DESCRIPTION
## Description
This fixes a bug where the import status and steps aren't correctly deconstructed in all cases

This ensure that regardless of site type or if jobsSteps is provided by the API, they will be deconstructed correctly 

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js @<id> file.sql` where id is a k8s-based site
1. Run `./dist/bin/vip-import-sql.js @<id> file.sql` where id is a non-k8s-based site
1. Verify import returns the progress correctly.

