### PR TITLE
Disable statsd by default

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -65,11 +65,13 @@ services:
     overrides:
       image: bitnami/elasticsearch:7.8.0
 
+<% if ( statsd ) { %>
   statsd:
     type: compose
     services:
       image: ghcr.io/automattic/vip-container-images/statsd:v0.8.6
       command: node stats.js /config/statsd-config.js
+<% } %>
 
   # Code containers
 

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -54,6 +54,7 @@ command()
 	.option( 'wordpress', 'Use a specific WordPress version or local directory (default: last stable)' )
 	.option( 'mu-plugins', 'Use a specific mu-plugins changeset or local directory (default: "auto": last commit in master)' )
 	.option( 'client-code', 'Use the client code from a local directory or VIP skeleton (default: use the VIP skeleton)' )
+	.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
@@ -85,6 +86,7 @@ command()
 		const instanceDataWithSlug = {
 			...instanceData,
 			siteSlug: slug,
+			statsd: opt.statsd || false,
 		};
 
 		try {


### PR DESCRIPTION

## Description

Statsd is not that useful container for end-users of dev-env. However, it is a bit resource intensive. So we are disabling it by default. Providing `--statsd` during creation will enable statsd.

## Steps to Test

VErify statsd is not included in new dev environments.

