### PR TITLE
[dev-env] mount wordpress code

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -178,7 +178,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				.mockResolvedValueOnce( input.mode )
 				.mockResolvedValueOnce( input.path );
 
-			const result = await promptForComponent( input.component );
+			const result = await promptForComponent( input.component, true );
 
 			expect( result ).toStrictEqual( input.expected );
 		} );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -96,22 +96,34 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{ // wordpress tag
 				param: 5.6,
 				option: 'wordpress',
+				allowLocal: true,
 				expected: {
 					image: 'ghcr.io/automattic/vip-container-images/wordpress',
 					mode: 'image',
 					tag: '5.6',
 				},
 			},
+			{ // wordpress local is not allowed
+				param: '/tmp/wp',
+				option: 'wordpress',
+				allowLocal: false,
+				expected: {
+					image: 'ghcr.io/automattic/vip-container-images/wordpress',
+					mode: 'image',
+					tag: '/tmp/wp',
+				},
+			},
 			{ // muPlugins - path
 				param: '~/path',
 				option: 'muPlugins',
+				allowLocal: true,
 				expected: {
 					mode: 'local',
 					dir: '~/path',
 				},
 			},
 		] )( 'should process options and use defaults', async input => {
-			const result = processComponentOptionInput( input.param, input.option );
+			const result = processComponentOptionInput( input.param, input.option, input.allowLocal );
 
 			expect( result ).toStrictEqual( input.expected );
 		} );
@@ -133,23 +145,13 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 		} );
 
 		it.each( [
-			{
-				component: 'wordpress',
+			{ // mu plugins local
+				component: 'muPlugins',
 				mode: 'local',
 				path: '/tmp',
 				expected: {
 					mode: 'local',
 					dir: '/tmp',
-				},
-			},
-			{
-				component: 'wordpress',
-				mode: 'image',
-				path: '5.6',
-				expected: {
-					mode: 'image',
-					image: 'ghcr.io/automattic/vip-container-images/wordpress',
-					tag: '5.6',
 				},
 			},
 			{ // muPlugins hav just one tag - auto
@@ -177,6 +179,24 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				.mockResolvedValueOnce( input.path );
 
 			const result = await promptForComponent( input.component );
+
+			expect( result ).toStrictEqual( input.expected );
+		} );
+
+		it.each( [
+			{
+				tag: '5.6',
+				expected: {
+					mode: 'image',
+					image: 'ghcr.io/automattic/vip-container-images/wordpress',
+					tag: '5.6',
+				},
+			},
+		] )( 'should return correct component for wordpress %p', async input => {
+			selectRunMock
+				.mockResolvedValueOnce( input.tag );
+
+			const result = await promptForComponent( 'wordpress', false );
 
 			expect( result ).toStrictEqual( input.expected );
 		} );

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -106,17 +106,13 @@ services:
       command: node stats.js /config/statsd-config.js
 <% } %>
 
-<% if ( wordpress.mode == 'image' ) { %>
   wordpress:
     type: compose
     services:
       image: <%= wordpress.image %>:<%= wordpress.tag %>
       command: sh -c "rsync -a /wp/ /shared/; sleep infinity"
       volumes:
-        - wordpress:/shared
-    volumes:
-      wordpress: {}
-<% } %>
+        - ./wordpress:/shared
 
 <% if ( muPlugins.mode == 'image' ) { %>
   mu-plugins:
@@ -178,15 +174,7 @@ tooling:
         - ./config:/wp/config
         - ./log:/wp/log
         - ./uploads:/wp/wp-content/uploads
-<% if ( wordpress.mode == 'image' ) { %>
-        - type: volume
-          source: wordpress
-          target: /wp
-          volume:
-            nocopy: true
-<% } else { %>
-        - <%= wordpress.dir %>:/wp
-<% } %>
+        - ./wordpress:/wp
 <% if ( muPlugins.mode == 'image' ) { %>
         - type: volume
           source: mu-plugins

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -12,7 +12,7 @@ services:
   devtools:
     type: compose
     services:
-      image: ghcr.io/automattic/vip-container-images/dev-tools:0.6
+      image: ghcr.io/automattic/vip-container-images/dev-tools:0.7
       command: sleep infinity
       volumes:
         - devtools:/dev-tools

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -47,9 +47,11 @@ services:
           volume:
             nocopy: true
 <% wpVolumes() %>
-
-    run_as_root:
+    run:
       - sh /dev-tools/setup.sh database root "http://<%= siteSlug %>.vipdev.lndo.site/" "<%= wpTitle %>" <% if ( multisite ) { %> <%= siteSlug %>.vipdev.lndo.site <% } %>
+    run_as_root:
+      - echo "Copying dev-env-plugin.php to mu-plugins"
+      - cp /dev-tools/dev-env-plugin.php /wp/wp-content/mu-plugins/
 
   database:
     type: compose

--- a/package-lock.json
+++ b/package-lock.json
@@ -10576,7 +10576,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -13233,7 +13233,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -263,11 +263,11 @@ export async function promptForComponent( component: string, allowLocal: boolean
 	let modeResult = initialMode;
 	const selectMode = choices.length > 1;
 	if ( selectMode ) {
-		const initialModeIx = choices.findIndex( choice => choice.value === initialMode );
+		const initialModeIndex = choices.findIndex( choice => choice.value === initialMode );
 		const select = new Select( {
 			message: `How would you like to source ${ componentDisplayName }`,
 			choices,
-			initial: initialModeIx,
+			initial: initialModeIndex,
 		} );
 
 		modeResult = await select.run();

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -96,10 +96,10 @@ type ComponentConfig = {
 	tag?: string,
 }
 
-export function processComponentOptionInput( passedParam: string, type: string ): ComponentConfig {
+export function processComponentOptionInput( passedParam: string, type: string, allowLocal: boolean ): ComponentConfig {
 	// cast to string
 	const param = passedParam + '';
-	if ( param.includes( '/' ) ) {
+	if ( allowLocal && param.includes( '/' ) ) {
 		return {
 			mode: 'local',
 			dir: param,
@@ -173,10 +173,11 @@ export async function promptForArguments( providedOptions: NewInstanceOptions, a
 async function processComponent( component: string, option: string ) {
 	let result = null;
 
+	const allowLocal = component !== 'wordpress';
 	if ( option ) {
-		result = processComponentOptionInput( option, component );
+		result = processComponentOptionInput( option, component, allowLocal );
 	} else {
-		result = await promptForComponent( component );
+		result = await promptForComponent( component, allowLocal );
 	}
 
 	while ( 'local' === result?.mode ) {
@@ -239,32 +240,42 @@ const componentDisplayNames = {
 	clientCode: 'site-code',
 };
 
-export async function promptForComponent( component: string ): Promise<ComponentConfig> {
+export async function promptForComponent( component: string, allowLocal: boolean ): Promise<ComponentConfig> {
 	const componentDisplayName = componentDisplayNames[ component ] || component;
-	const choices = [
-		{
+	const choices = [];
+
+	if ( allowLocal ) {
+		choices.push( {
 			message: `local folder - where you already have ${ componentDisplayName } code`,
 			value: 'local',
-		},
-		{
-			message: 'image - that gets automatically fetched',
-			value: 'image',
-		},
-	];
-	let initial = 1;
-	if ( 'clientCode' === component ) {
-		initial = 0;
+		} );
 	}
-
-	const select = new Select( {
-		message: `How would you like to source ${ componentDisplayName }`,
-		choices,
-		initial,
+	choices.push( {
+		message: 'image - that gets automatically fetched',
+		value: 'image',
 	} );
 
-	const modeResult = await select.run();
+	let initial = 'image';
+	if ( 'clientCode' === component ) {
+		initial = 'local';
+	}
+
+	let modeResult = initial;
+	const selectMode = choices.length > 1;
+	if ( selectMode ) {
+		const initialIx = choices.findIndex( choice => choice.value === initial );
+		const select = new Select( {
+			message: `How would you like to source ${ componentDisplayName }`,
+			choices,
+			initial: initialIx,
+		} );
+
+		modeResult = await select.run();
+	}
+
+	const messagePrefix = selectMode ? '\t' : `${ componentDisplayName } - `;
 	if ( 'local' === modeResult ) {
-		const directoryPath = await promptForText( `	What is a path to your local ${ componentDisplayName }`, '' );
+		const directoryPath = await promptForText( `${ messagePrefix }What is a path to your local ${ componentDisplayName }`, '' );
 		return {
 			mode: modeResult,
 			dir: directoryPath,
@@ -281,8 +292,9 @@ export async function promptForComponent( component: string ): Promise<Component
 	const componentsWithPredefinedImageTag = [ 'muPlugins', 'clientCode' ];
 
 	if ( ! componentsWithPredefinedImageTag.includes( component ) ) {
+		const message = `${ messagePrefix }Which version would you like`;
 		const selectTag = new Select( {
-			message: '	Which version would you like',
+			message,
 			choices: getLatestImageTags( component ),
 		} );
 		tag = await selectTag.run();

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -255,19 +255,19 @@ export async function promptForComponent( component: string, allowLocal: boolean
 		value: 'image',
 	} );
 
-	let initial = 'image';
+	let initialMode = 'image';
 	if ( 'clientCode' === component ) {
-		initial = 'local';
+		initialMode = 'local';
 	}
 
-	let modeResult = initial;
+	let modeResult = initialMode;
 	const selectMode = choices.length > 1;
 	if ( selectMode ) {
-		const initialIx = choices.findIndex( choice => choice.value === initial );
+		const initialModeIx = choices.findIndex( choice => choice.value === initialMode );
 		const select = new Select( {
 			message: `How would you like to source ${ componentDisplayName }`,
 			choices,
-			initial: initialIx,
+			initial: initialModeIx,
 		} );
 
 		modeResult = await select.run();


### PR DESCRIPTION
Local WP source code is not working on dev-env. The reason is that we do some patches and add extra files so that wp works similar to our prod site.

Therefore we will drop the option to link to the local codebase, but will instead mount wp source files automatically to the env location so that folks can change those to debug/test.

# Test
* Create new environemnt.
* Notice the wizzard is only prompting for a version of WP not local vs image anymore.
* In the environment location there is a `wordpress` folder containing the mount of wp source files.

**Note:** The user permissions are not happy with this as we have a rather complex system of images now, and they mount into each others file system. Some files ended up owned by root which makes `destroy` that removes those to fail. The solution is to run install not as root, but that breaks copying to mu-plugins. That's why there is that `run_as_root` change. - https://github.com/Automattic/vip-container-images/pull/27