### PR TITLE
Send header each time

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -86,7 +86,7 @@ export default async function API(): Promise<ApolloClient> {
 	} );
 
 	const apiClient = new ApolloClient( {
-		link: ApolloLink.from( [ errorLink, httpLink ] ),
+		link: ApolloLink.from( [ withToken, errorLink, authLink, httpLink ] ),
 		cache: new InMemoryCache(),
 	} );
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -32,8 +32,10 @@ export function disableGlobalGraphQLErrorHandling() {
 }
 
 export default async function API(): Promise<ApolloClient> {
+	const authToken = await Token.get();
 	const headers = {
 		'User-Agent': env.userAgent,
+		Authorization: authToken ? `Bearer ${ authToken.raw }` : null,
 	};
 
 	const errorLink = onError( ( { networkError, graphQLErrors } ) => {
@@ -84,7 +86,7 @@ export default async function API(): Promise<ApolloClient> {
 	} );
 
 	const apiClient = new ApolloClient( {
-		link: ApolloLink.from( [ withToken, errorLink, authLink, httpLink ] ),
+		link: ApolloLink.from( [ errorLink, httpLink ] ),
 		cache: new InMemoryCache(),
 	} );
 


### PR DESCRIPTION
## Description

Authentication fix to fix failing sql import

Started failing after https://github.com/Automattic/vip/pull/823/commits/fd5d442be36faf520b9f569ec55a4b6e1f3bf983

## Steps to Test


1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-import-sql.js  @site.env test.sql --skip-validate`
1. Verify import proceeds after confirmations

