### PR TITLE
Add formatting options for vip logs

### DIFF
--- a/__tests__/bin/vip-logs.js
+++ b/__tests__/bin/vip-logs.js
@@ -51,7 +51,7 @@ describe( 'getLogs', () => {
 			},
 			type: 'app',
 			limit: 500,
-			format: 'console',
+			format: 'text',
 		};
 	} );
 
@@ -80,7 +80,7 @@ describe( 'getLogs', () => {
 			env_id: 3,
 			type: 'app',
 			limit: 500,
-			format: 'console',
+			format: 'text',
 		};
 
 		expect( tracker.trackEvent ).toHaveBeenCalledTimes( 2 );
@@ -183,7 +183,7 @@ describe( 'getLogs', () => {
 			env_id: 3,
 			type: 'app',
 			limit: 500,
-			format: 'console',
+			format: 'text',
 		};
 
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 1, 'logs_command_execute', trackingParams );
@@ -220,7 +220,7 @@ describe( 'getLogs', () => {
 			env_id: 3,
 			type: 'app',
 			limit: 500,
-			format: 'console',
+			format: 'text',
 		};
 
 		expect( rollbar.error ).toHaveBeenCalledTimes( 1 );
@@ -261,7 +261,7 @@ describe( 'getLogs', () => {
 		await expect( promise ).rejects.toBe( 'EXIT WITH ERROR' );
 
 		expect( exit.withError ).toHaveBeenCalledTimes( 1 );
-		expect( exit.withError ).toHaveBeenCalledWith( 'Invalid format: jso. The supported formats are: csv, json, console.' );
+		expect( exit.withError ).toHaveBeenCalledWith( 'Invalid format: jso. The supported formats are: csv, json, text.' );
 
 		expect( logsLib.getRecentLogs ).not.toHaveBeenCalled();
 

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -13,7 +13,7 @@ import { formatData } from 'lib/cli/format';
 const LIMIT_MAX = 5000;
 const LIMIT_MIN = 1;
 const ALLOWED_TYPES = [ 'app', 'batch' ];
-const ALLOWED_FORMATS = [ 'csv', 'json', 'console' ];
+const ALLOWED_FORMATS = [ 'csv', 'json', 'text' ];
 
 export async function getLogs( arg: string[], opt ): Promise<void> {
 	validateInputs( opt.type, opt.limit, opt.format );
@@ -59,7 +59,7 @@ export async function getLogs( arg: string[], opt ): Promise<void> {
 	} );
 
 	let output = '';
-	if ( opt.format && 'console' === opt.format ) {
+	if ( opt.format && 'text' === opt.format ) {
 		const rows = [];
 		for ( const { timestamp, message } of logs ) {
 			rows.push( `${ timestamp } ${ message }` );
@@ -109,7 +109,7 @@ command( {
 } )
 	.option( 'type', 'The type of logs to be returned: "app" or "batch"', 'app' )
 	.option( 'limit', 'The maximum number of log lines', 500 )
-	.option( 'format', 'Output the log lines in CSV or JSON format', 'console' )
+	.option( 'format', 'Output the log lines in CSV or JSON format', 'text' )
 	.examples( [
 		{
 			usage: 'vip @mysite.production logs',

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -125,7 +125,7 @@ command( {
 		},
 		{
 			usage: 'vip @mysite.production logs --limit 100 --format csv',
-			description: 'Get the most recent 100 log entries formatted as comma-separated values (CSV)
+			description: 'Get the most recent 100 log entries formatted as comma-separated values (CSV)',
 		},
 		{
 			usage: 'vip @mysite.production logs --limit 100 --format json',

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -121,15 +121,15 @@ command( {
 		},
 		{
 			usage: 'vip @mysite.production logs --limit 100',
-			description: 'Get the most recent 100 logs',
+			description: 'Get the most recent 100 log entries',
 		},
 		{
 			usage: 'vip @mysite.production logs --limit 100 --format csv',
-			description: 'Get the most recent 100 logs formatted as a CSV',
+			description: 'Get the most recent 100 log entries formatted as comma-separated values (CSV)
 		},
 		{
 			usage: 'vip @mysite.production logs --limit 100 --format json',
-			description: 'Get the most recent 100 logs formatted in JSON',
+			description: 'Get the most recent 100 log entries formatted as JSON',
 		},
 	] )
 	.argv( process.argv, getLogs );


### PR DESCRIPTION
`json` and `csv` are supported. Default is "console" which just outputs timestamp and message

See CAFE-312

cc @chriszarate 

## Steps to Test

1. Check out PR.
1. Run `npm run build`

Invalid format:

```
./dist/bin/vip-logs.js @123 --format jso
Error:  Invalid format: jso. The supported formats are: csv, json, console.
Debug:  VIP-CLI v2.6.0, Node v12.18.4, darwin 20.6.0
```

No format:

```
./dist/bin/vip-logs.js @
2021-12-02T16:08:31.141418694Z This is a log message
```

JSON

```
./dist/bin/vip-logs.js @123 --format json
[
	{
		"timestamp": "2021-12-02T16:08:31.141472025Z",
		"message": "This is a log"
	}
]
```

CSV
```
./dist/bin/vip-logs.js @123 --format csv
"timestamp","message"
"2021-12-02T16:08:31.141472025Z","This is a log"
```