### PR TITLE
Add support for the site logs tailing feature

### DIFF
--- a/__tests__/bin/vip-logs.js
+++ b/__tests__/bin/vip-logs.js
@@ -28,6 +28,7 @@ jest.mock( 'lib/tracker', () => ( {
 } ) );
 
 jest.mock( 'lib/app-logs/app-logs', () => ( {
+	// Only mock what is really needed, otherwise exported constants like LIMIT_MAX would be `undefined` during the tests
 	...jest.requireActual( 'lib/app-logs/app-logs' ),
 	getRecentLogs: jest.fn(),
 } ) );

--- a/__tests__/bin/vip-logs.js
+++ b/__tests__/bin/vip-logs.js
@@ -28,6 +28,7 @@ jest.mock( 'lib/tracker', () => ( {
 } ) );
 
 jest.mock( 'lib/app-logs/app-logs', () => ( {
+	...jest.requireActual( 'lib/app-logs/app-logs' ),
 	getRecentLogs: jest.fn(),
 } ) );
 
@@ -56,10 +57,13 @@ describe( 'getLogs', () => {
 	beforeEach( jest.clearAllMocks );
 
 	it( 'should display the logs in the output', async () => {
-		logsLib.getRecentLogs.mockImplementation( async () => [
-			{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
-			{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2' },
-		] );
+		logsLib.getRecentLogs.mockImplementation( async () => ( {
+			nextCursor: null,
+			nodes: [
+				{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
+				{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2' },
+			],
+		} ) );
 
 		await getLogs( [], opts );
 
@@ -78,6 +82,7 @@ describe( 'getLogs', () => {
 			env_id: 3,
 			type: 'app',
 			limit: 500,
+			follow: false,
 			format: 'text',
 		};
 
@@ -85,7 +90,7 @@ describe( 'getLogs', () => {
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 1, 'logs_command_execute', trackingParams );
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 2, 'logs_command_success', {
 			...trackingParams,
-			logs_output: 2,
+			total: 2,
 		} );
 
 		expect( rollbar.error ).not.toHaveBeenCalled();
@@ -94,10 +99,13 @@ describe( 'getLogs', () => {
 	it( 'should display the logs in the output with JSON format', async () => {
 		opts.format = 'json';
 
-		logsLib.getRecentLogs.mockImplementation( async () => [
-			{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
-			{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2' },
-		] );
+		logsLib.getRecentLogs.mockImplementation( async () => ( {
+			nextCursor: null,
+			nodes: [
+				{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
+				{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2' },
+			],
+		} ) );
 
 		await getLogs( [], opts );
 
@@ -124,6 +132,7 @@ describe( 'getLogs', () => {
 			env_id: 3,
 			type: 'app',
 			limit: 500,
+			follow: false,
 			format: 'json',
 		};
 
@@ -131,7 +140,7 @@ describe( 'getLogs', () => {
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 1, 'logs_command_execute', trackingParams );
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 2, 'logs_command_success', {
 			...trackingParams,
-			logs_output: 2,
+			total: 2,
 		} );
 
 		expect( rollbar.error ).not.toHaveBeenCalled();
@@ -140,10 +149,13 @@ describe( 'getLogs', () => {
 	it( 'should display the logs in the output with CSV format', async () => {
 		opts.format = 'csv';
 
-		logsLib.getRecentLogs.mockImplementation( async () => [
-			{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
-			{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2 has "double quotes", \'single quotes\', commas, multiple\nlines\n, and	tabs' },
-		] );
+		logsLib.getRecentLogs.mockImplementation( async () => ( {
+			nextCursor: null,
+			nodes: [
+				{ timestamp: '2021-11-05T20:18:36.234041811Z', message: 'My container message 1' },
+				{ timestamp: '2021-11-09T20:47:07.301221112Z', message: 'My container message 2 has "double quotes", \'single quotes\', commas, multiple\nlines\n, and	tabs' },
+			],
+		} ) );
 
 		await getLogs( [], opts );
 
@@ -165,6 +177,7 @@ lines
 			env_id: 3,
 			type: 'app',
 			limit: 500,
+			follow: false,
 			format: 'csv',
 		};
 
@@ -172,14 +185,14 @@ lines
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 1, 'logs_command_execute', trackingParams );
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 2, 'logs_command_success', {
 			...trackingParams,
-			logs_output: 2,
+			total: 2,
 		} );
 
 		expect( rollbar.error ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should show a message if no logs were found', async () => {
-		logsLib.getRecentLogs.mockImplementation( async () => [] ); // empty logs
+		logsLib.getRecentLogs.mockImplementation( async () => ( { nextCursor: null, nodes: [] } ) ); // empty logs
 
 		await getLogs( [], opts );
 
@@ -196,13 +209,14 @@ lines
 			env_id: 3,
 			type: 'app',
 			limit: 500,
+			follow: false,
 			format: 'text',
 		};
 
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 1, 'logs_command_execute', trackingParams );
 		expect( tracker.trackEvent ).toHaveBeenNthCalledWith( 2, 'logs_command_success', {
 			...trackingParams,
-			logs_output: 0,
+			total: 0,
 		} );
 
 		expect( rollbar.error ).not.toHaveBeenCalled();
@@ -233,6 +247,7 @@ lines
 			env_id: 3,
 			type: 'app',
 			limit: 500,
+			follow: false,
 			format: 'text',
 		};
 

--- a/__tests__/lib/app-logs/app-logs.js
+++ b/__tests__/lib/app-logs/app-logs.js
@@ -12,15 +12,17 @@ import { getRecentLogs } from 'lib/app-logs/app-logs';
 jest.mock( 'lib/api', () => jest.fn() );
 
 const EXPECTED_QUERY = gql`
-	query GetAppLogs( $appId: Int, $envId: Int, $type: AppEnvironmentLogType, $limit: Int ) {
+	query GetAppLogs( $appId: Int, $envId: Int, $type: AppEnvironmentLogType, $limit: Int, $after: String ) {
 		app( id: $appId ) {
 			environments( id: $envId ) {
 				id
-				logs( type: $type, limit: $limit ) {
+				logs( type: $type, limit: $limit, after: $after ) {
 					nodes {
 						timestamp
 						message
 					}
+					nextCursor
+					pollingDelaySeconds
 				}
 			}
 		}
@@ -52,6 +54,7 @@ describe( 'getRecentLogs()', () => {
 				envId: 3,
 				type: 'batch',
 				limit: 1200,
+				after: undefined,
 			},
 		} );
 	} );
@@ -71,13 +74,14 @@ describe( 'getRecentLogs()', () => {
 	} );
 } );
 
-function logsResponse( logs ) {
+function logsResponse( logs, nextCursor = null ) {
 	return {
 		data: {
 			app: {
 				environments: [
 					{
 						logs: {
+							nextCursor,
 							nodes: logs,
 						},
 					},

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -73,9 +73,14 @@ export async function followLogs( opt ): Promise<void> {
 		try {
 			logs = await logsLib.getRecentLogs( opt.app.id, opt.env.id, opt.type, limit, after );
 		} catch ( error ) {
+			// If the first request fails we don't want to retry (it's probably not recoverable)
+			if ( isFirstRequest ) {
+				console.error( `Error fetching initial logs` );
+				break;
+			}
 			// Increase the delay on errors to avoid overloading the server, up to a max of 5 minutes
 			delay += 30;
-			delay = Math.max( delay, 300 );
+			delay = Math.min( delay, 300 );
 			console.error( `Failed to fetch logs. Trying again in ${ delay } seconds` );
 			rollbar.error( error );
 		}

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -74,15 +74,15 @@ export async function followLogs( opt ): Promise<void> {
 			rollbar.error( error );
 		}
 
-		if ( logs.nodes.length ) {
+		if ( logs?.nodes.length ) {
 			printLogs( logs.nodes, opt.format );
 		}
 
-		after = logs.nextCursor;
+		after = logs?.nextCursor;
 		isFirstRequest = false;
 
 		// Keep a sane lower limit of MIN_POLLING_DELAY_SECONDS just in case something goes wrong in the server-side
-		const delay = Math.min( ( logs.pollingDelaySeconds || 10 ), MIN_POLLING_DELAY_SECONDS ) * 1000;
+		const delay = Math.min( ( logs?.pollingDelaySeconds || 10 ), MIN_POLLING_DELAY_SECONDS ) * 1000;
 
 		await new Promise( resolve => setTimeout( resolve, delay ) );
 	}

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -82,7 +82,7 @@ export async function followLogs( opt ): Promise<void> {
 		isFirstRequest = false;
 
 		// Keep a sane lower limit of MIN_POLLING_DELAY_SECONDS just in case something goes wrong in the server-side
-		const delay = Math.min( ( logs?.pollingDelaySeconds || 10 ), MIN_POLLING_DELAY_SECONDS ) * 1000;
+		const delay = Math.max( ( logs?.pollingDelaySeconds || 10 ), MIN_POLLING_DELAY_SECONDS ) * 1000;
 
 		await new Promise( resolve => setTimeout( resolve, delay ) );
 	}

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -31,12 +31,12 @@ export async function getLogs( arg: string[], opt ): Promise<void> {
 
 	await trackEvent( 'logs_command_execute', trackingParams );
 
-	if ( opt.follow ) {
-		return await followLogs( opt );
-	}
-
 	let logs;
 	try {
+		if ( opt.follow ) {
+			return await followLogs( opt );
+		}
+
 		logs = await logsLib.getRecentLogs( opt.app.id, opt.env.id, opt.type, opt.limit );
 	} catch ( error ) {
 		rollbar.error( error );

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -82,7 +82,7 @@ export async function followLogs( opt ): Promise<void> {
 		isFirstRequest = false;
 
 		// Keep a sane lower limit of MIN_POLLING_DELAY_SECONDS just in case something goes wrong in the server-side
-		const delay = Math.max( ( logs?.pollingDelaySeconds || 10 ), MIN_POLLING_DELAY_SECONDS ) * 1000;
+		const delay = Math.max( ( logs?.pollingDelaySeconds || 30 ), MIN_POLLING_DELAY_SECONDS ) * 1000;
 
 		await new Promise( resolve => setTimeout( resolve, delay ) );
 	}

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -25,7 +25,7 @@ export async function getLogs( arg: string[], opt ): Promise<void> {
 		env_id: opt.env.id,
 		type: opt.type,
 		limit: opt.limit,
-		follow: opt.follow,
+		follow: opt.follow || false,
 		format: opt.format,
 	};
 

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -14,6 +14,7 @@ const LIMIT_MAX = 5000;
 const LIMIT_MIN = 1;
 const ALLOWED_TYPES = [ 'app', 'batch' ];
 const ALLOWED_FORMATS = [ 'csv', 'json', 'text' ];
+const MIN_POLLING_DELAY_SECONDS = 5;
 
 export async function getLogs( arg: string[], opt ): Promise<void> {
 	validateInputs( opt.type, opt.limit, opt.format );
@@ -60,8 +61,6 @@ export async function getLogs( arg: string[], opt ): Promise<void> {
 }
 
 export async function followLogs( opt ): Promise<void> {
-	let interval = 30;
-
 	let after = null;
 
 	while ( true ) {
@@ -79,7 +78,10 @@ export async function followLogs( opt ): Promise<void> {
 
 		after = logs.nextCursor;
 
-		await new Promise( ( resolve ) => { setTimeout( resolve, interval * 1000 ); } );
+		// Keep a sane lower limit of MIN_POLLING_DELAY_SECONDS just in case something goes wrong in the server-side
+		const delay = Math.min( ( logs.pollingDelaySeconds || 10 ), MIN_POLLING_DELAY_SECONDS ) * 1000;
+
+		await new Promise( resolve => setTimeout( resolve, delay ) );
 	}
 }
 

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -75,7 +75,7 @@ export async function followLogs( opt ): Promise<void> {
 		} catch ( error ) {
 			// If the first request fails we don't want to retry (it's probably not recoverable)
 			if ( isFirstRequest ) {
-				console.error( `Error fetching initial logs` );
+				console.error( 'Error fetching initial logs' );
 				break;
 			}
 			// Increase the delay on errors to avoid overloading the server, up to a max of 5 minutes

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -31,7 +31,7 @@ export function disableGlobalGraphQLErrorHandling() {
 	globalGraphQLErrorHandlingEnabled = false;
 }
 
-export default async function API( exitOnError = true ): Promise<ApolloClient> {
+export default async function API( { exitOnError = true } = {} ): Promise<ApolloClient> {
 	const authToken = await Token.get();
 	const headers = {
 		'User-Agent': env.userAgent,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -31,7 +31,7 @@ export function disableGlobalGraphQLErrorHandling() {
 	globalGraphQLErrorHandlingEnabled = false;
 }
 
-export default async function API(): Promise<ApolloClient> {
+export default async function API( exitOnError = true ): Promise<ApolloClient> {
 	const authToken = await Token.get();
 	const headers = {
 		'User-Agent': env.userAgent,
@@ -52,7 +52,9 @@ export default async function API(): Promise<ApolloClient> {
 				console.error( chalk.red( 'Error:' ), error.message );
 			} );
 
-			process.exit();
+			if ( exitOnError ) {
+				process.exit();
+			}
 		}
 	} );
 

--- a/src/lib/app-logs/app-logs.js
+++ b/src/lib/app-logs/app-logs.js
@@ -40,7 +40,7 @@ type GetRecentLogsResponse = {
 };
 
 export async function getRecentLogs( appId: number, envId: number, type: string, limit: number, after?: string ): Promise<GetRecentLogsResponse> {
-	const api = await API( false );
+	const api = await API( { exitOnError: false } );
 
 	const response = await api.query( {
 		query: QUERY_ENVIRONMENT_LOGS,

--- a/src/lib/app-logs/app-logs.js
+++ b/src/lib/app-logs/app-logs.js
@@ -13,6 +13,8 @@ import gql from 'graphql-tag';
  */
 import API from 'lib/api';
 
+export const LIMIT_MAX = 5000;
+
 const QUERY_ENVIRONMENT_LOGS = gql`
 	query GetAppLogs( $appId: Int, $envId: Int, $type: AppEnvironmentLogType, $limit: Int, $after: String ) {
 		app( id: $appId ) {

--- a/src/lib/app-logs/app-logs.js
+++ b/src/lib/app-logs/app-logs.js
@@ -14,11 +14,11 @@ import gql from 'graphql-tag';
 import API from 'lib/api';
 
 const QUERY_ENVIRONMENT_LOGS = gql`
-	query GetAppLogs( $appId: Int, $envId: Int, $type: AppEnvironmentLogType, $limit: Int ) {
+	query GetAppLogs( $appId: Int, $envId: Int, $type: AppEnvironmentLogType, $limit: Int, $since: String ) {
 		app( id: $appId ) {
 			environments( id: $envId ) {
 				id
-				logs( type: $type, limit: $limit ) {
+				logs( type: $type, limit: $limit, since: $since ) {
 					nodes {
 						timestamp
 						message
@@ -29,7 +29,7 @@ const QUERY_ENVIRONMENT_LOGS = gql`
 	}
 `;
 
-export async function getRecentLogs( appId: number, envId: number, type: string, limit: number ): Promise<Array<{ timestamp: string, message: string }>> {
+export async function getRecentLogs( appId: number, envId: number, type: string, limit: number, since: string ): Promise<Array<{ timestamp: string, message: string }>> {
 	const api = await API();
 
 	const response = await api.query( {
@@ -39,6 +39,7 @@ export async function getRecentLogs( appId: number, envId: number, type: string,
 			envId,
 			type,
 			limit,
+			since,
 		},
 	} );
 

--- a/src/lib/app-logs/app-logs.js
+++ b/src/lib/app-logs/app-logs.js
@@ -24,13 +24,14 @@ const QUERY_ENVIRONMENT_LOGS = gql`
 						message
 					}
 					nextCursor
+					pollingDelaySeconds
 				}
 			}
 		}
 	}
 `;
 
-export async function getRecentLogs( appId: number, envId: number, type: string, limit: number, after: string ): Promise<{ nodes: Array<{ timestamp: string, message: string }>, nextCursor: string }> {
+export async function getRecentLogs( appId: number, envId: number, type: string, limit: number, after: string ): Promise<{ nodes: Array<{ timestamp: string, message: string }>, nextCursor: string, pollingDelaySeconds: number }> {
 	const api = await API();
 
 	const response = await api.query( {

--- a/src/lib/app-logs/app-logs.js
+++ b/src/lib/app-logs/app-logs.js
@@ -33,7 +33,13 @@ const QUERY_ENVIRONMENT_LOGS = gql`
 	}
 `;
 
-export async function getRecentLogs( appId: number, envId: number, type: string, limit: number, after: string ): Promise<{ nodes: Array<{ timestamp: string, message: string }>, nextCursor: string, pollingDelaySeconds: number }> {
+type GetRecentLogsResponse = {
+	nodes: Array<{ timestamp: string, message: string }>,
+	nextCursor: string,
+	pollingDelaySeconds: number,
+};
+
+export async function getRecentLogs( appId: number, envId: number, type: string, limit: number, after?: string ): Promise<GetRecentLogsResponse> {
 	const api = await API();
 
 	const response = await api.query( {

--- a/src/lib/app-logs/app-logs.js
+++ b/src/lib/app-logs/app-logs.js
@@ -40,7 +40,7 @@ type GetRecentLogsResponse = {
 };
 
 export async function getRecentLogs( appId: number, envId: number, type: string, limit: number, after?: string ): Promise<GetRecentLogsResponse> {
-	const api = await API();
+	const api = await API( false );
 
 	const response = await api.query( {
 		query: QUERY_ENVIRONMENT_LOGS,


### PR DESCRIPTION
## Description

This adds a new `--follow` parameter to the `logs` command that uses the new Graphql parameter to fetch logs only from a specific timestamp. This way, `vip-cli` will poll the API to fetch only the new logs since the previous request.

The API functionality is still not integrated, so this needs a full local dev environment

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-logs.js @<site>.<env> --follow`
1. This will run forever, fetching new logs every 30 seconds

