### PR TITLE
[dev-env] Save instance data state

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -92,7 +92,6 @@ command()
 			statsd: opt.statsd || false,
 			phpmyadmin: opt.phpmyadmin || false,
 			xdebug: opt.xdebug || false,
-			version: 1.0,
 		};
 
 		try {

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -92,6 +92,7 @@ command()
 			statsd: opt.statsd || false,
 			phpmyadmin: opt.phpmyadmin || false,
 			xdebug: opt.xdebug || false,
+			version: 1.0,
 		};
 
 		try {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -30,6 +30,7 @@ const landoFileTemplatePath = path.join( __dirname, '..', '..', '..', 'assets', 
 const nginxFileTemplatePath = path.join( __dirname, '..', '..', '..', 'assets', 'dev-env.nginx.template.conf.ejs' );
 const landoFileName = '.lando.yml';
 const nginxFileName = 'extra.conf';
+const instanceDataFileName = 'instance_data.json';
 
 const homeDirPathInsideContainers = '/user';
 
@@ -91,6 +92,7 @@ type NewInstanceData = {
 	muPlugins: Object,
 	clientCode: Object,
 	mediaRedirectDomain: string,
+	version: number,
 }
 
 export async function createEnvironment( instanceData: NewInstanceData ) {
@@ -207,19 +209,23 @@ export function doesEnvironmentExist( slug: string ) {
 async function prepareLandoEnv( instanceData, instancePath ) {
 	const landoFile = await ejs.renderFile( landoFileTemplatePath, instanceData );
 	const nginxFile = await ejs.renderFile( nginxFileTemplatePath, instanceData );
+	const instanceDataFile = JSON.stringify( instanceData );
 
 	const landoFileTargetPath = path.join( instancePath, landoFileName );
 	const nginxFolderPath = path.join( instancePath, nginxPathString );
 	const nginxFileTargetPath = path.join( nginxFolderPath, nginxFileName );
+	const instanceDataTargetPath = path.join( instancePath, instanceDataFileName );
 
 	fs.mkdirSync( instancePath, { recursive: true } );
 	fs.mkdirSync( nginxFolderPath, { recursive: true } );
 
 	fs.writeFileSync( landoFileTargetPath, landoFile );
 	fs.writeFileSync( nginxFileTargetPath, nginxFile );
+	fs.writeFileSync( instanceDataTargetPath, instanceDataFile );
 
 	debug( `Lando file created in ${ landoFileTargetPath }` );
 	debug( `Nginx file created in ${ nginxFileTargetPath }` );
+	debug( `Instance data file created in ${ instanceDataTargetPath }` );
 }
 
 function getAllEnvironmentNames() {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -92,7 +92,6 @@ type NewInstanceData = {
 	muPlugins: Object,
 	clientCode: Object,
 	mediaRedirectDomain: string,
-	version: number,
 }
 
 export async function createEnvironment( instanceData: NewInstanceData ) {


### PR DESCRIPTION
## Description

Save instance data string to a file on creation.

This will enable us to re-trigger the setup wizard in order to reconfigure the existing environment.

## Steps to Test

1) create new environment.
1) In the location you can find - `instance_data.json`