### PR TITLE
FORNO-1047: Recalculate md5 hash after compressing file

### DIFF
--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -111,16 +111,11 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 
 		const isCompressed = [ 'application/zip', 'application/gzip' ].includes( mimeType );
 
-		debug( 'Calculating file md5 checksum...' );
-		const md5 = await getFileMD5Hash( fileName );
-		debug( `Calculated file md5 checksum: ${ md5 }\n` );
-
 		resolve( {
 			basename,
 			fileName,
 			fileSize,
 			isCompressed,
-			md5,
 		} );
 	} );
 }
@@ -162,9 +157,6 @@ export async function uploadImportSqlFileToS3( {
 		fileMeta.isCompressed = true;
 		fileMeta.fileSize = await getFileSize( fileMeta.fileName );
 
-		// file was compressed, so we need to recalculate md5
-		fileMeta.md5 = await getFileMD5Hash( fileMeta.fileName );
-
 		debug( `Compressed file is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
 
 		const fewerBytes = uncompressedFileSize - fileMeta.fileSize;
@@ -175,6 +167,10 @@ export async function uploadImportSqlFileToS3( {
 
 		debug( `** Compression resulted in a ${ calculation } smaller file 📦 **\n` );
 	}
+
+	debug( 'Calculating file md5 checksum...' );
+	fileMeta.md5 = await getFileMD5Hash( fileMeta.fileName );
+	debug( `Calculated file md5 checksum: ${ fileMeta.md5 }\n` );
 
 	const result =
 		fileMeta.fileSize < MULTIPART_THRESHOLD

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -162,6 +162,9 @@ export async function uploadImportSqlFileToS3( {
 		fileMeta.isCompressed = true;
 		fileMeta.fileSize = await getFileSize( fileMeta.fileName );
 
+		// file was compressed, so we need to recalculate md5
+		fileMeta.md5 = await getFileMD5Hash( fileMeta.fileName );
+
 		debug( `Compressed file is ~ ${ Math.floor( fileMeta.fileSize / MB_IN_BYTES ) } MB\n` );
 
 		const fewerBytes = uncompressedFileSize - fileMeta.fileSize;


### PR DESCRIPTION
## Description

Currently, we calculate md5 hash of the file, then we compress it if it's over 16MB and upload it to S3. On the other side, we download it, uncompress it and recalculate md5 hash and compare them. 

Customers can also import already compressed files, and in this case the md5 calculation on the backend fails, as we would first uncompress file and then calculate the hash. In order to fix this on the backend, we need to merge this PR, which recalculates the md5 hash after we compress the file. This ensures that the md5 hash sent to the backend is always the one from the file being uploaded ( currently the hash is of the uncompressed file ).

## Steps to Test

1. Check out PR.
2. Make sure your test site is running 0.5.8 version of site jobs
3. Run SQL Import with file larger than 16MB
4. The md5 hash calculation step should not fail

