### PR TITLE
[dev-env] Primary domain prompt for primary domain redirect

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -136,6 +136,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 						type: 'develop',
 						branch: 'dev',
 						isMultisite: true,
+						primaryDomain: '',
 					},
 				},
 			},
@@ -178,6 +179,9 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 							type: 'develop',
 							branch: 'dev',
 							isMultisite: true,
+							primaryDomain: {
+								name: 'test.develop.com',
+							},
 						},
 						{
 							name: 'prodName',
@@ -196,6 +200,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 						type: 'develop',
 						branch: 'dev',
 						isMultisite: true,
+						primaryDomain: 'test.develop.com',
 					},
 				},
 			},

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -84,6 +84,7 @@ command()
 			debug( `WARNING: ${ message }`, error.message );
 			console.log( chalk.yellow( 'Warning:' ), message );
 		}
+		debug( 'App Info', appInfo );
 
 		const instanceData = await promptForArguments( opt, appInfo );
 		const instanceDataWithSlug = {
@@ -92,7 +93,6 @@ command()
 			statsd: opt.statsd || false,
 			phpmyadmin: opt.phpmyadmin || false,
 			xdebug: opt.xdebug || false,
-			mediaRedirectDomain: opt.mediaRedirectDomain || '',
 		};
 
 		try {

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -84,7 +84,6 @@ command()
 			debug( `WARNING: ${ message }`, error.message );
 			console.log( chalk.yellow( 'Warning:' ), message );
 		}
-		debug( 'App Info', appInfo );
 
 		const instanceData = await promptForArguments( opt, appInfo );
 		const instanceDataWithSlug = {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -133,6 +133,7 @@ type AppInfo = {
 		type: string,
 		branch: string,
 		isMultisite: boolean,
+		primaryDomain: string,
 	}
 }
 
@@ -156,10 +157,20 @@ export async function promptForArguments( providedOptions: NewInstanceOptions, a
 		multisite: 'multisite' in providedOptions ? providedOptions.multisite : await promptForBoolean( multisiteText, multisiteDefault ),
 		elasticsearch: providedOptions.elasticsearch || DEV_ENVIRONMENT_DEFAULTS.elasticsearchVersion,
 		mariadb: providedOptions.mariadb || DEV_ENVIRONMENT_DEFAULTS.mariadbVersion,
+		mediaRedirectDomain: '',
 		wordpress: {},
 		muPlugins: {},
 		clientCode: {},
 	};
+
+	const primaryDomain = appInfo?.environment?.primaryDomain;
+	if ( primaryDomain ) {
+		const mediaRedirectPromptText = `Would you like to redirect to ${ primaryDomain } for missing media files?`;
+		const setMediaRedirectDomain = await promptForBoolean( mediaRedirectPromptText, true );
+		if ( setMediaRedirectDomain ) {
+			instanceData.mediaRedirectDomain = primaryDomain;
+		}
+	}
 
 	for ( const component of DEV_ENVIRONMENT_COMPONENTS ) {
 		const option = providedOptions[ component ];

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -258,7 +258,10 @@ export async function getApplicationInformation( appId: number, envType: string 
 			name,
 			type,
 			branch,
-			isMultisite
+			isMultisite,
+			primaryDomain {
+				name
+			}
 		}`;
 
 	const queryResult = await app( appId, fieldsQuery );
@@ -284,6 +287,7 @@ export async function getApplicationInformation( appId: number, envType: string 
 				branch: envData.branch,
 				type: envData.type,
 				isMultisite: envData.isMultisite,
+				primaryDomain: envData.primaryDomain?.name || '',
 			};
 		}
 	}


### PR DESCRIPTION
## Description

When using the `@` notation we should prompt for domain. Eg:

```
$ vip dev-env @2891 create 
This is a wizard to help you set up your local dev environment.

Sensible default values were pre-selected for convenience. You may also choose to create multiple environments with different settings using the --slug option.


✔ WordPress site title · pschoffer-develop.go-vip.net
✔ Multisite (pschoffer-develop.go-vip.net is NOT multisite) (y/N) · false
✔ Would you like to redirect to pschoffer-develop.go-vip.net for missing media files? (Y/n) · true

```


