### PR TITLE
Not using a prefix to all dev environments

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -1,4 +1,4 @@
-name: vipdev<%= siteSlug %>
+name: <%= siteSlug %>
 env_file:
   - .env
 proxy:


### PR DESCRIPTION
## Description

All environments created by the CLI have the prefix `vipdev`. That was initially designed to avoid conflicts, but what it ends up doing is creating very long and sometimes hard to read names:

<img width="1440" alt="Captura de Pantalla 2021-08-30 a les 13 17 23" src="https://user-images.githubusercontent.com/7188409/131334474-9d862412-6a87-4211-8ea1-16f1c86eb88b.png">

This PR removes that prefix.

## Steps to Test

1. Check out PR.
2. Create a new environment.
3. Check it the container names don't have the prefix.