### PR TITLE
Add the `vip logs` command to get the most recent logs from a site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ dist
 config/config.json
 
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 

--- a/__tests__/bin/vip-logs.js
+++ b/__tests__/bin/vip-logs.js
@@ -1,0 +1,160 @@
+/**
+ * Internal dependencies
+ */
+import * as tracker from 'lib/tracker';
+import * as logsLib from 'lib/logs/logs';
+import * as exit from 'lib/cli/exit';
+import { rollbar } from 'lib/rollbar';
+import { getLogs } from 'bin/vip-logs';
+
+jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+jest.spyOn( rollbar, 'error' ).mockImplementation( () => {} );
+jest.spyOn( exit, 'withError' ).mockImplementation( () => {
+	throw 'EXIT WITH ERROR'; // throws to break the flow (the real implementation does a process.exit)
+} );
+
+jest.mock( 'lib/cli/command', () => {
+	const commandMock = {
+		argv: () => commandMock,
+		examples: () => commandMock,
+		option: () => commandMock,
+	};
+	return jest.fn( () => commandMock );
+} );
+
+jest.mock( 'lib/tracker', () => ( {
+	trackEvent: jest.fn(),
+} ) );
+
+jest.mock( 'lib/logs/logs', () => ( {
+	getRecentLogs: jest.fn(),
+} ) );
+
+describe( 'getLogs', () => {
+	const opts = {
+		app: {
+			id: 1,
+			organization: {
+				id: 2,
+			},
+		},
+		env: {
+			id: 3,
+			type: 'develop',
+		},
+		type: 'app',
+		limit: 500,
+	};
+
+	beforeEach( jest.clearAllMocks );
+
+	it( 'should display the logs in the output', async () => {
+		logsLib.getRecentLogs.mockImplementation( async () => [
+			{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
+			{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2' },
+		] );
+
+		await getLogs( [], opts );
+
+		expect( logsLib.getRecentLogs ).toHaveBeenCalledTimes( 1 );
+		expect( logsLib.getRecentLogs ).toHaveBeenCalledWith( 1, 3, 'app', 500 );
+
+		expect( console.log ).toHaveBeenCalledTimes( 2 );
+		expect( console.log ).toHaveBeenNthCalledWith( 1, '2021-11-05T20:18:36.234041811Z My container message 1' );
+		expect( console.log ).toHaveBeenNthCalledWith( 2, '2021-11-09T20:47:07.301221112Z My container message 2' );
+
+		const trackingParams = {
+			command: 'vip logs',
+			org_id: 2,
+			app_id: 1,
+			env_id: 3,
+			type: 'app',
+			limit: 500,
+		};
+
+		expect( tracker.trackEvent ).toHaveBeenCalledTimes( 2 );
+		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 1, 'logs_command_execute', trackingParams );
+		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 2, 'logs_command_success', trackingParams );
+
+		expect( rollbar.error ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should track unexpected errors', async () => {
+		const error = new Error( 'My intentional Error' );
+		logsLib.getRecentLogs.mockImplementation( async () => {
+			throw error;
+		} );
+
+		const promise = getLogs( [], opts );
+
+		await expect( promise ).rejects.toBe( 'EXIT WITH ERROR' );
+
+		expect( exit.withError ).toHaveBeenCalledTimes( 1 );
+		expect( exit.withError ).toHaveBeenCalledWith( 'My intentional Error' );
+
+		expect( logsLib.getRecentLogs ).toHaveBeenCalledTimes( 1 );
+		expect( logsLib.getRecentLogs ).toHaveBeenCalledWith( 1, 3, 'app', 500 );
+
+		expect( console.log ).not.toHaveBeenCalled();
+
+		const trackingParams = {
+			command: 'vip logs',
+			org_id: 2,
+			app_id: 1,
+			env_id: 3,
+			type: 'app',
+			limit: 500,
+		};
+
+		expect( rollbar.error ).toHaveBeenCalledTimes( 1 );
+		expect( rollbar.error ).toHaveBeenCalledWith( error );
+
+		expect( tracker.trackEvent ).toHaveBeenCalledTimes( 2 );
+		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 1, 'logs_command_execute', trackingParams );
+		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 2, 'logs_command_error', {
+			...trackingParams,
+			error: 'My intentional Error',
+		} );
+	} );
+
+	it( 'should exit with error if "type" is invalid', async () => {
+		const promise = getLogs( [], { ...opts, type: 'my-type' } );
+
+		await expect( promise ).rejects.toBe( 'EXIT WITH ERROR' );
+
+		expect( exit.withError ).toHaveBeenCalledTimes( 1 );
+		expect( exit.withError ).toHaveBeenCalledWith( 'Invalid type: my-type. The supported types are: app, batch.' );
+
+		expect( logsLib.getRecentLogs ).not.toHaveBeenCalled();
+
+		expect( console.log ).not.toHaveBeenCalled();
+
+		expect( tracker.trackEvent ).not.toHaveBeenCalled();
+
+		expect( rollbar.error ).not.toHaveBeenCalled();
+	} );
+
+	it.each( [
+		'abc',
+		-1,
+		0,
+		12.4,
+		5001,
+	] )( 'should exit with error if "limit" is invalid (%p)', async limit => {
+		const promise = getLogs( [], { ...opts, limit } );
+
+		await expect( promise ).rejects.toBe( 'EXIT WITH ERROR' );
+
+		expect( exit.withError ).toHaveBeenCalledTimes( 1 );
+		expect( exit.withError ).toHaveBeenCalledWith( `Invalid limit: ${ limit }. It should be a number between 1 and 5000.` );
+
+		expect( logsLib.getRecentLogs ).not.toHaveBeenCalled();
+
+		expect( console.log ).not.toHaveBeenCalled();
+
+		expect( tracker.trackEvent ).not.toHaveBeenCalled();
+
+		expect( rollbar.error ).not.toHaveBeenCalled();
+	} );
+} );
+

--- a/__tests__/lib/logs/logs.js
+++ b/__tests__/lib/logs/logs.js
@@ -69,20 +69,6 @@ describe( 'getRecentLogs()', () => {
 
 		await expect( result ).rejects.toThrow( 'Unable to query logs' );
 	} );
-
-	it( 'should throw when logs array is empty', async () => {
-		const queryMock = jest.fn();
-
-		API.mockImplementation( () => ( {
-			query: queryMock,
-		} ) );
-
-		queryMock.mockImplementation( () => logsResponse( [] ) );
-
-		const result = getRecentLogs( 1, 3, 'batch', 1200 );
-
-		await expect( result ).rejects.toThrow( 'No logs found' );
-	} );
 } );
 
 function logsResponse( logs ) {

--- a/__tests__/lib/logs/logs.js
+++ b/__tests__/lib/logs/logs.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+import { getRecentLogs } from 'lib/logs/logs';
+
+jest.mock( 'lib/api', () => jest.fn() );
+
+const EXPECTED_QUERY = gql`
+	query App( $appId: Int, $envId: Int ) {
+		app( id: $appId ) {
+			environments( id: $envId ) {
+				id
+				logs( type: String, limit: Int ) {
+					nodes {
+						timestamp
+						message
+					}
+				}
+			}
+		}
+	}
+`;
+
+describe( 'getRecentLogs()', () => {
+	beforeEach( jest.clearAllMocks );
+
+	it( 'should query the API with the correct values', async () => {
+		const queryMock = jest.fn();
+
+		API.mockImplementation( () => ( {
+			query: queryMock,
+		} ) );
+
+		queryMock.mockImplementation( () => logsResponse( [
+			{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
+			{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2' },
+		] ) );
+
+		await getRecentLogs( 1, 3, 'batch', 1200 );
+
+		expect( queryMock ).toHaveBeenCalledTimes( 1 );
+		expect( queryMock ).toHaveBeenCalledWith( {
+			query: EXPECTED_QUERY,
+			variables: {
+				appId: 1,
+				envId: 3,
+				type: 'batch',
+				limit: 1200,
+			},
+		} );
+	} );
+} );
+
+function logsResponse( logs ) {
+	return {
+		data: {
+			app: {
+				environments: [
+					{
+						logs: {
+							nodes: logs,
+						},
+					},
+				],
+			},
+		},
+	};
+}

--- a/__tests__/lib/logs/logs.js
+++ b/__tests__/lib/logs/logs.js
@@ -12,11 +12,11 @@ import { getRecentLogs } from 'lib/logs/logs';
 jest.mock( 'lib/api', () => jest.fn() );
 
 const EXPECTED_QUERY = gql`
-	query App( $appId: Int, $envId: Int ) {
+	query GetAppLogs( $appId: Int, $envId: Int, $type: String, $limit: Int ) {
 		app( id: $appId ) {
 			environments( id: $envId ) {
 				id
-				logs( type: String, limit: Int ) {
+				logs( type: $type, limit: $limit ) {
 					nodes {
 						timestamp
 						message

--- a/__tests__/lib/logs/logs.js
+++ b/__tests__/lib/logs/logs.js
@@ -55,6 +55,34 @@ describe( 'getRecentLogs()', () => {
 			},
 		} );
 	} );
+
+	it( 'should throw when logs field is not returned', async () => {
+		const queryMock = jest.fn();
+
+		API.mockImplementation( () => ( {
+			query: queryMock,
+		} ) );
+
+		queryMock.mockImplementation( () => {} );
+
+		const result = getRecentLogs( 1, 3, 'batch', 1200 );
+
+		await expect( result ).rejects.toThrow( 'Unable to query logs' );
+	} );
+
+	it( 'should throw when logs array is empty', async () => {
+		const queryMock = jest.fn();
+
+		API.mockImplementation( () => ( {
+			query: queryMock,
+		} ) );
+
+		queryMock.mockImplementation( () => logsResponse( [] ) );
+
+		const result = getRecentLogs( 1, 3, 'batch', 1200 );
+
+		await expect( result ).rejects.toThrow( 'No logs found' );
+	} );
 } );
 
 function logsResponse( logs ) {

--- a/__tests__/lib/logs/logs.js
+++ b/__tests__/lib/logs/logs.js
@@ -12,7 +12,7 @@ import { getRecentLogs } from 'lib/logs/logs';
 jest.mock( 'lib/api', () => jest.fn() );
 
 const EXPECTED_QUERY = gql`
-	query GetAppLogs( $appId: Int, $envId: Int, $type: String, $limit: Int ) {
+	query GetAppLogs( $appId: Int, $envId: Int, $type: AppEnvironmentLogType, $limit: Int ) {
 		app( id: $appId ) {
 			environments( id: $envId ) {
 				id

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "vip-import-sql-status": "dist/bin/vip-import-sql-status.js",
     "vip-import-validate-files": "dist/bin/vip-import-validate-files.js",
     "vip-import-validate-sql": "dist/bin/vip-import-validate-sql.js",
+    "vip-logs": "dist/bin/vip-logs.js",
     "vip-search-replace": "dist/bin/vip-search-replace.js",
     "vip-sync": "dist/bin/vip-sync.js",
     "vip-wp": "dist/bin/vip-wp.js"

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -84,15 +84,15 @@ command( {
 	.option( 'limit', 'The maximum number of log lines', 500 )
 	.examples( [
 		{
-			usage: 'vip logs --app 9999 --env develop',
+			usage: 'vip @mysite.production logs',
 			description: 'Get the most recent app logs',
 		},
 		{
-			usage: 'vip logs --app 9999 --env develop --type batch',
+			usage: 'vip @mysite.production logs --type batch',
 			description: 'Get the most recent batch logs',
 		},
 		{
-			usage: 'vip logs --app 9999 --env develop --limit 100',
+			usage: 'vip @mysite.production logs --limit 100',
 			description: 'Get the most recent 100 logs',
 		},
 	] )

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -14,7 +14,7 @@ const LIMIT_MIN = 1;
 const ALLOWED_TYPES = [ 'app', 'batch' ];
 
 export async function getLogs( arg: string[], opt ): Promise<void> {
-	validateInputs( opt.type, opt.limit );
+	validateInputs( opt.type, opt.limit, opt.env );
 
 	const trackingParams = {
 		command: 'vip logs',
@@ -44,7 +44,11 @@ export async function getLogs( arg: string[], opt ): Promise<void> {
 	await trackEvent( 'logs_command_success', trackingParams );
 }
 
-export function validateInputs( type: string, limit: number ): void {
+export function validateInputs( type: string, limit: number, env: Object ): void {
+	if ( ! env.isK8sResident ) {
+		exit.withError( '`vip logs` is not supported for the specified environment.' );
+	}
+
 	if ( ! ALLOWED_TYPES.includes( type ) ) {
 		exit.withError( `Invalid type: ${ type }. The supported types are: ${ ALLOWED_TYPES.join( ', ' ) }.` );
 	}
@@ -62,6 +66,7 @@ export const appQuery = `
 		appId
 		name
 		type
+		isK8sResident
 	}
 	organization {
 		id

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// @flow
+/**
+ * Internal dependencies
+ */
+import command from 'lib/cli/command';
+import { rollbar } from 'lib/rollbar';
+import { trackEvent } from 'lib/tracker';
+import * as logsLib from 'lib/logs/logs';
+import * as exit from 'lib/cli/exit';
+
+const LIMIT_MAX = 5000;
+const LIMIT_MIN = 1;
+const ALLOWED_TYPES = [ 'app', 'batch' ];
+
+export async function getLogs( arg: string[], opt ): Promise<void> {
+	validateInputs( opt.type, opt.limit );
+
+	const trackingParams = {
+		command: 'vip logs',
+		org_id: opt.app.organization.id,
+		app_id: opt.app.id,
+		env_id: opt.env.id,
+		type: opt.type,
+		limit: opt.limit,
+	};
+
+	await trackEvent( 'logs_command_execute', trackingParams );
+
+	try {
+		const logs = await logsLib.getRecentLogs( opt.app.id, opt.env.id, opt.type, opt.limit );
+
+		for ( const { timestamp, message } of logs ) {
+			console.log( `${ timestamp } ${ message }` );
+		}
+	} catch ( error ) {
+		rollbar.error( error );
+
+		await trackEvent( 'logs_command_error', { ...trackingParams, error: error.message } );
+
+		return exit.withError( error.message );
+	}
+
+	await trackEvent( 'logs_command_success', trackingParams );
+}
+
+export function validateInputs( type: string, limit: number ): void {
+	if ( ! ALLOWED_TYPES.includes( type ) ) {
+		exit.withError( `Invalid type: ${ type }. The supported types are: ${ ALLOWED_TYPES.join( ', ' ) }.` );
+	}
+
+	if ( ! Number.isInteger( limit ) || limit < LIMIT_MIN || limit > LIMIT_MAX ) {
+		exit.withError( `Invalid limit: ${ limit }. It should be a number between ${ LIMIT_MIN } and ${ LIMIT_MAX }.` );
+	}
+}
+
+export const appQuery = `
+	id
+	name
+	environments {
+		id
+		appId
+		name
+		type
+	}
+	organization {
+		id
+		name
+	}
+`;
+
+command( {
+	appContext: true,
+	appQuery,
+	envContext: true,
+	module: 'logs',
+} )
+	.option( 'type', 'The type of logs to be returned: "app" or "batch"', 'app' )
+	.option( 'limit', 'The maximum number of log lines', 500 )
+	.examples( [
+		{
+			usage: 'vip logs --app 9999 --env develop',
+			description: 'Get the most recent app logs',
+		},
+		{
+			usage: 'vip logs --app 9999 --env develop --type batch',
+			description: 'Get the most recent batch logs',
+		},
+		{
+			usage: 'vip logs --app 9999 --env develop --limit 100',
+			description: 'Get the most recent 100 logs',
+		},
+	] )
+	.argv( process.argv, getLogs );

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -30,6 +30,10 @@ export async function getLogs( arg: string[], opt ): Promise<void> {
 	try {
 		const logs = await logsLib.getRecentLogs( opt.app.id, opt.env.id, opt.type, opt.limit );
 
+		if ( ! logs.length ) {
+			console.error( 'No logs found' );
+		}
+
 		for ( const { timestamp, message } of logs ) {
 			console.log( `${ timestamp } ${ message }` );
 		}

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -40,6 +40,7 @@ const runCmd = async function() {
 		.command( 'config', 'Set configuration for your VIP applications' )
 		.command( 'dev-env', 'Use local dev-environment' )
 		.command( 'import', 'Import media or SQL files into your VIP applications' )
+		.command( 'logs', 'Get logs from your VIP applications' )
 		.command( 'search-replace', 'Perform search and replace tasks on files' )
 		.command( 'sync', 'Sync production to a development environment' )
 		.command( 'wp', 'Run WP CLI commands against an environment' );

--- a/src/lib/logs/logs.js
+++ b/src/lib/logs/logs.js
@@ -14,11 +14,11 @@ import gql from 'graphql-tag';
 import API from 'lib/api';
 
 const QUERY_ENVIRONMENT_LOGS = gql`
-	query App( $appId: Int, $envId: Int ) {
+	query GetAppLogs( $appId: Int, $envId: Int, $type: String, $limit: Int ) {
 		app( id: $appId ) {
 			environments( id: $envId ) {
 				id
-				logs( type: String, limit: Int ) {
+				logs( type: $type, limit: $limit ) {
 					nodes {
 						timestamp
 						message

--- a/src/lib/logs/logs.js
+++ b/src/lib/logs/logs.js
@@ -1,0 +1,52 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+
+const QUERY_ENVIRONMENT_LOGS = gql`
+	query App( $appId: Int, $envId: Int ) {
+		app( id: $appId ) {
+			environments( id: $envId ) {
+				id
+				logs( type: String, limit: Int ) {
+					nodes {
+						timestamp
+						message
+					}
+				}
+			}
+		}
+	}
+`;
+
+export async function getRecentLogs( appId: number, envId: number, type: string, limit: number ): Promise<Array<{ timestamp: string, message: string }>> {
+	const api = await API();
+
+	const response = await api.query( {
+		query: QUERY_ENVIRONMENT_LOGS,
+		variables: {
+			appId,
+			envId,
+			type,
+			limit,
+		},
+	} );
+
+	const logs = response?.data?.app?.environments[ 0 ]?.logs?.nodes;
+
+	if ( ! logs ) {
+		throw new Error( 'Unable to query logs' );
+	}
+
+	return logs;
+}

--- a/src/lib/logs/logs.js
+++ b/src/lib/logs/logs.js
@@ -48,5 +48,9 @@ export async function getRecentLogs( appId: number, envId: number, type: string,
 		throw new Error( 'Unable to query logs' );
 	}
 
+	if ( ! logs.length ) {
+		throw new Error( 'No logs found' );
+	}
+
 	return logs;
 }

--- a/src/lib/logs/logs.js
+++ b/src/lib/logs/logs.js
@@ -14,7 +14,7 @@ import gql from 'graphql-tag';
 import API from 'lib/api';
 
 const QUERY_ENVIRONMENT_LOGS = gql`
-	query GetAppLogs( $appId: Int, $envId: Int, $type: String, $limit: Int ) {
+	query GetAppLogs( $appId: Int, $envId: Int, $type: AppEnvironmentLogType, $limit: Int ) {
 		app( id: $appId ) {
 			environments( id: $envId ) {
 				id

--- a/src/lib/logs/logs.js
+++ b/src/lib/logs/logs.js
@@ -48,9 +48,5 @@ export async function getRecentLogs( appId: number, envId: number, type: string,
 		throw new Error( 'Unable to query logs' );
 	}
 
-	if ( ! logs.length ) {
-		throw new Error( 'No logs found' );
-	}
-
 	return logs;
 }


### PR DESCRIPTION
## Description

Add the `vip logs` command to get the most recent logs from a site.

## Steps to Test

#### Before the API is available in production, the easiest way to test this PR is by pointing to the local API and returning fake logs in GOOP API:
1. Check out the API branch `add/get-runtime-logs` and execute `docker-compose up`
1. On GOOP, replace this line `const logs = await getRecentLogs( site, tier, limitNumber );` in the endpoint implementation with something like this:
```javascript
const logs = Array( limitNumber ).fill( 0 ).map( ( a, index ) => {
	return {
		message: `My ${ tier } log message ${ index + 1 }`,
		timestamp: new Date().toISOString().replace( 'Z', '000000Z' ),
		pod: 'my-pod-123456',
	};
} );
```
then...
1. Check out this PR.
1. Run `npm run build`
1. Run `npm link`
1. Run `VIP_PROXY="" API_HOST=http://localhost:4000 vip @5000.production logs --type app --limit 10`
1. Verify the output is in the format: `2021-11-09T20:47:07.747765934Z My log message`.
1. Verify the logs are limited to the specified `--limit`

#### After the API is available in production:

1. Check out PR.
1. Run `npm run build`
1. Run `npm link`
1. Run `vip @[app-id].[env] logs --type app --limit 10`
1. Verify the logs for the specified type are displayed
1. Verify the output is in the format: `2021-11-09T20:47:07.747765934Z My log message`.
1. Verify the logs are limited to the specified `--limit`
