### PR TITLE
Add `config envvar get` and `get-all` commands

### DIFF
--- a/__tests__/bin/vip-config-envvar-get-all.js
+++ b/__tests__/bin/vip-config-envvar-get-all.js
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getAllEnvVarsCommand } from 'bin/vip-config-envvar-get-all';
+import command from 'lib/cli/command';
+import { formatData } from 'lib/cli/format';
+import { getEnvVars } from 'lib/envvar/api';
+import { rollbar } from 'lib/rollbar';
+import { trackEvent } from 'lib/tracker';
+
+function mockExit() {
+	throw 'EXIT'; // can't actually exit the test
+}
+
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+jest.spyOn( rollbar, 'error' ).mockImplementation( () => {} );
+jest.spyOn( process, 'exit' ).mockImplementation( mockExit );
+
+jest.mock( 'lib/cli/command', () => {
+	const commandMock = {
+		argv: () => commandMock,
+		examples: () => commandMock,
+	};
+
+	return jest.fn( () => commandMock );
+} );
+
+jest.mock( 'lib/cli/format', () => ( {
+	formatData: jest.fn(),
+} ) );
+
+jest.mock( 'lib/envvar/api', () => ( {
+	getEnvVars: jest.fn(),
+} ) );
+
+jest.mock( 'lib/envvar/logging', () => ( {
+	debug: jest.fn(),
+	getEnvContext: () => 'test',
+} ) );
+
+jest.mock( 'lib/tracker', () => ( {
+	trackEvent: jest.fn(),
+} ) );
+
+describe( 'vip config envvar get-all', () => {
+	it( 'registers as a command', () => {
+		expect( command ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'getAllEnvVarsCommand', () => {
+	const args = [];
+	const opts = {
+		app: {
+			id: 1,
+			organization: {
+				id: 2,
+			},
+		},
+		env: {
+			id: 3,
+			type: 'develop',
+		},
+		format: 'csv',
+	};
+	const eventPayload = expect.objectContaining( { command: 'vip config envvar get-all' } );
+	const executeEvent = [ 'envvar_get_all_command_execute', eventPayload ];
+	const successEvent = [ 'envvar_get_all_command_success', eventPayload ];
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns env vars from getEnvVars with correct format', async () => {
+		const returnedEnvVars = [ { name: 'HELLO', value: 'bananas' } ];
+		getEnvVars.mockImplementation( () => Promise.resolve( returnedEnvVars ) );
+
+		await getAllEnvVarsCommand( args, opts );
+
+		expect( formatData ).toHaveBeenCalledWith( returnedEnvVars, 'csv' );
+		expect( trackEvent.mock.calls ).toEqual( [ executeEvent, successEvent ] );
+		expect( rollbar.error ).not.toHaveBeenCalled();
+	} );
+
+	it( 'exits with message when there are no env vars', async () => {
+		getEnvVars.mockImplementation( () => Promise.resolve( [] ) );
+
+		await expect( () => getAllEnvVarsCommand( args, opts ) ).rejects.toEqual( 'EXIT' );
+
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'There are no environment variables' ) );
+		expect( process.exit ).toHaveBeenCalled();
+		expect( formatData ).not.toHaveBeenCalled();
+		expect( trackEvent.mock.calls ).toEqual( [ executeEvent, successEvent ] );
+		expect( rollbar.error ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rethrows error thrown from getEnvVars', async () => {
+		const thrownError = new Error( 'fetch error' );
+		const queryErrorEvent = [ 'envvar_get_all_query_error', eventPayload ];
+		getEnvVars.mockImplementation( () => Promise.reject( thrownError ) );
+
+		await expect( () => getAllEnvVarsCommand( args, opts ) ).rejects.toEqual( thrownError );
+
+		expect( formatData ).not.toHaveBeenCalled();
+		expect( trackEvent.mock.calls ).toEqual( [ executeEvent, queryErrorEvent ] );
+		expect( rollbar.error ).toHaveBeenCalledWith( thrownError );
+	} );
+} );
+

--- a/__tests__/bin/vip-config-envvar-get.js
+++ b/__tests__/bin/vip-config-envvar-get.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getEnvVarCommand } from 'bin/vip-config-envvar-get';
+import command from 'lib/cli/command';
+import { getEnvVar } from 'lib/envvar/api';
+import { rollbar } from 'lib/rollbar';
+import { trackEvent } from 'lib/tracker';
+
+function mockExit() {
+	throw 'EXIT'; // can't actually exit the test
+}
+
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+jest.spyOn( rollbar, 'error' ).mockImplementation( () => {} );
+jest.spyOn( process, 'exit' ).mockImplementation( mockExit );
+
+jest.mock( 'lib/cli/command', () => {
+	const commandMock = {
+		argv: () => commandMock,
+		examples: () => commandMock,
+	};
+
+	return jest.fn( () => commandMock );
+} );
+
+jest.mock( 'lib/envvar/api', () => ( {
+	getEnvVar: jest.fn(),
+} ) );
+
+jest.mock( 'lib/envvar/logging', () => ( {
+	debug: jest.fn(),
+	getEnvContext: () => 'test',
+} ) );
+
+jest.mock( 'lib/tracker', () => ( {
+	trackEvent: jest.fn(),
+} ) );
+
+describe( 'vip config envvar get', () => {
+	it( 'registers as a command', () => {
+		expect( command ).toHaveBeenCalled();
+	} );
+} );
+
+describe( 'getEnvVarCommand', () => {
+	const args = [ 'HELLO' ];
+	const opts = {
+		app: {
+			id: 1,
+			organization: {
+				id: 2,
+			},
+		},
+		env: {
+			id: 3,
+			type: 'develop',
+		},
+	};
+	const eventPayload = expect.objectContaining( { command: 'vip config envvar get HELLO' } );
+	const executeEvent = [ 'envvar_get_command_execute', eventPayload ];
+	const successEvent = [ 'envvar_get_command_success', eventPayload ];
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns an env var from getEnvVar with correct format', async () => {
+		const returnedEnvVar = { name: 'HELLO', value: 'banana' };
+		getEnvVar.mockImplementation( () => Promise.resolve( returnedEnvVar ) );
+
+		await getEnvVarCommand( args, opts );
+
+		expect( console.log ).toHaveBeenCalledWith( 'banana' );
+		expect( trackEvent.mock.calls ).toEqual( [ executeEvent, successEvent ] );
+		expect( rollbar.error ).not.toHaveBeenCalled();
+	} );
+
+	it( 'exits with message when the env var doesn’t exist', async () => {
+		getEnvVar.mockImplementation( () => Promise.resolve( null ) );
+
+		await expect( () => getEnvVarCommand( args, opts ) ).rejects.toEqual( 'EXIT' );
+
+		expect( console.log ).toHaveBeenCalledWith( expect.stringContaining( 'The environment variable "HELLO" does not exist' ) );
+		expect( process.exit ).toHaveBeenCalled();
+		expect( trackEvent.mock.calls ).toEqual( [ executeEvent, successEvent ] );
+		expect( rollbar.error ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rethrows error thrown from getEnvVar', async () => {
+		const thrownError = new Error( 'fetch error' );
+		const queryErrorEvent = [ 'envvar_get_query_error', eventPayload ];
+		getEnvVar.mockImplementation( () => Promise.reject( thrownError ) );
+
+		await expect( () => getEnvVarCommand( args, opts ) ).rejects.toEqual( thrownError );
+
+		expect( trackEvent.mock.calls ).toEqual( [ executeEvent, queryErrorEvent ] );
+		expect( rollbar.error ).toHaveBeenCalledWith( thrownError );
+	} );
+} );
+

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "vip-config": "dist/bin/vip-config.js",
     "vip-config-envvar": "dist/bin/vip-config-envvar.js",
     "vip-config-envvar-delete": "dist/bin/vip-config-envvar-delete.js",
+    "vip-config-envvar-get": "dist/bin/vip-config-envvar-get.js",
+    "vip-config-envvar-get-all": "dist/bin/vip-config-envvar-get-all.js",
     "vip-config-envvar-list": "dist/bin/vip-config-envvar-list.js",
     "vip-config-envvar-set": "dist/bin/vip-config-envvar-set.js",
     "vip-dev-env": "dist/bin/vip-dev-env.js",

--- a/src/bin/vip-config-envvar-get-all.js
+++ b/src/bin/vip-config-envvar-get-all.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import chalk from 'chalk';
+
+/**
+ * Internal dependencies
+ */
+import command from 'lib/cli/command';
+import { formatData } from 'lib/cli/format';
+import { appQuery, getEnvVars } from 'lib/envvar/api';
+import { debug, getEnvContext } from 'lib/envvar/logging';
+import { rollbar } from 'lib/rollbar';
+import { trackEvent } from 'lib/tracker';
+
+const usage = 'vip config envvar get-all';
+
+// Command examples
+const examples = [
+	{
+		usage,
+		description: 'Get the values of all environment variables',
+	},
+];
+
+export async function getAllEnvVarsCommand( arg: string[], opt ): void {
+	const trackingParams = {
+		app_id: opt.app.id,
+		command: usage,
+		env_id: opt.env.id,
+		format: opt.format,
+		org_id: opt.app.organization.id,
+	};
+
+	debug( `Request: Get all environment variables for ${ getEnvContext( opt.app, opt.env ) }` );
+	await trackEvent( 'envvar_get_all_command_execute', trackingParams );
+
+	const envvars = await getEnvVars( opt.app.id, opt.env.id )
+		.catch( async err => {
+			rollbar.error( err );
+			await trackEvent( 'envvar_get_all_query_error', { ...trackingParams, error: err.message } );
+
+			throw err;
+		} );
+
+	await trackEvent( 'envvar_get_all_command_success', trackingParams );
+
+	if ( 0 === envvars.length ) {
+		console.log( chalk.yellow( 'There are no environment variables' ) );
+		process.exit();
+	}
+
+	// Vary data by expected format.
+	let key = 'name';
+	if ( 'keyValue' === opt.format ) {
+		key = 'key';
+	} else if ( 'ids' === opt.format ) {
+		key = 'id';
+	}
+
+	const envvarsObject = envvars.map( ( { name: envvarName, value } ) => ( { [ key ]: envvarName, value } ) );
+
+	console.log( formatData( envvarsObject, opt.format ) );
+}
+
+command( {
+	appContext: true,
+	appQuery,
+	envContext: true,
+	format: true,
+	usage,
+} )
+	.examples( examples )
+	.argv( process.argv, getAllEnvVarsCommand );
+

--- a/src/bin/vip-config-envvar-get.js
+++ b/src/bin/vip-config-envvar-get.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import chalk from 'chalk';
+
+/**
+ * Internal dependencies
+ */
+import command from 'lib/cli/command';
+import { appQuery, getEnvVar } from 'lib/envvar/api';
+import { debug, getEnvContext } from 'lib/envvar/logging';
+import { rollbar } from 'lib/rollbar';
+import { trackEvent } from 'lib/tracker';
+
+const baseUsage = 'vip config envvar get';
+
+// Command examples
+const examples = [
+	{
+		usage: `${ baseUsage } MY_VARIABLE`,
+		description: 'Get the value of the environment variable "MY_VARIABLE"',
+	},
+];
+
+export async function getEnvVarCommand( arg: string[], opt ): void {
+	// Help the user by uppercasing input.
+	const name = arg[ 0 ].trim().toUpperCase();
+
+	const trackingParams = {
+		app_id: opt.app.id,
+		command: `${ baseUsage } ${ name }`,
+		env_id: opt.env.id,
+		org_id: opt.app.organization.id,
+		variable_name: name,
+	};
+
+	debug( `Request: Get environment variable ${ JSON.stringify( name ) } for ${ getEnvContext( opt.app, opt.env ) }` );
+	await trackEvent( 'envvar_get_command_execute', trackingParams );
+
+	const envvar = await getEnvVar( opt.app.id, opt.env.id, name )
+		.catch( async err => {
+			rollbar.error( err );
+			await trackEvent( 'envvar_get_query_error', { ...trackingParams, error: err.message } );
+
+			throw err;
+		} );
+
+	await trackEvent( 'envvar_get_command_success', trackingParams );
+
+	if ( ! envvar ) {
+		const message = `The environment variable ${ JSON.stringify( name ) } does not exist`;
+		console.log( chalk.yellow( message ) );
+		process.exit();
+	}
+
+	console.log( envvar.value );
+}
+
+command( {
+	appContext: true,
+	appQuery,
+	envContext: true,
+	requiredArgs: 1,
+	usage: `${ baseUsage } <VARIABLE_NAME>`,
+} )
+	.examples( examples )
+	.argv( process.argv, getEnvVarCommand );
+

--- a/src/bin/vip-config-envvar.js
+++ b/src/bin/vip-config-envvar.js
@@ -18,6 +18,8 @@ command( {
 	requiredArgs: 1,
 } )
 	.command( 'delete', 'Permanently delete an environment variable' )
-	.command( 'list', 'List all environment variables' )
+	.command( 'get', 'Get the value of an environment variable' )
+	.command( 'get-all', 'Get the values of all environment variable' )
+	.command( 'list', 'List the names of all environment variables' )
 	.command( 'set', 'Add or update an environment variable' )
 	.argv( process.argv );

--- a/src/bin/vip-config.js
+++ b/src/bin/vip-config.js
@@ -14,7 +14,6 @@ command( {
 	requiredArgs: 2,
 } )
 	.command( 'envvar', 'Manage environment variables for an application environment' )
-	.argv( process.argv, async ( arg, opts ) => {
-		console.log( 'hello from here' );
+	.argv( process.argv, async () => {
 		process.exit( 0 );
 	} );

--- a/src/lib/envvar/api-get-all.js
+++ b/src/lib/envvar/api-get-all.js
@@ -1,0 +1,50 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+
+const query = gql`
+	query GetEnvironmentVariablesWithValues(
+		$appId: Int!
+		$envId: Int!
+	) {
+		app(
+			id: $appId
+		) {
+			id
+			environments(
+				id: $envId
+			) {
+				id
+				environmentVariables {
+					total
+					nodes {
+						name
+						# value
+					}
+				}
+			}
+		}
+	}
+`;
+
+export default async function getEnvVars( appId: number, envId: number ) {
+	const api = await API();
+
+	const variables = {
+		appId,
+		envId,
+	};
+
+	const { data } = await api.query( { query, variables } );
+
+	return data.app.environments[ 0 ].environmentVariables.nodes;
+}
+

--- a/src/lib/envvar/api-get-all.js
+++ b/src/lib/envvar/api-get-all.js
@@ -27,7 +27,7 @@ const query = gql`
 					total
 					nodes {
 						name
-						# value
+						value
 					}
 				}
 			}

--- a/src/lib/envvar/api-get.js
+++ b/src/lib/envvar/api-get.js
@@ -1,0 +1,15 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import getEnvVars from 'lib/envvar/api-get-all';
+
+export default async function getEnvVar( appId: number, envId: number, name: string ) {
+	const envvars = await getEnvVars( appId, envId );
+	return envvars.find( ( { name: foundName } ) => name === foundName );
+}

--- a/src/lib/envvar/api.js
+++ b/src/lib/envvar/api.js
@@ -13,12 +13,16 @@ import chalk from 'chalk';
  */
 import { debug } from 'lib/envvar/logging';
 import deleteEnvVar from './api-delete';
+import getEnvVar from './api-get';
+import getEnvVars from './api-get-all';
 import listEnvVars from './api-list';
 import setEnvVar from './api-set';
 
 // Reexport for convenience
 export {
 	deleteEnvVar,
+	getEnvVar,
+	getEnvVars,
 	listEnvVars,
 	setEnvVar,
 };


### PR DESCRIPTION
## Description

Adding `get` and `get-all` subcommands to allow org and app admins to retrieve the value of environment variables. Access control is handled by Parker.

## Steps to Test

1. Check out PR.
2. Point to local Parker with `update/allow-get-env-var` branch checked out.
1. Run `npm run build`
1. Run `./dist/bin/vip config envvar get CUSTOM_VAR`
1. Verify envvars are delicious.

