### PR TITLE
Updating command descriptions and arguments on dev-env

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -22,7 +22,6 @@ import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/co
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
-// Command examples
 const examples = [
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create`,
@@ -38,11 +37,11 @@ const examples = [
 	},
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --slug test`,
-		description: 'Creates a blank local dev environment with custom name "test", this enables to create multiple independend environments',
+		description: 'Creates a blank local dev environment with custom name "test", this enables to create multiple independent environments',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress "5.6" --client-code "~/git/my_code"`,
-		description: 'Creates a local dev environment that is multisite and is using WP 5.6 and client code is expected to be in "~/git/my_code"',
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress "5.8" --client-code "~/git/my_code"`,
+		description: 'Creates a local multisite dev environment using WP 5.8 and client code is expected to be in "~/git/my_code"',
 	},
 ];
 
@@ -51,13 +50,13 @@ command()
 	.option( 'title', 'Title for the WordPress site (default: "VIP Dev")' )
 	.option( 'multisite', 'Enable multisite install', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'wordpress', 'Use a specific WordPress version or local directory (default: last stable)' )
-	.option( 'mu-plugins', 'Use a specific mu-plugins changeset or local directory (default: "auto": last commit in master)' )
+	.option( [ 'u', 'mu-plugins' ], 'Use a specific mu-plugins changeset or local directory (default: "auto": last commit in master)' )
 	.option( 'client-code', 'Use the client code from a local directory or VIP skeleton (default: use the VIP skeleton)' )
 	.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use' )
-	.option( 'mariadb', 'Explicitly choose MariaDB verison to use' )
+	.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
@@ -78,10 +77,10 @@ command()
 			if ( opt.app ) {
 				appInfo = await getApplicationInformation( opt.app, opt.env );
 			}
-		} catch ( e ) {
+		} catch ( error ) {
 			const message = `failed to fetch application "${ opt.app }" information`;
 
-			debug( `WARNING: ${ message }`, e.message );
+			debug( `WARNING: ${ message }`, error.message );
 			console.log( chalk.yellow( 'Warning:' ), message );
 		}
 
@@ -101,7 +100,7 @@ command()
 
 			const message = '\n' + chalk.green( '✓' ) + ` environment created.\n\nTo start it please run:\n\n${ startCommand }\n`;
 			console.log( message );
-		} catch ( e ) {
-			exit.withError( e.message );
+		} catch ( error ) {
+			exit.withError( error.message );
 		}
 	} );

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -22,11 +22,10 @@ import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
-// Command examples
 const examples = [
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } destroy`,
-		description: 'Destroys a default local dev environment',
+		description: 'Destroys the default local dev environment',
 	},
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } destroy --slug foo`,
@@ -49,7 +48,7 @@ command()
 
 			const message = chalk.green( '✓' ) + ' environment destroyed.\n';
 			console.log( message );
-		} catch ( e ) {
-			exit.withError( e.message );
+		} catch ( error ) {
+			exit.withError( error.message );
 		}
 	} );

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -17,7 +17,6 @@ import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-
 import { exec } from 'lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
-// Command examples
 const examples = [
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec -- wp post list`,
@@ -40,20 +39,20 @@ command( { wildcardCommand: true } )
 		const slug = getEnvironmentName( opt );
 
 		try {
-			// to avoid confusion let's enforce -- as a spliter for arguments for this command and wp itself
-			const argSpliterIx = process.argv.findIndex( argument => '--' === argument );
-			const argSpliterFound = argSpliterIx > -1;
-			if ( unmatchedArgs.length > 0 && ! argSpliterFound ) {
+			// to avoid confusion let's enforce -- as a splitter for arguments for this command and wp itself
+			const argSplitterIx = process.argv.findIndex( argument => '--' === argument );
+			const argSplitterFound = argSplitterIx > -1;
+			if ( unmatchedArgs.length > 0 && ! argSplitterFound ) {
 				throw new Error( 'Please provide "--" argument to separate arguments for "vip" and command to be executed (see "--help" for examples)' );
 			}
 
 			let arg = [];
-			if ( argSpliterFound && argSpliterIx + 1 < process.argv.length ) {
-				arg = process.argv.slice( argSpliterIx + 1 );
+			if ( argSplitterFound && argSplitterIx + 1 < process.argv.length ) {
+				arg = process.argv.slice( argSplitterIx + 1 );
 			}
 
 			await exec( slug, arg );
-		} catch ( e ) {
-			handleCLIException( e );
+		} catch ( error ) {
+			handleCLIException( error );
 		}
 	} );

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -20,7 +20,6 @@ import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/co
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
-// Command examples
 const examples = [
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info -all`,
@@ -38,7 +37,7 @@ const examples = [
 
 command()
 	.option( 'slug', 'Custom name of the dev environment' )
-	.option( 'all', 'Show Info for all local dev environemnts' )
+	.option( 'all', 'Show Info for all local dev environments' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
@@ -51,7 +50,7 @@ command()
 			} else {
 				await printEnvironmentInfo( slug );
 			}
-		} catch ( e ) {
-			handleCLIException( e );
+		} catch ( error ) {
+			handleCLIException( error );
 		}
 	} );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -25,7 +25,6 @@ const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 // PowerShell command for Windows Docker patch
 const dockerWindowsPathCmd = 'wsl -d docker-desktop bash -c "sysctl -w vm.max_map_count=262144"';
 
-// Command examples
 const examples = [
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } start`,
@@ -61,7 +60,7 @@ command()
 			}
 
 			await startEnvironment( slug, options );
-		} catch ( e ) {
-			handleCLIException( e );
+		} catch ( error ) {
+			handleCLIException( error );
 		}
 	} );

--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -21,7 +21,6 @@ import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
-// Command examples
 const examples = [
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } stop`,
@@ -42,7 +41,7 @@ command()
 
 			const message = chalk.green( '✓' ) + ' environment stopped.\n';
 			console.log( message );
-		} catch ( e ) {
-			handleCLIException( e );
+		} catch ( error ) {
+			handleCLIException( error );
 		}
 	} );

--- a/src/bin/vip-dev-env.js
+++ b/src/bin/vip-dev-env.js
@@ -17,10 +17,10 @@ import command from 'lib/cli/command';
 command( {
 	requiredArgs: 1,
 } )
-	.command( 'create', 'Create a local dev environment' )
+	.command( 'create', 'Create a new local dev environment' )
 	.command( 'start', 'Start a local dev environment' )
 	.command( 'stop', 'Stop a local dev environment' )
-	.command( 'destroy', 'Destroy a local dev environment' )
-	.command( 'info', 'Provides basic info about a local dev environment' )
-	.command( 'exec', 'Execute operation on dev environment' )
+	.command( 'destroy', 'Remove containers, networks, volumes and configuration files of a local dev environment' )
+	.command( 'info', 'Provides basic info about one or multiple local dev environments' )
+	.command( 'exec', 'Execute an operation on a dev environment' )
 	.argv( process.argv );


### PR DESCRIPTION
## Description

This PR fixes an issue where there were duplicate arguments on the `vip dev-env create` with `-M`. We now moved `--mu-plugins` to `-u`.

We also fix some typos on descriptions and we clarify some descriptions.

## Steps to Test

Mostly use the `-h` flag on the `vip dev-env` commands.
