### PR TITLE
Removing mu-plugins test command

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -128,12 +128,6 @@ tooling:
     cmd:
       - wp
 
-  test:
-    service: php
-    description: "Run all tests: lando test"
-    cmd:
-      - cd /wp/wp-content/mu-plugins && phpunit
-
   add-site:
     service: php
     description: "Add site to a multisite installation"


### PR DESCRIPTION
## Description

This PR removes the `test` command from the dev-environment. That command is supposed to run the tests on mu-plugins, but it doesn't work. To run the `mu-plugins` test, please refer to that repository for instructions.