### PR TITLE
FORNO-943 Fixes a bug which prevents displaying SQL Import error messages

### DIFF
--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -308,7 +308,7 @@ ${ maybeExitPrompt }
 
 				let failedImportStep;
 
-				if ( jobCreationTime && importStepProgress?.started_at * 1000 > jobCreationTime ) {
+				if ( jobCreationTime && importStepProgress?.started_at * 1000 >= jobCreationTime ) {
 					// The contents of the `import_progress` meta are pertinent to the most recent import job
 					failedImportStep = importStepProgress.steps.find(
 						step =>


### PR DESCRIPTION
## Description

This PR fixes a bug which prevents displaying SQL Import messages for k8s sites. On VIPd, HA was created before the job started, thus this condition was always true, but on k8s job usually start very fast, thus it's possible for createdAt and startedAt to be the same.

## Steps to Test

1. Create a `test.sql` file which will cause the import to fail. For example, you can create a table that already exists, which will trigger an error.

```
CREATE TABLE `wp_users` (
  `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `user_login` varchar(60) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_pass` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_nicename` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_email` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_url` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_registered` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
  `user_activation_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_status` int(11) NOT NULL DEFAULT 0,
  `display_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `spam` tinyint(2) NOT NULL DEFAULT 0,
  `deleted` tinyint(2) NOT NULL DEFAULT 0,
  PRIMARY KEY (`ID`),
  KEY `user_login_key` (`user_login`),
  KEY `user_nicename` (`user_nicename`),
  KEY `user_email` (`user_email`)
) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```
2. Run `vip import sql @<site-id>.production test.sql --skip-validate`
3. The import should fail as table wp_users already exists
4. Validate that the output contains more than just ` Import step failed`. It should also contain message about site being restored, and description of a step at which the failure happened. Example of a response:

```
=============================================================
Checking the SQL import status for your environment...
✓ Import preflights
✓ Downloading file from s3
✓ Checking md5 hashes
✓ Backup db
✕ Importing db
✓ Restore db

=============================================================
Status: Failed ✕
Site: nejc-test-site (PRODUCTION)
SQL Import Started: 11/16/2021, 10:57:58 AM (Tue, 16 Nov 2021 09:57:58 GMT)
SQL Import Completed: TBD
=============================================================

Error:  Import step failed
This error occurred during the mysql batch script processing of your SQL file.

Your site is automatically being rolled back to the last backup prior to your import job.
Please contact support and include this message along with your sql file.
```

