### PR TITLE
Making PHPMyAdmin optional on dev-env

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -51,6 +51,7 @@ services:
   memcached:
     type: memcached:1.5.12
 
+<% if ( phpmyadmin ) { %>
   phpmyadmin:
     type: phpmyadmin
     hosts:
@@ -58,6 +59,7 @@ services:
     overrides:
       environment:
         UPLOAD_LIMIT: 4G
+<% } %>
 
   vip-search:
     type: elasticsearch:custom

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -55,6 +55,7 @@ command()
 	.option( 'mu-plugins', 'Use a specific mu-plugins changeset or local directory (default: "auto": last commit in master)' )
 	.option( 'client-code', 'Use the client code from a local directory or VIP skeleton (default: use the VIP skeleton)' )
 	.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
+	.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
@@ -87,6 +88,7 @@ command()
 			...instanceData,
 			siteSlug: slug,
 			statsd: opt.statsd || false,
+			phpmyadmin: opt.phpmyadmin || false,
 		};
 
 		try {


### PR DESCRIPTION
## Description

This PR makes the PHPMyAdmin container optional i order to reduce resource consumption when running an environment. That means it will be disabled by default and users can enable it by

`vip dev-env create --phpmyadmin`

## Steps to Test

1. Check out PR.
2. Create an environment with PMA and one without it.
3. Check that in each case, a Docker container with PMA is running (or not).