### PR TITLE
Sets jest maxWorkers to 4

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
 		'./jest.setupMocks.js',
 	],
 	testURL: 'http://localhost/',
+	maxWorkers: 4,
 };


### PR DESCRIPTION
## Description

For some reason, if we add new test files, CircleCI builds for `lts-stretch` and `current-stretch` fail with the error: 
```
Too long with no output (exceeded 10m0s): context deadline exceeded
```

Setting jest `maxWorkers` looks to solve the issue and also makes the tests run between 10% to 40% faster.

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm ci`
1. Run `npm run jest`