### PR TITLE
Update envvar list command to only show names

### DIFF
--- a/__tests__/bin/vip-config-envvar-list.js
+++ b/__tests__/bin/vip-config-envvar-list.js
@@ -76,12 +76,12 @@ describe( 'listEnvVarsCommand', () => {
 	} );
 
 	it( 'returns env vars from listEnvVars with correct format', async () => {
-		const returnedEnvVars = [ { key: 'hello' } ];
+		const returnedEnvVars = [ 'hello' ];
 		listEnvVars.mockImplementation( () => Promise.resolve( returnedEnvVars ) );
 
 		await listEnvVarsCommand( args, opts );
 
-		expect( formatData ).toHaveBeenCalledWith( returnedEnvVars, 'csv' );
+		expect( formatData ).toHaveBeenCalledWith( [ { name: 'hello' } ], 'csv' );
 		expect( trackEvent.mock.calls ).toEqual( [ executeEvent, successEvent ] );
 		expect( rollbar.error ).not.toHaveBeenCalled();
 	} );

--- a/src/lib/envvar/api-list.js
+++ b/src/lib/envvar/api-list.js
@@ -34,7 +34,8 @@ const query = gql`
 	}
 `;
 
-export default async function listEnvVars( appId: number, envId: number, format: string ) {
+// List the names (but not values) of environment variables.
+export default async function listEnvVars( appId: number, envId: number ) {
 	const api = await API();
 
 	const variables = {
@@ -44,16 +45,5 @@ export default async function listEnvVars( appId: number, envId: number, format:
 
 	const { data } = await api.query( { query, variables } );
 
-	// Environment variable values are never exposed by the public API.
-	const value = '**********';
-
-	// Vary data by expected format.
-	let key: string = 'name';
-	if ( 'keyValue' === format ) {
-		key = 'key';
-	} else if ( 'ids' === format ) {
-		key = 'id';
-	}
-
-	return data.app.environments[ 0 ].environmentVariables.nodes.map( ( { name } ) => ( { [ key ]: name, value } ) );
+	return data.app.environments[ 0 ].environmentVariables.nodes.map( ( { name } ) => name );
 }


### PR DESCRIPTION
## Description

Product feedback: Masking values and caveating the command made it confusing for users. Instead, the `list` command should only show the names and not act like a command that could potentially show values.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip config envvar list`

