### PR TITLE
Fixes issue where user is unable to login after logout

### DIFF
--- a/__tests__/lib/cli/apiConfig.js
+++ b/__tests__/lib/cli/apiConfig.js
@@ -11,12 +11,15 @@
  */
 import { checkFeatureEnabled, exitWhenFeatureDisabled, checkIsVIP } from 'lib/cli/apiConfig';
 import * as featureFlags from 'lib/api/feature-flags';
+import Token from 'lib/token';
 
 jest.mock( 'lib/tracker' );
 const getFeatureSpy = jest.spyOn( featureFlags, 'get' );
 
 describe( 'apiConfig', () => {
 	beforeEach( () => {
+		Token.set( 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaWQiOjcsImlhdCI6MTUxNjIzOTAyMn0.RTJMXHhhiaCxQberZ5Pre7SBU3Ci8EvCyaOXoqG3pNA' );
+
 		getFeatureSpy.mockClear();
 	} );
 
@@ -87,6 +90,13 @@ describe( 'apiConfig', () => {
 			} );
 			const check = await checkIsVIP();
 			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
+			expect( check ).toBe( false );
+		} );
+		it( 'returns false when token is not set', async () => {
+			Token.set( null );
+
+			const check = await checkIsVIP();
+
 			expect( check ).toBe( false );
 		} );
 		it( 'returns false when the public API has no response', async () => {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -66,7 +66,7 @@ export default async function API(): Promise<ApolloClient> {
 		operation.setContext( {
 			headers: {
 				Authorization: token ? `Bearer ${ token.raw }` : null,
-			}
+			},
 		} );
 
 		return forward( operation );

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -8,6 +8,8 @@
  */
 import fetch from 'node-fetch';
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client/core';
+import { ApolloLink } from '@apollo/client/link/core';
+import { setContext } from '@apollo/client/link/context';
 import { onError } from '@apollo/client/link/error';
 import chalk from 'chalk';
 
@@ -30,9 +32,7 @@ export function disableGlobalGraphQLErrorHandling() {
 }
 
 export default async function API(): Promise<ApolloClient> {
-	const token = await Token.get();
 	const headers = {
-		Authorization: token ? `Bearer ${ token.raw }` : null,
 		'User-Agent': env.userAgent,
 	};
 
@@ -54,6 +54,24 @@ export default async function API(): Promise<ApolloClient> {
 		}
 	} );
 
+	const withToken = setContext( async () =>{
+		const token = await Token.get();
+
+		return { token };
+	} );
+
+	const authLink = new ApolloLink( ( operation, forward ) => {
+		const { token } = operation.getContext();
+
+		operation.setContext( {
+			headers: {
+				Authorization: token ? `Bearer ${ token.raw }` : null,
+			}
+		} );
+
+		return forward( operation );
+	} );
+
 	const proxyAgent = createSocksProxyAgent();
 
 	const httpLink = new HttpLink( {
@@ -66,7 +84,7 @@ export default async function API(): Promise<ApolloClient> {
 	} );
 
 	const apiClient = new ApolloClient( {
-		link: errorLink.concat( httpLink ),
+		link: ApolloLink.from( [ withToken, errorLink, authLink, httpLink ] ),
 		cache: new InMemoryCache(),
 	} );
 

--- a/src/lib/cli/apiConfig.js
+++ b/src/lib/cli/apiConfig.js
@@ -65,7 +65,7 @@ export async function checkIsVIP(): Promise<boolean> {
 }
 
 export async function checkIfUserIsVip() {
-	let token = await Token.get();
+	const token = await Token.get();
 
 	if ( token && token.valid() ) {
 		const res = await featureFlags.get();
@@ -73,7 +73,7 @@ export async function checkIfUserIsVip() {
 		return res?.data?.me?.isVIP;
 	}
 
-	return false;	
+	return false;
 }
 
 export async function exitWhenFeatureDisabled( featureName: string ): Promise<boolean> {

--- a/src/lib/cli/apiConfig.js
+++ b/src/lib/cli/apiConfig.js
@@ -13,6 +13,7 @@
 import { trackEvent } from 'lib/tracker';
 import * as exit from './exit';
 import * as featureFlags from 'lib/api/feature-flags';
+import Token from 'lib/token';
 
 export async function checkFeatureEnabled(
 	featureName: string,
@@ -64,8 +65,15 @@ export async function checkIsVIP(): Promise<boolean> {
 }
 
 export async function checkIfUserIsVip() {
-	const res = await featureFlags.get();
-	return res?.data?.me?.isVIP;
+	let token = await Token.get();
+
+	if ( token && token.valid() ) {
+		const res = await featureFlags.get();
+
+		return res?.data?.me?.isVIP;
+	}
+
+	return false;	
 }
 
 export async function exitWhenFeatureDisabled( featureName: string ): Promise<boolean> {

--- a/src/lib/cli/apiConfig.js
+++ b/src/lib/cli/apiConfig.js
@@ -70,7 +70,7 @@ export async function checkIfUserIsVip() {
 	if ( token && token.valid() ) {
 		const res = await featureFlags.get();
 
-		return res?.data?.me?.isVIP;
+		return !! res?.data?.me?.isVIP;
 	}
 
 	return false;


### PR DESCRIPTION
## Description

[v2.0.11](https://github.com/Automattic/vip/releases/tag/v2.0.11) introduced a bug where users would be unable to login after logging out. The root cause was a `checkIfUserIsVip()` call added to `trackEvent()`. When a token wasn't set, the request would return with `500` and the process would immediately exit. 

The solution here checks if a token is set before making a request to check if a user is VIP or not. Also, I noticed that after a successful login, we would also get an error message:

```
Unauthorized: You are unauthorized to perform this request, please logout with `vip logout` then try again.
```

The cause of that was that the request headers were only being set once at startup. I've used Apollo's `setContext` and middleware APIs to set the headers dynamically so that, after a token is set, subsequent requests succeed.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Run `./dist/bin/vip.js logout`
4. Run `./dist/bin/vip.js`
5. You should be able to login now. Before, you would get an error and would be unable to login.

