### PR TITLE
[dev-env] Make search data persistent between restarts

### DIFF
--- a/assets/dev-environment.lando.template.yml.ejs
+++ b/assets/dev-environment.lando.template.yml.ejs
@@ -90,6 +90,10 @@ services:
         ELASTICSEARCH_NODE_NAME: 'lando'
         ELASTICSEARCH_PORT_NUMBER: 9200
         discovery.type: 'single-node'
+      volumes:
+        - search_data:/usr/share/elasticsearch/data
+    volumes:
+      search_data:
 
 <% if ( statsd ) { %>
   statsd:


### PR DESCRIPTION
## Description

Persist data stored in ElasticSearch after the environment is shut down.

## Steps to Test

1) Create an env with the vip version from this pr
2) Have a client code enabling search
3) Start env `vip dev-env start`
4) Add a post
5) Stop env `vip dev-env stop`
6) Start env again `vip dev-env start` 
7) ... verify the doc representing the post you added in step 4 is still present in index. (you can do `vip dev-env exec -- wp vip-search documents get post <id>`)
