### PR TITLE
Temporarily gate access to new config command to VIP staff

### DIFF
--- a/__tests__/lib/cli/apiConfig.js
+++ b/__tests__/lib/cli/apiConfig.js
@@ -9,7 +9,7 @@
 /**
  * Internal dependencies
  */
-import { checkFeatureEnabled, exitWhenFeatureDisabled, checkIsVIP } from 'lib/cli/apiConfig';
+import { checkFeatureEnabled, exitWhenFeatureDisabled } from 'lib/cli/apiConfig';
 import * as featureFlags from 'lib/api/feature-flags';
 import Token from 'lib/token';
 
@@ -57,53 +57,6 @@ describe( 'apiConfig', () => {
 		it( 'returns false when the public API has no response', async () => {
 			getFeatureSpy.mockImplementation( () => undefined );
 			const check = await checkFeatureEnabled( 'any' );
-			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
-			expect( check ).toBe( false );
-		} );
-	} );
-	describe( 'checkIsVIP', () => {
-		it( 'return true when the public API returns isVIP = true', async () => {
-			getFeatureSpy.mockImplementation( () => {
-				const res = {
-					data: {
-						me: {
-							isVIP: true,
-						},
-					},
-				};
-				return res;
-			} );
-			const check = await checkIsVIP();
-			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
-			expect( check ).toBe( true );
-		} );
-		it( 'returns false when the public API return isVIP = false', async () => {
-			getFeatureSpy.mockImplementation( () => {
-				const res = {
-					data: {
-						me: {
-							isVIP: false,
-						},
-					},
-				};
-				return res;
-			} );
-			const check = await checkIsVIP();
-			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
-			expect( check ).toBe( false );
-		} );
-		it( 'returns false when token is not set', async () => {
-			Token.set( null );
-
-			const check = await checkIsVIP();
-
-			expect( check ).toBe( false );
-		} );
-		it( 'returns false when the public API has no response', async () => {
-			getFeatureSpy.mockImplementation( () => undefined );
-
-			const check = await checkIsVIP();
-
 			expect( getFeatureSpy ).toHaveBeenCalledTimes( 1 );
 			expect( check ).toBe( false );
 		} );

--- a/jest.setupMocks.js
+++ b/jest.setupMocks.js
@@ -3,4 +3,5 @@
  */
 import * as apiConfig from './src/lib/cli/apiConfig';
 
+// This function is mocked globally because it is called by trackEvent.
 jest.spyOn( apiConfig, 'checkIfUserIsVip' ).mockResolvedValue( true );

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -42,13 +42,14 @@ const runCmd = async function() {
 		.command( 'import', 'Import media or SQL files into your VIP applications' )
 		.command( 'search-replace', 'Perform search and replace tasks on files' )
 		.command( 'sync', 'Sync production to a development environment' )
-		.command( 'wp', 'Run WP CLI commands against an environment' )
-		.argv( process.argv );
+		.command( 'wp', 'Run WP CLI commands against an environment' );
 
 	// Gate access to VIP staff.
 	if ( await checkIfUserIsVip() ) {
 		cmd.command( 'config', 'Set configuration for your VIP applications' );
 	}
+
+	cmd.argv( process.argv );
 };
 
 const rootCmd = async function() {

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -13,6 +13,7 @@ import debugLib from 'debug';
  * Internal dependencies
  */
 import config from 'root/config/config.json';
+import { checkIfUserIsVip } from 'lib/cli/apiConfig';
 import command from 'lib/cli/command';
 import Token from 'lib/token';
 import { trackEvent, aliasUser } from 'lib/tracker';
@@ -28,7 +29,7 @@ if ( config && config.environment !== 'production' ) {
 // Config
 const tokenURL = 'https://dashboard.wpvip.com/me/cli/token';
 
-const runCmd = function() {
+const runCmd = async function() {
 	const cmd = command();
 	cmd
 		.command( 'logout', 'Logout from your current session', async () => {
@@ -37,13 +38,17 @@ const runCmd = function() {
 			console.log( 'You are successfully logged out.' );
 		} )
 		.command( 'app', 'List and modify your VIP applications' )
-		.command( 'config', 'Set configuration for your VIP applications' )
 		.command( 'dev-env', 'Use local dev-environment' )
 		.command( 'import', 'Import media or SQL files into your VIP applications' )
 		.command( 'search-replace', 'Perform search and replace tasks on files' )
 		.command( 'sync', 'Sync production to a development environment' )
 		.command( 'wp', 'Run WP CLI commands against an environment' )
 		.argv( process.argv );
+
+	// Gate access to VIP staff.
+	if ( await checkIfUserIsVip() ) {
+		cmd.command( 'config', 'Set configuration for your VIP applications' );
+	}
 };
 
 const rootCmd = async function() {

--- a/src/lib/cli/apiConfig.js
+++ b/src/lib/cli/apiConfig.js
@@ -50,20 +50,9 @@ export async function checkFeatureEnabled(
 	return isVIP === true;
 }
 
-export async function checkIsVIP(): Promise<boolean> {
-	await trackEvent( 'checkIsVIP_start' );
-
-	let isVip = false;
-	try {
-		isVip = await checkIfUserIsVip();
-	} catch ( err ) {
-		const message = err.toString();
-		await trackEvent( 'checkFeatureEnabled_fetch_error', { error: message } );
-	}
-
-	return !! isVip;
-}
-
+// Because this function is called by trackEvent:
+// - It cannot directly or indirectly call trackEvent, or it will cause a loop.
+// - It is mocked globally in jest.setupMocks.js.
 export async function checkIfUserIsVip() {
 	const token = await Token.get();
 


### PR DESCRIPTION
## Description

Temporarily gate access to new config command to VIP staff while we conduct testing and QA.

Also, clean up the `apiConfig` helper to remove unused functions and add comments describing the structure of these commands.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `npm test`
