### PR TITLE
Use official MariaDB image and enable version selection on dev-env

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -50,7 +50,7 @@ services:
   database:
     type: compose
     services:
-      image: mariadb:10.3
+      image: mariadb:<%= mariadb %>
       command: docker-entrypoint.sh mysqld
       environment:
         MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'

--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -48,8 +48,12 @@ services:
       - sh /dev-tools/setup.sh database root "http://<%= siteSlug %>.vipdev.lndo.site/" "<%= wpTitle %>" <% if ( multisite ) { %> <%= siteSlug %>.vipdev.lndo.site <% } %>
 
   database:
-    type: mariadb
-    #portforward: 13306
+    type: compose
+    services:
+      image: mariadb:10.3
+      command: docker-entrypoint.sh mysqld
+      environment:
+        MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
 
   memcached:
     type: memcached:1.5.12

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -57,8 +57,8 @@ command()
 	.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
-	.option( 'elastic-search', 'Explicitly choose ElasticSearch version to use' )
 	.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use' )
+	.option( 'mariadb', 'Explicitly choose MariaDB verison to use' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -20,6 +20,7 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	multisite: false,
 	phpVersion: '7.4',
 	elasticsearchVersion: '7.5.1',
+	mariadbVersion: '10.3',
 	wordpress: {},
 	muPlugins: {},
 	clientCode: {},

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -121,6 +121,7 @@ type NewInstanceOptions = {
 	muPlugins: string,
 	clientCode: string,
 	elasticsearch: string,
+	mariadb: string,
 }
 
 type AppInfo = {
@@ -154,6 +155,7 @@ export async function promptForArguments( providedOptions: NewInstanceOptions, a
 		wpTitle: providedOptions.title || await promptForText( 'WordPress site title', name || DEV_ENVIRONMENT_DEFAULTS.title ),
 		multisite: 'multisite' in providedOptions ? providedOptions.multisite : await promptForBoolean( multisiteText, multisiteDefault ),
 		elasticsearch: providedOptions.elasticsearch || DEV_ENVIRONMENT_DEFAULTS.elasticsearchVersion,
+		mariadb: providedOptions.mariadb || DEV_ENVIRONMENT_DEFAULTS.mariadbVersion,
 		wordpress: {},
 		muPlugins: {},
 		clientCode: {},


### PR DESCRIPTION
## Description

This PR switches the MariaDB image that's being used in the dev environment, from Bitnami's to the official one. The biggest difference being that the official image supports ARM architectures.

We are also introducing the possibility to select a specific MariaDB version. By default, we'll use 10.3.

## Steps to Test

1. Check out PR.
2. Create a new environment.
3. Verify that the environment and the database work as expected.