### PR TITLE
Conditionally disabling statsd on mu-plugins

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -35,6 +35,7 @@ services:
       working_dir: /wp
       environment:
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
+        STATSD: <%= statsd ? 'enable' : 'disable' %>
 
       volumes:
         - type: volume


### PR DESCRIPTION
## Description

This PR is dependent on https://github.com/Automattic/vip-container-images/pull/12.

When statsd was disabled (i.e. the container was not initialized), the mu-plugins would try to connect to it regardless, causing a lot of noise in the terminal of warnings alerting of a failed connection. This PR passes on the `enable` toggle to the dev-tools so we can set the `VIP_DISABLE_STATSD` flag and prevent those warnings.

## Steps to Test

1. Check out PR.
2. Create a new environment with statsd disabled.
3. You shouldn't see any statsd-related warnings on the terminal.