### PR TITLE
Adding media import command on dev environment

### DIFF
--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -13,11 +13,20 @@
  * Internal dependencies
  */
 import command from '../lib/cli/command';
+import { getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
+import { importMediaPath } from '../lib/dev-environment/dev-environment-core';
 
 command( {
 	requiredArgs: 1,
 } )
 	.option( 'slug', 'Custom name of the dev environment' )
-	.argv( process.argv, async () => {
-		console.log( 'Importing media to a dev environment is not available yet.' );
+	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
+		const [ filePath ] = unmatchedArgs;
+		const slug = getEnvironmentName( opt );
+
+		try {
+			await importMediaPath( slug, filePath );
+		} catch ( error ) {
+			handleCLIException( error );
+		}
 	} );

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -15,10 +15,23 @@
 import command from '../lib/cli/command';
 import { getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 import { importMediaPath } from '../lib/dev-environment/dev-environment-core';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+
+const examples = [
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import media path/to/wp-content/uploads`,
+		description: 'Import contents of the given WP uploads folder file into the media library of the default dev environment',
+	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import media path/to/wp-content/uploads --slug mysite`,
+		description: 'Import contents of the given WP uploads folder file into the media library of a dev environment named `mysite`',
+	},
+];
 
 command( {
 	requiredArgs: 1,
 } )
+	.examples( examples )
 	.option( 'slug', 'Custom name of the dev environment' )
 	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
 		const [ filePath ] = unmatchedArgs;

--- a/src/bin/vip-dev-env-import.js
+++ b/src/bin/vip-dev-env-import.js
@@ -21,8 +21,8 @@ const examples = [
 		description: 'Import the given SQL file to your site',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import media https://<path_to_publicly_accessible_archive>`,
-		description: 'Import contents of the given archive file into the media library of your site',
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import media path/to/wp-content/uploads`,
+		description: 'Import contents of the given WP uploads folder file into the media library of the default dev environment',
 	},
 ];
 
@@ -31,5 +31,6 @@ command( {
 } )
 	.examples( examples )
 	.command( 'sql', 'Import SQL to your dev-env database from a file' )
-	.command( 'media', 'Import media files to the dev environment of your application from a compressed web archive' )
+	.command( 'media', 'Import media files to the dev environment of your application from a compressed web archive. ' +
+		'This command will copy the contents of a folder to the `uploads` folder of the target dev environment.' )
 	.argv( process.argv );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -333,5 +333,5 @@ export async function importMediaPath( slug: string, filePath: string ) {
 
 	console.log( `${ chalk.yellow( '-' ) } Started copying files` );
 	copydir.sync( resolvedPath, uploadsPath );
-	console.log( `${ chalk.green( '✓' ) } Files successfuly copied to ${ uploadsPath }.` );
+	console.log( `${ chalk.green( '✓' ) } Files successfully copied to ${ uploadsPath }.` );
 }

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -303,3 +303,11 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 		dockerPath,
 	};
 }
+
+export async function importMediaPath( slug: string, filePath: string ) {
+	const resolvedPath = resolvePath( filePath );
+
+	if ( ! fs.existsSync( resolvedPath ) ) {
+		throw new Error( 'The provided path does not exist or it is not valid (see "--help" for examples)' );
+	}
+}

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -13,6 +13,7 @@ import fs from 'fs';
 import ejs from 'ejs';
 import path from 'path';
 import chalk from 'chalk';
+import { prompt } from 'enquirer';
 import copydir from 'copy-dir';
 
 /**
@@ -22,7 +23,6 @@ import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild
 import { searchAndReplace } from '../search-and-replace';
 import { printTable, resolvePath } from './dev-environment-cli';
 import app from '../api/app';
-import { prompt } from 'enquirer';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 


### PR DESCRIPTION
## Description

This PR adds a simple way of importing a media folder into a dev environment. It operates by copying a provided folder (ideally, a `wp-contents/uploads/` folder) into the proper directory of the environment.

This command works well when it's run in conjunction with `vip dev-env import sql`.

## Steps to Test

1. Check out PR and build the CLI.
2. Get an `uploads` folder from a WP install.
3. Run `vip dev-env import media path/to/wp-contents/uploads/`.
4. Check the files are available on the media library.