### PR TITLE
[dev-env] Introuces update to change existing environment

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -319,7 +319,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 			const result = await promptForArguments( input.preselected, input.default );
 
-
 			if ( input.preselected.mediaRedirectDomain ) {
 				expect( confirmRunMock ).toHaveBeenCalledTimes( 0 );
 			} else {

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -250,9 +250,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
 					multisite: true,
 				},
 				default: {
@@ -261,9 +258,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
 					multisite: false,
 				},
 				default: {
@@ -272,9 +266,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
 				},
 				default: {
 					multisite: true,
@@ -283,9 +274,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
 				},
 				default: {
 					multisite: false,
@@ -311,9 +299,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				preselected: {
 					title: 'a',
 					multisite: true,
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
 					mediaRedirectDomain: 'a',
 				},
 				default: {
@@ -324,9 +309,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				preselected: {
 					title: 'a',
 					multisite: true,
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
 				},
 				default: {
 					mediaRedirectDomain: 'b',
@@ -353,25 +335,15 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					multisite: true,
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
-					mediaRedirectDomain: 'a',
 					mariadb: 'maria_a',
 					elasticsearch: 'elastic_a',
 				},
 				default: {
-					mediaRedirectDomain: 'b',
 				},
 			},
 			{
 				preselected: {
 					title: 'a',
-					multisite: true,
-					muPlugins: 'mu',
-					clientCode: 'code',
-					wordpress: 'wp',
 				},
 				default: {
 					mariadb: 'maria_b',
@@ -386,6 +358,51 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 			expect( result.mariadb ).toStrictEqual( expectedMaria );
 			expect( result.elasticsearch ).toStrictEqual( expectedElastic );
+		} );
+		it.each( [
+			{
+				service: 'statsd',
+				preselected: true,
+				expected: true,
+			},
+			{
+				service: 'statsd',
+				expected: false,
+			},
+			{
+				service: 'statsd',
+				default: true,
+				expected: true,
+			},
+			{
+				service: 'statsd',
+				preselected: false,
+				default: true,
+				expected: false,
+			},
+			{
+				service: 'phpmyadmin',
+				preselected: true,
+				default: true,
+				expected: true,
+			},
+			{
+				service: 'xdebug',
+				default: true,
+				expected: true,
+			},
+		] )( 'should handle auxiliary services', async input => {
+			const preselected = {};
+			const defaultOptions = {};
+			if ( 'preselected' in input ) {
+				preselected[ input.service ] = input.preselected;
+			}
+			if ( 'default' in input ) {
+				defaultOptions[ input.service ] = input.default;
+			}
+			const result = await promptForArguments( preselected, defaultOptions );
+
+			expect( result[ input.service ] ).toStrictEqual( input.expected );
 		} );
 	} );
 } );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -320,6 +320,18 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 					mediaRedirectDomain: 'b',
 				},
 			},
+			{
+				preselected: {
+					title: 'a',
+					multisite: true,
+					muPlugins: 'mu',
+					clientCode: 'code',
+					wordpress: 'wp',
+				},
+				default: {
+					mediaRedirectDomain: 'b',
+				},
+			},
 		] )( 'should handle media redirect query', async input => {
 			confirmRunMock.mockResolvedValue( input.default.mediaRedirectDomain );
 
@@ -335,6 +347,45 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const expectedValue = input.preselected.mediaRedirectDomain ? input.preselected.mediaRedirectDomain : input.default.mediaRedirectDomain;
 
 			expect( result.mediaRedirectDomain ).toStrictEqual( expectedValue );
+		} );
+
+		it.each( [
+			{
+				preselected: {
+					title: 'a',
+					multisite: true,
+					muPlugins: 'mu',
+					clientCode: 'code',
+					wordpress: 'wp',
+					mediaRedirectDomain: 'a',
+					mariadb: 'maria_a',
+					elasticsearch: 'elastic_a',
+				},
+				default: {
+					mediaRedirectDomain: 'b',
+				},
+			},
+			{
+				preselected: {
+					title: 'a',
+					multisite: true,
+					muPlugins: 'mu',
+					clientCode: 'code',
+					wordpress: 'wp',
+				},
+				default: {
+					mariadb: 'maria_b',
+					elasticsearch: 'elastic_b',
+				},
+			},
+		] )( 'should handle elasticsearch/mariadb', async input => {
+			const result = await promptForArguments( input.preselected, input.default );
+
+			const expectedMaria = input.preselected.mariadb ? input.preselected.mariadb : input.default.mariadb;
+			const expectedElastic = input.preselected.elasticsearch ? input.preselected.elasticsearch : input.default.elasticsearch;
+
+			expect( result.mariadb ).toStrictEqual( expectedMaria );
+			expect( result.elasticsearch ).toStrictEqual( expectedElastic );
 		} );
 	} );
 } );

--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -23,6 +23,7 @@ import { getEnvironmentPath,
 } from '../../../src/lib/dev-environment/dev-environment-core';
 import { searchAndReplace } from '../../../src/lib/search-and-replace';
 import { resolvePath } from '../../../src/lib/dev-environment/dev-environment-cli';
+import { DEV_ENVIRONMENT_NOT_FOUND } from '../../../src/lib/constants/dev-environment';
 
 jest.mock( 'xdg-basedir', () => ( {} ) );
 jest.mock( 'fs' );
@@ -55,7 +56,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			const promise = startEnvironment( slug );
 
 			await expect( promise ).rejects.toEqual(
-				new Error( 'Environment not found.' )
+				new Error( DEV_ENVIRONMENT_NOT_FOUND )
 			);
 		} );
 	} );
@@ -67,7 +68,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			const promise = destroyEnvironment( slug );
 
 			await expect( promise ).rejects.toEqual(
-				new Error( 'Environment not found.' )
+				new Error( DEV_ENVIRONMENT_NOT_FOUND )
 			);
 		} );
 	} );

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -82,16 +82,10 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	}
 
 	const instanceData = await promptForArguments( opt, defaultOptions );
-	const instanceDataWithSlug = {
-		...instanceData,
-		siteSlug: slug,
-		statsd: opt.statsd || false,
-		phpmyadmin: opt.phpmyadmin || false,
-		xdebug: opt.xdebug || false,
-	};
+	instanceData.siteSlug = slug;
 
 	try {
-		await createEnvironment( instanceDataWithSlug );
+		await createEnvironment( instanceData );
 
 		await printEnvironmentInfo( slug );
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -18,6 +18,7 @@ import command from 'lib/cli/command';
 import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { addDevEnvConfigurationOptions, handleCLIException, promptForArguments } from '../lib/dev-environment/dev-environment-cli';
+import type { InstanceOptions } from '../lib/dev-environment/dev-environment-cli';
 import { doesEnvironmentExist, readEnvironmentData } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../lib/constants/dev-environment';
 
@@ -56,7 +57,16 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 		debug( 'Combined preselected data are', preselectedOptions );
 
-		const instanceData = await promptForArguments( preselectedOptions, {} );
+		const defaultOptions: InstanceOptions = {
+			clientCode: currentInstanceData.clientCode.dir || currentInstanceData.clientCode.tag,
+			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag,
+			wordpress: currentInstanceData.wordpress.tag,
+			elasticsearch: currentInstanceData.elasticsearch,
+			mariadb: currentInstanceData.mariadb,
+
+		}
+
+		const instanceData = await promptForArguments( preselectedOptions, currentInstanceData );
 		// const instanceDataWithSlug = {
 		// 	...currentInstanceData,
 		// 	siteSlug: slug,

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -63,7 +63,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			mariadb: currentInstanceData.mariadb,
 			statsd: currentInstanceData.statsd,
 			phpmyadmin: currentInstanceData.phpmyadmin,
-			xdebug: currentInstanceData.phpmyadmin,
+			xdebug: currentInstanceData.xdebug,
 			mediaRedirectDomain: currentInstanceData.mediaRedirectDomain,
 		};
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -18,7 +18,7 @@ import command from 'lib/cli/command';
 import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { addDevEnvConfigurationOptions, handleCLIException, promptForArguments } from '../lib/dev-environment/dev-environment-cli';
-import { InstanceOptions } from '../lib/dev-environment/types';
+import type { InstanceOptions } from '../lib/dev-environment/types';
 import { doesEnvironmentExist, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../lib/constants/dev-environment';
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import debugLib from 'debug';
+import chalk from 'chalk';
+
+/**
+ * Internal dependencies
+ */
+import command from 'lib/cli/command';
+import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
+import { addDevEnvConfigurationOptions, handleCLIException, promptForArguments } from '../lib/dev-environment/dev-environment-cli';
+import { doesEnvironmentExist, readEnvironmentData } from '../lib/dev-environment/dev-environment-core';
+import { DEV_ENVIRONMENT_NOT_FOUND } from '../lib/constants/dev-environment';
+
+const debug = debugLib( '@automattic/vip:bin:dev-environment' );
+
+const examples = [
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } update`,
+		description: 'Retriggers setup wizard in order to change environment configuration',
+	},
+];
+const cmd = command().option( 'slug', 'Custom name of the dev environment' );
+
+addDevEnvConfigurationOptions( cmd );
+
+cmd.examples( examples );
+cmd.argv( process.argv, async ( arg, opt ) => {
+	const slug = getEnvironmentName( opt );
+
+	try {
+		const environmentAlreadyExists = doesEnvironmentExist( slug );
+		if ( ! environmentAlreadyExists ) {
+			throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
+		}
+
+		const currentInstanceData = readEnvironmentData( slug );
+
+		debug( 'Read instance data', currentInstanceData );
+
+		const preselectedOptions = {
+			// Title and multisite can't be changed during update
+			title: currentInstanceData.wpTitle,
+			multisite: currentInstanceData.multisite,
+			...opt,
+		};
+
+		debug( 'Combined preselected data are', preselectedOptions );
+
+		const instanceData = await promptForArguments( preselectedOptions, {} );
+		// const instanceDataWithSlug = {
+		// 	...currentInstanceData,
+		// 	siteSlug: slug,
+		// 	statsd: opt.statsd || false,
+		// 	phpmyadmin: opt.phpmyadmin || false,
+		// 	xdebug: opt.xdebug || false,
+		// };
+	} catch ( error ) {
+		if ( 'ENOENT' === error.code ) {
+			const message = 'Environment was created before update was supported.\n\nTo update environment please destroy it and create a new one.';
+			handleCLIException( new Error( message ) );
+		} else {
+			handleCLIException( error );
+		}
+	}
+} );

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -19,7 +19,7 @@ import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { addDevEnvConfigurationOptions, handleCLIException, promptForArguments } from '../lib/dev-environment/dev-environment-cli';
 import { InstanceOptions } from '../lib/dev-environment/types';
-import { doesEnvironmentExist, readEnvironmentData } from '../lib/dev-environment/dev-environment-core';
+import { doesEnvironmentExist, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -55,22 +55,25 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			...opt,
 		};
 
-		const defaultOptions = {
+		const defaultOptions: InstanceOptions = {
 			clientCode: currentInstanceData.clientCode.dir || currentInstanceData.clientCode.tag || 'latest',
 			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
 			wordpress: currentInstanceData.wordpress.tag,
 			elasticsearch: currentInstanceData.elasticsearch,
 			mariadb: currentInstanceData.mariadb,
+			statsd: currentInstanceData.statsd,
+			phpmyadmin: currentInstanceData.phpmyadmin,
+			xdebug: currentInstanceData.phpmyadmin,
+			mediaRedirectDomain: currentInstanceData.mediaRedirectDomain,
 		};
 
 		const instanceData = await promptForArguments( preselectedOptions, defaultOptions );
-		// const instanceDataWithSlug = {
-		// 	...currentInstanceData,
-		// 	siteSlug: slug,
-		// 	statsd: opt.statsd || false,
-		// 	phpmyadmin: opt.phpmyadmin || false,
-		// 	xdebug: opt.xdebug || false,
-		// };
+		instanceData.siteSlug = slug;
+
+		await updateEnvironment( instanceData );
+
+		const message = '\n' + chalk.green( '✓' ) + ' environment updated. Restart environment for changes to take an affect.';
+		console.log( message );
 	} catch ( error ) {
 		if ( 'ENOENT' === error.code ) {
 			const message = 'Environment was created before update was supported.\n\nTo update environment please destroy it and create a new one.';

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -18,7 +18,7 @@ import command from 'lib/cli/command';
 import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { addDevEnvConfigurationOptions, handleCLIException, promptForArguments } from '../lib/dev-environment/dev-environment-cli';
-import type { InstanceOptions } from '../lib/dev-environment/dev-environment-cli';
+import { InstanceOptions } from '../lib/dev-environment/types';
 import { doesEnvironmentExist, readEnvironmentData } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../lib/constants/dev-environment';
 
@@ -55,18 +55,15 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			...opt,
 		};
 
-		debug( 'Combined preselected data are', preselectedOptions );
-
-		const defaultOptions: InstanceOptions = {
-			clientCode: currentInstanceData.clientCode.dir || currentInstanceData.clientCode.tag,
-			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag,
+		const defaultOptions = {
+			clientCode: currentInstanceData.clientCode.dir || currentInstanceData.clientCode.tag || 'latest',
+			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
 			wordpress: currentInstanceData.wordpress.tag,
 			elasticsearch: currentInstanceData.elasticsearch,
 			mariadb: currentInstanceData.mariadb,
+		};
 
-		}
-
-		const instanceData = await promptForArguments( preselectedOptions, currentInstanceData );
+		const instanceData = await promptForArguments( preselectedOptions, defaultOptions );
 		// const instanceDataWithSlug = {
 		// 	...currentInstanceData,
 		// 	siteSlug: slug,

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -506,6 +506,7 @@ Processing the SQL import for your environment...
 				environmentId: env.id,
 				basename: basename,
 				md5: md5,
+				searchReplace: [],
 			};
 
 			if ( searchReplace ) {

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -11,5 +11,6 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up your local dev environment.\n\n' +
 	'Sensible default values were pre-selected for convenience. ' +
 	'You may also choose to create multiple environments with different settings using the --slug option.\n\n';
+export const DEV_ENVIRONMENT_NOT_FOUND = 'Environment not found.';
 
 export const DEV_ENVIRONMENT_COMPONENTS = [ 'wordpress', 'muPlugins', 'clientCode' ];

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -25,7 +25,7 @@ import {
 	DEV_ENVIRONMENT_COMPONENTS,
 	DEV_ENVIRONMENT_NOT_FOUND,
 } from '../constants/dev-environment';
-import type { InstanceData, InstanceOptions } from './types';
+import { InstanceOptions, EnvironmentNameOptions } from './types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -122,7 +122,7 @@ export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
  * @returns {any} instance data
  */
 export async function promptForArguments( preselecteddOptions: InstanceOptions, defaultOptions: InstanceOptions) {
-	debug( 'Provided options', preselecteddOptions );
+	debug( 'Provided preselected', preselecteddOptions, 'and default', defaultOptions );
 
 	console.log( DEV_ENVIRONMENT_PROMPT_INTRO );
 
@@ -164,6 +164,7 @@ export async function promptForArguments( preselecteddOptions: InstanceOptions, 
 }
 
 async function processComponent( component: string, preselectedValue: string, defaultValue: string ) {
+	debug( `processing a component '${ component }', with preselected/deafault - ${ preselectedValue }/${ defaultValue }` );
 	let result = null;
 
 	const allowLocal = component !== 'wordpress';
@@ -235,17 +236,17 @@ const componentDisplayNames = {
 };
 
 export async function promptForComponent( component: string, allowLocal: boolean, defaultObject: ComponentConfig ): Promise<ComponentConfig> {
-	debug( `Prompting for ${ component }` );
+	debug( `Prompting for ${ component } with default:`, defaultObject );
 	const componentDisplayName = componentDisplayNames[ component ] || component;
-	const choices = [];
+	const modChoices = [];
 
 	if ( allowLocal ) {
-		choices.push( {
+		modChoices.push( {
 			message: `local folder - where you already have ${ componentDisplayName } code`,
 			value: 'local',
 		} );
 	}
-	choices.push( {
+	modChoices.push( {
 		message: 'image - that gets automatically fetched',
 		value: 'image',
 	} );
@@ -260,12 +261,12 @@ export async function promptForComponent( component: string, allowLocal: boolean
 	}
 
 	let modeResult = initialMode;
-	const selectMode = choices.length > 1;
+	const selectMode = modChoices.length > 1;
 	if ( selectMode ) {
-		const initialModeIndex = choices.findIndex( choice => choice.value === initialMode );
+		const initialModeIndex = modChoices.findIndex( choice => choice.value === initialMode );
 		const select = new Select( {
 			message: `How would you like to source ${ componentDisplayName }`,
-			choices,
+			choices: modChoices,
 			initial: initialModeIndex,
 		} );
 
@@ -285,17 +286,17 @@ export async function promptForComponent( component: string, allowLocal: boolean
 	// image with selection
 	if ( component === 'wordpress' ) {
 		const message = `${ messagePrefix }Which version would you like`;
-		const choices = getWordpressImageTags();
+		const tagChoices = getWordpressImageTags();
 		let initialTagIndex = 0;
 		if ( defaultObject?.tag ) {
-			const defaultTagIndex = choices.indexOf( choice => choice === defaultObject.tag );
+			const defaultTagIndex = tagChoices.indexOf( defaultObject.tag );
 			if ( defaultTagIndex !== -1 ) {
 				initialTagIndex = defaultTagIndex;
 			}
 		}
 		const selectTag = new Select( {
 			message,
-			choices,
+			choices: tagChoices,
 			initial: initialTagIndex,
 		} );
 		const tag = await selectTag.run();

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -84,8 +84,6 @@ export function printTable( data: Object ) {
 	console.log( formattedData );
 }
 
-
-
 export function processComponentOptionInput( passedParam: string, allowLocal: boolean ): ComponentConfig {
 	// cast to string
 	const param = passedParam + '';
@@ -101,7 +99,6 @@ export function processComponentOptionInput( passedParam: string, allowLocal: bo
 		tag: param,
 	};
 }
-
 
 export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
 	if ( ! appInfo ) {
@@ -121,7 +118,7 @@ export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
  * @param {InstanceOptions} defaultOptions - options to be used as default values for prompt
  * @returns {any} instance data
  */
-export async function promptForArguments( preselectedOptions: InstanceOptions, defaultOptions: InstanceOptions): InstanceData {
+export async function promptForArguments( preselectedOptions: InstanceOptions, defaultOptions: InstanceOptions ): InstanceData {
 	debug( 'Provided preselected', preselectedOptions, 'and default', defaultOptions );
 
 	console.log( DEV_ENVIRONMENT_PROMPT_INTRO );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -283,7 +283,6 @@ export async function promptForComponent( component: string, allowLocal: boolean
 	}
 
 	const messagePrefix = selectMode ? '\t' : `${ componentDisplayName } - `;
-	// path
 	if ( 'local' === modeResult ) {
 		const directoryPath = await promptForText( `${ messagePrefix }What is a path to your local ${ componentDisplayName }`, defaultObject?.dir || '' );
 		return {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -341,7 +341,7 @@ export async function getApplicationInformation( appId: number, envType: string 
 	return appData;
 }
 
-export async function resolveImportPath( slug: string, fileName: string, searchReplace: String | String[], inPlace: boolean ): Promise<SQLImportPaths> {
+export async function resolveImportPath( slug: string, fileName: string, searchReplace: string | string[], inPlace: boolean ): Promise<SQLImportPaths> {
 	let resolvedPath = resolvePath( fileName );
 
 	if ( ! fs.existsSync( resolvedPath ) ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -312,7 +312,7 @@ export async function getApplicationInformation( appId: number, envType: string 
 	return appData;
 }
 
-export async function resolveImportPath( slug: string, fileName: string, searchReplace: string, inPlace: boolean ): Promise<SQLImportPaths> {
+export async function resolveImportPath( slug: string, fileName: string, searchReplace: String | String[], inPlace: boolean ): Promise<SQLImportPaths> {
 	let resolvedPath = resolvePath( fileName );
 
 	if ( ! fs.existsSync( resolvedPath ) ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -24,6 +24,7 @@ import { searchAndReplace } from '../search-and-replace';
 import { printTable, resolvePath } from './dev-environment-cli';
 import app from '../api/app';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../constants/dev-environment';
+import type { InstanceData } from './types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -83,16 +84,6 @@ export async function stopEnvironment( slug: string ) {
 	}
 
 	await landoStop( instancePath );
-}
-
-type InstanceData = {
-	siteSlug: string,
-	wpTitle: string,
-	multisite: boolean,
-	wordpress: Object,
-	muPlugins: Object,
-	clientCode: Object,
-	mediaRedirectDomain: string,
 }
 
 export async function createEnvironment( instanceData: InstanceData ) {

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -1,5 +1,5 @@
 
-export type InstanceOptions = {
+export interface InstanceOptions {
 	title?: string,
 	multisite?: boolean,
 	php?: string,
@@ -37,7 +37,7 @@ export type EnvironmentNameOptions = {
 	env: string,
 }
 
-export type InstanceData = {
+export interface InstanceData {
 	siteSlug: string,
 	wpTitle: string,
 	multisite: boolean,

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -1,0 +1,49 @@
+
+export type InstanceOptions = {
+	title?: string,
+	multisite?: boolean,
+	php?: string,
+	wordpress?: string,
+	muPlugins?: string,
+	clientCode?: string,
+	elasticsearch?: string,
+	mariadb?: string,
+	mediaRedirectDomain?: string
+}
+
+export type AppInfo = {
+	id?: number,
+	name?: string,
+	repository?: string,
+	environment?: {
+		name: string,
+		type: string,
+		branch: string,
+		isMultisite: boolean,
+		primaryDomain: string,
+	}
+}
+
+export type ComponentConfig = {
+	mode: 'local' | 'image';
+	dir?: string,
+	image?: string,
+	tag?: string,
+}
+
+export type EnvironmentNameOptions = {
+	slug: string,
+	app: string,
+	env: string,
+}
+
+export type InstanceData = {
+	siteSlug: string,
+	wpTitle: string,
+	multisite: boolean,
+	wordpress: ComponentConfig,
+	muPlugins: ComponentConfig,
+	clientCode: ComponentConfig,
+	mediaRedirectDomain: string,
+}
+

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -1,7 +1,7 @@
 
 export interface InstanceOptions {
-	title?: string,
-	multisite?: boolean,
+	title: string,
+	multisite: boolean,
 	wordpress?: string,
 	muPlugins?: string,
 	clientCode?: string,

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -2,13 +2,15 @@
 export interface InstanceOptions {
 	title?: string,
 	multisite?: boolean,
-	php?: string,
 	wordpress?: string,
 	muPlugins?: string,
 	clientCode?: string,
 	elasticsearch?: string,
 	mariadb?: string,
-	mediaRedirectDomain?: string
+	mediaRedirectDomain?: string,
+	statsd?: boolean,
+	phpmyadmin?: boolean,
+	xdebug?: boolean,
 }
 
 export type AppInfo = {
@@ -45,5 +47,8 @@ export interface InstanceData {
 	muPlugins: ComponentConfig,
 	clientCode: ComponentConfig,
 	mediaRedirectDomain: string,
+	statsd: boolean,
+	phpmyadmin: boolean,
+	xdebug: boolean,
 }
 

--- a/src/lib/search-and-replace.js
+++ b/src/lib/search-and-replace.js
@@ -125,7 +125,7 @@ export type SearchReplaceOutput = {
 
 export const searchAndReplace = async (
 	fileName: string,
-	pairs: Array<String> | String,
+	pairs: Array<string> | string,
 	{ isImport = true, inPlace = false, output = process.stdout }: SearchReplaceOptions,
 	binary: string | null = null
 ): Promise<SearchReplaceOutput> => {


### PR DESCRIPTION
## Description

This command is usefull when want to tweak existing environment. Common scenarios are:
* Enable/disable phpmyadmin/statsd/xdebug
* Switch wp version


## Steps to Test

1) Create environment
2) Run `vip dev-env update`
3) Make sure it does what you would expect it to do and correct default values are fetched from existing env
