### PR TITLE
Add warning message when an envvar is set/deleted

### DIFF
--- a/src/bin/vip-config-envvar-delete.js
+++ b/src/bin/vip-config-envvar-delete.js
@@ -74,6 +74,11 @@ export async function deleteEnvVarCommand( arg: string[], opt ) {
 
 	await trackEvent( 'envvar_delete_command_success', trackingParams );
 	console.log( chalk.green( `Successfully deleted environment variable ${ JSON.stringify( name ) }` ) );
+
+	if ( ! opt.skipConfirmation ) {
+		console.log( chalk.bgYellow( chalk.bold( 'Important:' ) ),
+			'Updates to environment variables will not be available until the application’s next deploy.' );
+	}
 }
 
 command( {

--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -91,6 +91,11 @@ export async function setEnvVarCommand( arg: string[], opt ) {
 
 	await trackEvent( 'envvar_set_command_success', trackingParams );
 	console.log( chalk.green( `Successfully set environment variable ${ JSON.stringify( name ) }` ) );
+
+	if ( ! opt.skipConfirmation ) {
+		console.log( chalk.bgYellow( chalk.bold( 'Important:' ) ),
+			'Updates to environment variables will not be available until the application’s next deploy.' );
+	}
 }
 
 command( {


### PR DESCRIPTION
## Description

Add a warning message with a reminder that changes to the environment variables will only be applied upon an application deployment.

If `--skip-confirmation` is passed, the message will not be displayed.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `npm link`
1. Run `vip @1234.production config envvar set TESTING_VAR` (replace `@1234.production` with your environment).
2. You should see `Important: Updates to environment variables will not be available until the application’s next deploy.` after the success message.
3. Run `vip @1234.production config envvar delete TESTING_VAR` and check for the same message.
4. Try the previous commands with the `--skip-confirmation` flag and you shouldn't see the `Important` message.

