### PR TITLE
Patching Docker for Windows in dev-env

### DIFF
--- a/assets/docker-es-patch.ps1
+++ b/assets/docker-es-patch.ps1
@@ -1,0 +1,1 @@
+wsl -d docker-desktop bash -c "sysctl -w vm.max_map_count=262144"

--- a/assets/docker-es-patch.ps1
+++ b/assets/docker-es-patch.ps1
@@ -1,1 +1,0 @@
-wsl -d docker-desktop bash -c "sysctl -w vm.max_map_count=262144"

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -9,7 +9,6 @@
  * External dependencies
  */
 import debugLib from 'debug';
-import path from 'path';
 import { exec } from 'child_process';
 
 /**
@@ -19,10 +18,12 @@ import command from 'lib/cli/command';
 import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
+import chalk from 'chalk';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
-const dockerEsPatchPath = path.join( __dirname, '..', '..', '..', 'assets', 'docker-es-patch.ps1' );
+// PowerShell command for Windows Docker patch
+const dockerWindowsPathCmd = 'wsl -d docker-desktop bash -c "sysctl -w vm.max_map_count=262144"';
 
 // Command examples
 const examples = [
@@ -48,14 +49,14 @@ command()
 			if ( process.platform === 'win32' ) {
 				console.log( 'Running on Windows. Applying Docker patch...' );
 
-				exec( dockerEsPatchPath, { shell: 'powershell.exe' }, ( error, stdout, stderr ) => {
+				exec( dockerWindowsPathCmd, { shell: 'powershell.exe' }, ( error, stdout, stderr ) => {
 					if ( error != null ) {
 					  console.log( 'There was an error while applying the patch: ' );
 					  console.log( error );
 					  return;
 					}
 
-					console.log( 'Docker patch for Windows applied' );
+					console.log( `${ chalk.green( '✓' ) } Docker patch for Windows applied.` );
 				} );
 			}
 

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -49,6 +49,12 @@ command()
 				console.log( 'Running on Windows. Applying Docker patch...' );
 
 				exec( dockerEsPatchPath, { shell: 'powershell.exe' }, ( error, stdout, stderr ) => {
+					if ( error != null ) {
+					  console.log( 'There was an error while applying the patch: ' );
+					  console.log( error );
+					  return;
+					}
+
 					console.log( 'Docker patch for Windows applied' );
 				} );
 			}

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -50,9 +50,8 @@ command()
 				debug( 'Windows platform detected. Applying Docker patch...' );
 
 				exec( dockerWindowsPathCmd, { shell: 'powershell.exe' }, ( error, stdout, stderr ) => {
-					if ( error != null || stderr != null ) {
+					if ( error != null ) {
 						debug( error );
-						debug( stderr );
 						console.log( `${ chalk.red( '✕' ) } There was an error while applying the Windows Docker patch.` );
 					} else {
 						debug( stdout );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -47,16 +47,17 @@ command()
 		};
 		try {
 			if ( process.platform === 'win32' ) {
-				console.log( 'Running on Windows. Applying Docker patch...' );
+				debug( 'Windows platform detected. Applying Docker patch...' );
 
 				exec( dockerWindowsPathCmd, { shell: 'powershell.exe' }, ( error, stdout, stderr ) => {
-					if ( error != null ) {
-					  console.log( 'There was an error while applying the patch: ' );
-					  console.log( error );
-					  return;
+					if ( error != null || stderr != null ) {
+					  debug( error );
+					  debug( stderr );
+					  console.log( `${ chalk.red( '✕' ) } There was an error while applying the Windows Docker patch.` );
+					} else {
+					  debug( stdout );
+					  console.log( `${ chalk.green( '✓' ) } Docker patch for Windows applied.` );
 					}
-
-					console.log( `${ chalk.green( '✓' ) } Docker patch for Windows applied.` );
 				} );
 			}
 

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -8,6 +8,7 @@
 /**
  * External dependencies
  */
+import chalk from 'chalk';
 import debugLib from 'debug';
 import { exec } from 'child_process';
 
@@ -18,7 +19,6 @@ import command from 'lib/cli/command';
 import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import chalk from 'chalk';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -9,6 +9,8 @@
  * External dependencies
  */
 import debugLib from 'debug';
+import path from 'path';
+import { exec } from 'child_process';
 
 /**
  * Internal dependencies
@@ -19,6 +21,8 @@ import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
+
+const dockerEsPatchPath = path.join( __dirname, '..', '..', '..', 'assets', 'docker-es-patch.ps1' );
 
 // Command examples
 const examples = [
@@ -41,6 +45,14 @@ command()
 			skipRebuild: !! opt.skipRebuild,
 		};
 		try {
+			if ( process.platform === 'win32' ) {
+				console.log( 'Running on Windows. Applying Docker patch...' );
+
+				exec( dockerEsPatchPath, { shell: 'powershell.exe' }, ( error, stdout, stderr ) => {
+					console.log( 'Docker patch for Windows applied' );
+				} );
+			}
+
 			await startEnvironment( slug, options );
 		} catch ( e ) {
 			handleCLIException( e );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -51,12 +51,12 @@ command()
 
 				exec( dockerWindowsPathCmd, { shell: 'powershell.exe' }, ( error, stdout, stderr ) => {
 					if ( error != null || stderr != null ) {
-					  debug( error );
-					  debug( stderr );
-					  console.log( `${ chalk.red( '✕' ) } There was an error while applying the Windows Docker patch.` );
+						debug( error );
+						debug( stderr );
+						console.log( `${ chalk.red( '✕' ) } There was an error while applying the Windows Docker patch.` );
 					} else {
-					  debug( stdout );
-					  console.log( `${ chalk.green( '✓' ) } Docker patch for Windows applied.` );
+						debug( stdout );
+						console.log( `${ chalk.green( '✓' ) } Docker patch for Windows applied.` );
 					}
 				} );
 			}


### PR DESCRIPTION
## Description

Docker for Windows with the WSL 2 back-end would fail to boot the Elasticsearch container due to [some known misconfiguration](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_set_vm_max_map_count_to_at_least_262144). 

This PR tweaks the start script to detect if its running on Windows. If so, it runs a simple Powershell command to modify the virtual memory kernel flag.

## Steps to Test

1. Check out PR on a Windows machine.
2. Create an environment and start it.
3. Check that the Elasticsearch container launches properly.