### PR TITLE
[dev-env] Expose lando core logs

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -21,16 +21,18 @@ import App from 'lando/lib/app';
 /**
  * This file will hold all the interactions with lando library
  */
-
-const debug = debugLib( '@automattic/vip:bin:dev-environment-lando' );
+const DEBUG_KEY = '@automattic/vip:bin:dev-environment-lando';
+const debug = debugLib( DEBUG_KEY );
 
 function getLandoConfig() {
 	const landoPath = path.join( __dirname, '..', '..', '..', 'node_modules', 'lando' );
 
 	debug( `Getting lando config, using path '${ landoPath }' for plugins` );
 
+	const logLevelConsole = ( process.env.DEBUG || '' ).includes( DEBUG_KEY ) ? 'debug' : 'warn';
+
 	return {
-		logLevelConsole: 'warn',
+		logLevelConsole,
 		landoFile: '.lando.yml',
 		preLandoFiles: [ '.lando.base.yml', '.lando.dist.yml', '.lando.upstream.yml' ],
 		postLandoFiles: [ '.lando.local.yml' ],


### PR DESCRIPTION

## Description

This change adds ability to show lando internal logs in console. 

The hook is on `@automattic/vip:bin:dev-environment-lando` to be inline with the way `vip` debug system works.


## Steps to Test

1) Run `vip dev-env start` (or any other subcommand using lando under the hood
2) `export DEBUG='@automattic/vip:bin:dev-environment-lando'`
3) Run `vip dev-env start` again and see a lot more information coming from lando.

