### PR TITLE
Hide roll back message after SQL Import failure for launched sites

### DIFF
--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -96,7 +96,7 @@ async function getStatus( api, appId, envId ) {
 	return {
 		importStatus,
 		importJob,
-	  	launched,
+		launched,
 	};
 }
 

--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -29,6 +29,7 @@ const IMPORT_SQL_PROGRESS_QUERY = gql`
 			environments(id: $envId) {
 				id
 				isK8sResident
+				launched
 				jobs(types: "sql_import") {
 					id
 					type
@@ -84,7 +85,8 @@ async function getStatus( api, appId, envId ) {
 		throw new Error( 'Unable to determine import status from environment' );
 	}
 	const [ environment ] = environments;
-	const { importStatus, jobs } = environment;
+	const { importStatus, jobs, launched } = environment;
+
 	if ( ! environment.isK8sResident && ! jobs?.length ) {
 		return {};
 	}
@@ -94,13 +96,14 @@ async function getStatus( api, appId, envId ) {
 	return {
 		importStatus,
 		importJob,
+	  	launched,
 	};
 }
 
-function getErrorMessage( importFailed ) {
+function getErrorMessage( importFailed, launched = false ) {
 	debug( { importFailed } );
 
-	const rollbackMessage = `Your site is ${ chalk.blue(
+	const rollbackMessage = launched ? '' : `Your site is ${ chalk.blue(
 		'automatically being rolled back'
 	) } to the last backup prior to your import job.
 `;
@@ -238,7 +241,7 @@ ${ maybeExitPrompt }
 				} catch ( error ) {
 					return reject( { error } );
 				}
-				const { importStatus } = status;
+				const { importStatus, launched } = status;
 				let { importJob } = status;
 
 				let jobStatus, jobSteps = [];
@@ -317,7 +320,7 @@ ${ maybeExitPrompt }
 				}
 
 				if ( ! jobSteps.length ) {
-					return reject( { error: 'Could not enumerate the import job steps' } );
+					return reject( { error: 'Could not enumerate the import job steps', launched } );
 				}
 
 				if ( failedImportStep ) {
@@ -338,6 +341,7 @@ ${ maybeExitPrompt }
 						error: 'Import step failed',
 						stepName: failedImportStep.name,
 						errorText: failedImportStep.error,
+						launched,
 					} );
 				}
 
@@ -346,7 +350,7 @@ ${ maybeExitPrompt }
 				setSuffixAndPrint();
 
 				if ( jobStatus === 'error' ) {
-					return reject( { error: 'Import job failed', steps: jobSteps } );
+					return reject( { error: 'Import job failed', steps: jobSteps, launched } );
 				}
 
 				if ( jobStatus !== 'running' && completedAt ) {
@@ -364,7 +368,6 @@ ${ maybeExitPrompt }
 
 	try {
 		const results = await getResults();
-
 		if ( typeof results === 'string' ) {
 			overallStatus = results;
 		} else {
@@ -384,7 +387,7 @@ ${ maybeExitPrompt }
 	} catch ( importFailed ) {
 		progressTracker.stopPrinting();
 		progressTracker.print( { clearAfter: true } );
-		exit.withError( getErrorMessage( importFailed ) );
+		exit.withError( getErrorMessage( importFailed, importFailed.launched ) );
 	}
 }
 


### PR DESCRIPTION
## Description

When an SQL Import fails, we automatically roll back to the latest backup for unlaunched sites. We don't do that for launched sites, but currently, the error message still says that the site was automatically rolled back.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Create a SQL Import file that will make the import fail. You can use the following, which will make the import fail as the table `wp_users` already exists:

```
CREATE TABLE `wp_users` (
  `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `user_login` varchar(60) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_pass` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_nicename` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_email` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_url` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_registered` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
  `user_activation_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `user_status` int(11) NOT NULL DEFAULT 0,
  `display_name` varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
  `spam` tinyint(2) NOT NULL DEFAULT 0,
  `deleted` tinyint(2) NOT NULL DEFAULT 0,
  PRIMARY KEY (`ID`),
  KEY `user_login_key` (`user_login`),
  KEY `user_nicename` (`user_nicename`),
  KEY `user_email` (`user_email`)
) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
```
4. Run SQL Import for unlaunched site, e.g.`vip import sql @4361.production test.sql --skip-validate`
5. Validate that after failure, a rollback message is displayed: `Your site is automatically being rolled back to the last backup prior to your import job.`
6. Run SQL Import for launched site
7. Validate that after failure, rollback message is not displayed

