### PR TITLE
Switch to npm-shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10582,7 +10582,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },


### PR DESCRIPTION
To help enforce dependencies since package-lock is not shipped with npm releases.

Note: this is merging into `master` since this is for a hotfix release.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-dev-env-info.js` -- make sure it works.
1. Test other commands in dist and make sure they work as well.

