### PR TITLE
Use official memcached image on dev-env

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -64,7 +64,7 @@ services:
     type: memcached:custom
     overrides:
       image: memcached:1.6-alpine3.14
-      command: docker-entrypoint.sh
+      command: docker-entrypoint.sh memcached
 
 <% if ( phpmyadmin ) { %>
   phpmyadmin:

--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -61,7 +61,10 @@ services:
         LANDO_NEEDS_EXEC: 'DOEEET'
 
   memcached:
-    type: memcached:1.5.12
+    type: memcached:custom
+    overrides:
+      image: memcached:1.6-alpine3.14
+      command: docker-entrypoint.sh
 
 <% if ( phpmyadmin ) { %>
   phpmyadmin:


### PR DESCRIPTION
## Description

This PR replaces the memcached Bitnami image that's being used by default by Lando for the official memcached image. The main reason for this change is ARM support of the official image. We are also bumping the version (from 1.15 to 1.16) and moving from the Debian-base image to the Alpine-based one.

## Steps to Test

1. Check out PR.
2. Create a new environment.
3. Check that WordPress works correctly and the new environment spins up.
4. Set and get keys with `wp cache get/set`