### PR TITLE
[dev-env] Switch lando to use our fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3718,6 +3718,24 @@
         }
       }
     },
+    "@lando/platformsh": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@lando/platformsh/-/platformsh-0.6.0.tgz",
+      "integrity": "sha512-TQGpVZn0qVHDbtAX+3Y14Iq91wyQgWo6/zA3cREGR7p8kH2nD2Yd3ZrfLfPO2ikN+9iZPYxtKO1rPNeZAQxVpQ==",
+      "requires": {
+        "js-yaml": "^3.4.6",
+        "lodash": "^4.17.21",
+        "platformsh-client": "^0.1.179",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -4334,9 +4352,9 @@
       },
       "dependencies": {
         "follow-redirects": {
-          "version": "1.14.4",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-          "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+          "version": "1.14.5",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+          "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
         }
       }
     },
@@ -6357,9 +6375,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -10016,9 +10034,10 @@
       "dev": true
     },
     "lando": {
-      "version": "git+https://github.com/lando/cli.git#4590f740cbebf553ef5203153c77900855f7011c",
-      "from": "git+https://github.com/lando/cli.git#v3.4.3",
+      "version": "git+https://github.com/Automattic/lando-cli.git#2dc2401b6c99f14f3ca8b7ed3ba0f8d34031adfc",
+      "from": "git+https://github.com/Automattic/lando-cli.git#2dc2401b6c99f14f3ca8b7ed3ba0f8d34031adfc",
       "requires": {
+        "@lando/platformsh": "^0.6.0",
         "axios": "0.21.4",
         "bluebird": "^3.4.1",
         "clean-stacktrace": "^1.1.0",
@@ -10039,12 +10058,10 @@
         "mkdirp": "^0.5.1",
         "node-cache": "^4.1.1",
         "object-hash": "^1.1.8",
-        "platformsh-client": "^0.1.129",
         "semver": "^7.3.2",
         "shelljs": "^0.8.4",
         "string-argv": "0.1.1",
         "sudo-block": "^2.0.0",
-        "tar": "^6.1.9",
         "through": "^2.3.8",
         "transliteration": "^2.2.0",
         "uuid": "^3.2.1",
@@ -10059,14 +10076,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
-        "cli-table": {
-          "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
-          "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
-          "requires": {
-            "colors": "1.0.3"
-          }
-        },
         "cliui": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -10076,11 +10085,6 @@
             "strip-ansi": "^4.0.0",
             "wrap-ansi": "^2.0.0"
           }
-        },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         },
         "find-up": {
           "version": "3.0.0",
@@ -10717,9 +10721,9 @@
       }
     },
     "mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
     },
     "mime-db": {
       "version": "1.49.0",
@@ -11711,9 +11715,9 @@
       }
     },
     "platformsh-client": {
-      "version": "0.1.179",
-      "resolved": "https://registry.npmjs.org/platformsh-client/-/platformsh-client-0.1.179.tgz",
-      "integrity": "sha512-E25FoOF+KmWmL/5Dec8Zi/3gMiwYzjt7H9czUjiIfIhzjywExXE3LDWolfk0F7lfyAkeXBMIbcIdiZDcFyh4Yw==",
+      "version": "0.1.185",
+      "resolved": "https://registry.npmjs.org/platformsh-client/-/platformsh-client-0.1.185.tgz",
+      "integrity": "sha512-mNKOzFuggFWUf1Yy2RULJRmvv/o5Pq83rG5aep2cal3fOv28pAIkMhgQ9SbYkyYRlcnufOfNS2jr7qffRITtUw==",
       "requires": {
         "atob": "^2.1.2",
         "basename": "^0.1.2",
@@ -11729,13 +11733,6 @@
         "slugify": "^1.3.4",
         "to-querystring": "^1.1.1",
         "url-pattern": "^1.0.3"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.2.6",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-          "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
-        }
       }
     },
     "posix-character-classes": {
@@ -12687,9 +12684,9 @@
       }
     },
     "slugify": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.1.tgz",
-      "integrity": "sha512-5ofqMTbetNhxlzjYYLBaZFQd6oiTuSkQlyfPEFIMwgUABlZQ0hbk5xIV9Ydd5jghWeRoO7GkiJliUvTpLOjNRA=="
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.2.tgz",
+      "integrity": "sha512-XMtI8qD84LwCpthLMBHlIhcrj10cgA+U/Ot8G6FD6uFuWZtMfKK75JO7l81nzpFJsPlsW6LT+VKqWQJW3+6New=="
     },
     "smart-buffer": {
       "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10035,7 +10035,7 @@
     },
     "lando": {
       "version": "git+https://github.com/Automattic/lando-cli.git#2dc2401b6c99f14f3ca8b7ed3ba0f8d34031adfc",
-      "from": "git+https://github.com/Automattic/lando-cli.git#2dc2401b6c99f14f3ca8b7ed3ba0f8d34031adfc",
+      "from": "git+https://github.com/Automattic/lando-cli.git#v3.5.1-patch2021_11_22",
       "requires": {
         "@lando/platformsh": "^0.6.0",
         "axios": "0.21.4",
@@ -10076,6 +10076,30 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
+        "cli-table": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.8.tgz",
+          "integrity": "sha512-5IO15fJRzgM+hHZjvQlqD6UPRuVGWR4Ny5ZzaM5VJxJEQqSIEVyVh9dMAUN6CBAVfMc4/6CFEzbhnRftLRCyug==",
+          "requires": {
+            "colors": "1.0.3",
+            "strip-ansi": "^6.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+              "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
+          }
+        },
         "cliui": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -10085,6 +10109,11 @@
             "strip-ansi": "^4.0.0",
             "wrap-ansi": "^2.0.0"
           }
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         },
         "find-up": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ini": "2.0.0",
     "json2csv": "5.0.6",
     "jwt-decode": "2.2.0",
-    "lando": "git+https://github.com/Automattic/lando-cli.git#2dc2401b6c99f14f3ca8b7ed3ba0f8d34031adfc",
+    "lando": "git+https://github.com/Automattic/lando-cli.git#v3.5.1-patch2021_11_22",
     "node-fetch": "^2.6.1",
     "opn": "5.5.0",
     "rollbar": "2.22.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "ini": "2.0.0",
     "json2csv": "5.0.6",
     "jwt-decode": "2.2.0",
-    "lando": "git+https://github.com/lando/cli.git#v3.4.3",
+    "lando": "git+https://github.com/Automattic/lando-cli.git#2dc2401b6c99f14f3ca8b7ed3ba0f8d34031adfc",
     "node-fetch": "^2.6.1",
     "opn": "5.5.0",
     "rollbar": "2.22.0",


### PR DESCRIPTION

## Description

We recently needed to change lando code a bit in [here](https://github.com/Automattic/lando-cli/pull/1). This change brings our fork of `lando-cli` library to `vip`.

## Steps to Test

1) test all dev-env stuff :)

