### PR TITLE
Enable ssl forwarding on dev-env

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -21,6 +21,8 @@ services:
 
   nginx:
     type: compose
+    ssl: true
+    sslExpose: false
     services:
       image: ghcr.io/automattic/vip-container-images/nginx:1.21.1
       command: nginx -g "daemon off;"


### PR DESCRIPTION

## Description

After a DB import from a real-life environment, most of the links lead to https. This is a first step towards supporting https to an extend in local dev-env. It is not possible to get a trusted TLS certificate for the local domain, however, we can use Lando's self-signed one (which requires approval in the browser, but works afterward).

Another piece of the puzzle is the new dev-tools image needed, that does some more config WordPress wise - https://github.com/Automattic/vip-container-images/pull/13

## Steps to Test

1) Create a new dev-env
2) There should be https variant in the info now:
```
 NAME               vip-local                                                                    
 LOCATION           /home/pavel/.local/share/vip/dev-environment/vip-local                       
 SERVICES           devtools, nginx, php, database, memcached, phpmyadmin, vip-search, wordpress 
 NGINX URLS         http://vip-local.vipdev.lndo.site/                                           
                    https://vip-local.vipdev.lndo.site/                                          
 PHPMYADMIN URLS    http://localhost:49274                                                       
 ENTERPRISE SEARCH  http://127.0.0.1:49275                                                       
 STATUS             UP 
```
