### PR TITLE
Support ES version option

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -68,7 +68,7 @@ services:
     type: elasticsearch:custom
     portforward: true
     overrides:
-      image: bitnami/elasticsearch:<%= elasticSearch %>
+      image: bitnami/elasticsearch:<%= elasticsearch %>
 
 <% if ( statsd ) { %>
   statsd:

--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -68,7 +68,7 @@ services:
     type: elasticsearch:custom
     portforward: true
     overrides:
-      image: bitnami/elasticsearch:7.8.0
+      image: bitnami/elasticsearch:<%= elasticSearch %>
 
 <% if ( statsd ) { %>
   statsd:

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -58,6 +58,7 @@ command()
 	.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'elastic-search', 'Explicitly choose ElasticSearch version to use' )
+	.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -57,6 +57,7 @@ command()
 	.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
+	.option( 'elastic-search', 'Explicitly choose ElasticSearch version to use' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -19,6 +19,7 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	title: 'VIP Dev',
 	multisite: false,
 	phpVersion: '7.4',
+	elasticSearchVersion: '7.5.1',
 	wordpress: {},
 	muPlugins: {},
 	clientCode: {},

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -19,7 +19,7 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	title: 'VIP Dev',
 	multisite: false,
 	phpVersion: '7.4',
-	elasticSearchVersion: '7.5.1',
+	elasticsearchVersion: '7.5.1',
 	wordpress: {},
 	muPlugins: {},
 	clientCode: {},

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -120,7 +120,7 @@ type NewInstanceOptions = {
 	wordpress: string,
 	muPlugins: string,
 	clientCode: string,
-	elasticSearch: string,
+	elasticsearch: string,
 }
 
 type AppInfo = {
@@ -153,7 +153,7 @@ export async function promptForArguments( providedOptions: NewInstanceOptions, a
 	const instanceData = {
 		wpTitle: providedOptions.title || await promptForText( 'WordPress site title', name || DEV_ENVIRONMENT_DEFAULTS.title ),
 		multisite: 'multisite' in providedOptions ? providedOptions.multisite : await promptForBoolean( multisiteText, multisiteDefault ),
-		elasticSearch: providedOptions.elasticSearch || DEV_ENVIRONMENT_DEFAULTS.elasticSearchVersion,
+		elasticsearch: providedOptions.elasticsearch || DEV_ENVIRONMENT_DEFAULTS.elasticsearchVersion,
 		wordpress: {},
 		muPlugins: {},
 		clientCode: {},

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -119,7 +119,8 @@ type NewInstanceOptions = {
 	php: string,
 	wordpress: string,
 	muPlugins: string,
-	clientCode: string
+	clientCode: string,
+	elasticSearch: string,
 }
 
 type AppInfo = {
@@ -152,6 +153,7 @@ export async function promptForArguments( providedOptions: NewInstanceOptions, a
 	const instanceData = {
 		wpTitle: providedOptions.title || await promptForText( 'WordPress site title', name || DEV_ENVIRONMENT_DEFAULTS.title ),
 		multisite: 'multisite' in providedOptions ? providedOptions.multisite : await promptForBoolean( multisiteText, multisiteDefault ),
+		elasticSearch: providedOptions.elasticSearch || DEV_ENVIRONMENT_DEFAULTS.elasticSearchVersion,
 		wordpress: {},
 		muPlugins: {},
 		clientCode: {},


### PR DESCRIPTION
## Description

Sets the default version of ElasticSearch to 7.5.1 (to match production environment), also introduces `--elastic-search` option to choose a version during the creation of dev-environment.

## Steps to Test

Try to use `--elastic-search` on dev-env creation.

