### PR TITLE
Envvar: Show message when there is an attempt to change the New Relic key.

### DIFF
--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -23,6 +23,8 @@ import { trackEvent } from 'lib/tracker';
 
 const baseUsage = 'vip config envvar set';
 
+const NEW_RELIC_ENVVAR_KEY = 'NEW_RELIC_LICENSE_KEY';
+
 // Command examples
 const examples = [
 	{
@@ -50,6 +52,13 @@ export async function setEnvVarCommand( arg: string[], opt ) {
 
 	if ( ! validateNameWithMessage( name ) ) {
 		await trackEvent( 'envvar_set_invalid_name', trackingParams );
+		process.exit( 1 );
+	}
+
+	if ( NEW_RELIC_ENVVAR_KEY === name ) {
+		await trackEvent( 'envvar_set_newrelic_key', trackingParams );
+		console.log( chalk.bold.red( 'Setting the New Relic key is not permitted.' ),
+			'If you want to set your own New Relic key, please contact our support team through the usual channels.' );
 		process.exit( 1 );
 	}
 


### PR DESCRIPTION
## Description

When a user tries to change the New Relic environment variable, a generic error is currently shown:

```
$ vip @1234 config envvar set NEW_RELIC_LICENSE_KEY
For multiline input, use the --from-file option.

✔ Enter the value for NEW_RELIC_LICENSE_KEY: · abc123
✔ Please confirm the input value above (y/N) · true
Error: Not allowed to access key 'NEW_RELIC_LICENSE_KEY'.
```

This PR implements a custom error message, suggesting to open a support request to change the New Relic key.

```
$ vip @3076.production config envvar set NEW_RELIC_LICENSE_KEY
Setting the New Relic key is not permitted. If you want to set your own New Relic key, please contact our support team through the usual channels.
```

This will also add tracking on this specific error (using the event `envvar_set_newrelic_key`) so that we can track interest in changing the New Relic key.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `npm link`
1. Run `vip @1234.production config envvar set NEW_RELIC_LICENSE_KEY` (replace `@1234.production` with your environment).
2. You should see the new error message.

