### PR TITLE
Update/no login dev env

### DIFF
--- a/__tests__/lib/cli/command.js
+++ b/__tests__/lib/cli/command.js
@@ -1,0 +1,35 @@
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { containsAppEnvArgument } from 'lib/cli/command';
+
+describe( 'utils/cli/command', () => {
+	describe( 'containsAppEnvArgument', () => {
+		it.each( [
+			[
+				[ 'test', 'one' ],
+				false,
+			],
+			[
+				[ 'test', '@123', 'dev-env' ],
+				true,
+			],
+			[
+				[ 'test', '@123.develop', 'dev-env' ],
+				true,
+			],
+			[
+				[ 'test', '--app', '123', 'dev-env' ],
+				true,
+			],
+		] )( 'should identify app/env arguments - %p', ( argv, expected ) => {
+			const result = containsAppEnvArgument( argv );
+			expect( result ).toBe( expected );
+		} );
+	} );
+} );

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -13,7 +13,7 @@ import debugLib from 'debug';
  * Internal dependencies
  */
 import config from 'root/config/config.json';
-import command from 'lib/cli/command';
+import command, { containsAppEnvArgument } from 'lib/cli/command';
 import Token from 'lib/token';
 import { trackEvent, aliasUser } from 'lib/tracker';
 import { rollbar } from 'lib/rollbar';
@@ -52,10 +52,11 @@ const rootCmd = async function() {
 
 	const isHelpCommand = process.argv.some( arg => arg === 'help' || arg === '-h' || arg === '--help' );
 	const isLogoutCommand = process.argv.some( arg => arg === 'logout' );
+	const isDevEnvCommandWithoutEnv = process.argv.some( arg => arg === 'dev-env' ) && ! containsAppEnvArgument( process.argv );
 
 	debug( 'Argv:', process.argv );
 
-	if ( isLogoutCommand || isHelpCommand || ( token && token.valid() ) ) {
+	if ( isLogoutCommand || isHelpCommand || isDevEnvCommandWithoutEnv || ( token && token.valid() ) ) {
 		runCmd();
 	} else {
 		console.log();

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -537,3 +537,19 @@ export function getEnvIdentifier( env ) {
 
 	return identifier;
 }
+
+export function containsAppEnvArgument( argv ) {
+	const parsedAlias = parseEnvAliasFromArgv( argv );
+
+	const options = args
+		.option( 'app', 'app' )
+		.option( 'env', 'env' )
+		.parse( parsedAlias.argv );
+
+	if ( parsedAlias.app ) {
+		options.app = parsedAlias.app;
+		options.env = parsedAlias.env;
+	}
+
+	return !! ( options.app || options.env );
+}

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -541,15 +541,5 @@ export function getEnvIdentifier( env ) {
 export function containsAppEnvArgument( argv ) {
 	const parsedAlias = parseEnvAliasFromArgv( argv );
 
-	const options = args
-		.option( 'app', 'app' )
-		.option( 'env', 'env' )
-		.parse( parsedAlias.argv );
-
-	if ( parsedAlias.app ) {
-		options.app = parsedAlias.app;
-		options.env = parsedAlias.env;
-	}
-
-	return !! ( options.app || options.env );
+	return !! ( parsedAlias.app || parsedAlias.env || argv.includes( '--app' ) || argv.includes( '--env' ) );
 }


### PR DESCRIPTION


## Description

`dev-env` subcommands don't communicate with parker most of the time. The only exception is when `@app.env` arguments are provided we prefetch some info about env.

This change stops requiring login to use the other parts of `dev-env` subcommands. This was recently requested to support customers-to-be that dont yet have an account to log in to.

## Steps to Test

1) Logout `vip logout`
2) Try some dev-env commands without app `vip dev-env create` / `vip dev-env info` .... should work without login
3) Try some dev-env commands with app `vip @2891 create` / `vip dev-env @2891 info` ... should ask you to login
