### PR TITLE
[dev-env] Handles user already exists during sql import

### DIFF
--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -9,6 +9,7 @@
  * External dependencies
  */
 import fs from 'fs';
+import chalk from 'chalk';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import command from '../lib/cli/command';
 import { getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
-import chalk from 'chalk';
 
 const examples = [
 	{

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -17,6 +17,7 @@ import command from '../lib/cli/command';
 import { getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+import chalk from 'chalk';
 
 const examples = [
 	{
@@ -62,8 +63,16 @@ command( {
 			const cacheArg = [ 'wp', 'cache', 'flush' ];
 			await exec( slug, cacheArg );
 
-			const addUserArg = [ 'wp', 'user', 'create', 'vipgo', 'vipgo@go-vip.net', '--user_pass=password', '--role=administrator' ];
-			await exec( slug, addUserArg );
+			try {
+				const addUserArg = [ 'wp', 'user', 'create', 'vipgo', 'vipgo@go-vip.net', '--user_pass=password', '--role=administrator' ];
+				await exec( slug, addUserArg );
+			} catch ( exception ) {
+				if ( ( exception.message || '' ).includes( 'is already registered' ) ) {
+					console.log( chalk.bold( chalk.green( 'Success: ' ) ) + 'Skipping user vipgo provisioning' );
+				} else {
+					throw exception;
+				}
+			}
 		} catch ( error ) {
 			handleCLIException( error );
 		}


### PR DESCRIPTION
## Description

After SQL import we try to provision the `vipgo` user.

However, that fails if the vipgo user is already present.

```
$ vip dev-env import sql --slug test ~/test.sql 
Success: Imported from '/user/test.sql'.
Success: The cache was flushed.
Error: The 'vipgo' username is already registered.
Error: Error: The 'vipgo' username is already registered.
```

I couldn't find a way to fully suppress the error as that is printed by `wp` cli . I tried to capture output of `wp user list` and to check if the user exists before attempting to create it, but no luck there either. Because the `wp-cli` runs inside a container and passing those `stdio` doesn't work as expected.

We could alternatively create a different CLI, but seems like overdoing it.

So I just removed one error and print extra success line:
```
Success: Imported from '/user/test.sql'.
Success: The cache was flushed.
Error: The 'vipgo' username is already registered.
Success: Skipping user vipgo provisioning
```
 

## Steps to Test

1) `vip dev-env --slug test exec  -- wp db export - > ~/test.sql`
1) `vip dev-env --slug test import sql ~/test.sql`
