### PR TITLE
Increasing dev-env PMA upload limit to 4G

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -55,6 +55,9 @@ services:
     type: phpmyadmin
     hosts:
       - database
+    overrides:
+      environment:
+        UPLOAD_LIMIT: 128M
 
   vip-search:
     type: elasticsearch:custom

--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -57,7 +57,7 @@ services:
       - database
     overrides:
       environment:
-        UPLOAD_LIMIT: 128M
+        UPLOAD_LIMIT: 4G
 
   vip-search:
     type: elasticsearch:custom


### PR DESCRIPTION
## Description

PHPMyAdmin on the development environment would fail to import big SQL files. This PR adds an explicit value to the maximum upload size of the file. By default, that size is 2M and we are bumping it to 4G.

## Steps to Test

Example:

1. Check out PR.
2. Create a new environment
3. Try to upload a big SQL file on PHPMyAdmin