### PR TITLE
[dev-env] Custom user permissions setup

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -49,10 +49,10 @@ services:
           volume:
             nocopy: true
         - type: volume
-            source: scripts
-            target: /scripts
-            volume:
-              nocopy: true
+          source: scripts
+          target: /scripts
+          volume:
+            nocopy: true
 <% wpVolumes() %>
     run:
       - sh /dev-tools/setup.sh database root "http://<%= siteSlug %>.vipdev.lndo.site/" "<%= wpTitle %>" <% if ( multisite ) { %> <%= siteSlug %>.vipdev.lndo.site <% } %>

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -16,8 +16,10 @@ services:
       command: sleep infinity
       volumes:
         - devtools:/dev-tools
+        - scripts:/scripts
     volumes:
       devtools: {}
+      scripts:
 
   nginx:
     type: compose
@@ -46,6 +48,11 @@ services:
           target: /dev-tools
           volume:
             nocopy: true
+        - type: volume
+            source: scripts
+            target: /scripts
+            volume:
+              nocopy: true
 <% wpVolumes() %>
     run:
       - sh /dev-tools/setup.sh database root "http://<%= siteSlug %>.vipdev.lndo.site/" "<%= wpTitle %>" <% if ( multisite ) { %> <%= siteSlug %>.vipdev.lndo.site <% } %>
@@ -120,6 +127,11 @@ services:
       command: sh -c "rsync -a /wp/ /shared/; sleep infinity"
       volumes:
         - ./wordpress:/shared
+        - type: volume
+          source: scripts
+          target: /scripts
+          volume:
+            nocopy: true
 
 <% if ( muPlugins.mode == 'image' ) { %>
   mu-plugins:
@@ -129,6 +141,11 @@ services:
       command: sh -c 'rsync -a /mu-plugins/ /shared/; sh /autoupdate.sh /shared'
       volumes:
         - mu-plugins:/shared
+        - type: volume
+          source: scripts
+          target: /scripts
+          volume:
+            nocopy: true
     volumes:
       mu-plugins: {}
 <% } %>

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -41,6 +41,7 @@ services:
       environment:
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
         STATSD: <%= statsd ? 'enable' : 'disable' %>
+        LANDO_NO_USER_PERMS: "We have our own user mapping script under /scripts"
 
       volumes:
         - type: volume

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -41,7 +41,9 @@ services:
       environment:
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
         STATSD: <%= statsd ? 'enable' : 'disable' %>
-        LANDO_NO_USER_PERMS: "We have our own user mapping script under /scripts"
+
+        LANDO_NO_USER_PERMS: 'enable'
+
 
       volumes:
         - type: volume


### PR DESCRIPTION
In some cases lando's user permission setup fails to map `www-data` user to the current running user.

This causes `dev-env` unusable and undeletable.

One scenario that the user mapping can fail is that user ID is higher than what `alpine` supports by default.

In this change we map `/scritps` from dev-tools to containers that need `www-data` user. Our script is able to create the user even with the high ID as we are able to adjust the script to the specific containers we are using.

## Steps to Test

1) Create and start new environments.
2) [optional] Create and start new environment while your user's OS ID is over `256000`
   - Depends on your OS how, but something like this:
    - `sudo useradd high-id-user -M -N -l -r -u 42000002`
    - `su high-id-user`

