### PR TITLE
FORNO-1047: Fix SQL Import for compressed files

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10595,7 +10595,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -27,7 +27,7 @@ import {
 // eslint-disable-next-line no-duplicate-imports
 import type { AppForImport, EnvForImport } from 'lib/site-import/db-file-import';
 import { importSqlCheckStatus } from 'lib/site-import/status';
-import { checkFileAccess, getFileSize, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
+import { checkFileAccess, getFileSize, getFileMeta, uploadImportSqlFileToS3 } from 'lib/client-file-uploader';
 import { trackEventWithEnv } from 'lib/tracker';
 import { staticSqlValidations, getTableNames } from 'lib/validations/sql';
 import { siteTypeValidations } from 'lib/validations/site-type';
@@ -37,8 +37,9 @@ import * as exit from 'lib/cli/exit';
 import { fileLineValidations } from 'lib/validations/line-by-line';
 import { formatEnvironment, formatSearchReplaceValues, getGlyphForStatus } from 'lib/cli/format';
 import { ProgressTracker } from 'lib/cli/progress';
-import { isFile } from '../lib/client-file-uploader';
+import { detectCompressedMimeType, FileMeta, isFile } from '../lib/client-file-uploader';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
+import path from 'path';
 
 export type WPSiteListType = {
 	id: string,
@@ -373,10 +374,23 @@ command( {
 	)
 	.examples( examples )
 	.argv( process.argv, async ( arg: string[], opts ) => {
-		const { app, env, searchReplace, skipValidate } = opts;
+		const { app, env } = opts;
+		let { skipValidate, searchReplace } = opts;
 		const { id: envId, appId } = env;
 		const [ fileName ] = arg;
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
+		const fileMeta = await getFileMeta( fileName );
+
+		if ( fileMeta.isCompressed ) {
+			console.log(
+				chalk.yellowBright(
+					'You are importing a compressed file. Validation and search-replace operation will be skipped.'
+				)
+			);
+
+			skipValidate = true;
+			searchReplace = undefined;
+		}
 
 		debug( 'Options: ', opts );
 		debug( 'Args: ', arg );
@@ -492,12 +506,14 @@ Processing the SQL import for your environment...
 
 		try {
 			const {
-				fileMeta: { basename, md5 },
+				fileMeta: { basename },
+				md5,
 				result,
 			} = await uploadImportSqlFileToS3( {
 				app,
 				env,
 				fileName: fileNameToUpload,
+				fileMeta,
 				progressCallback,
 			} );
 

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -98,6 +98,27 @@ export const gzipFile = async ( uncompressedFileName: string, compressedFileName
 			.on( 'error', error => reject( `could not compress file: ${ error }` ) )
 	);
 
+export async function getFileMeta( fileName: string ): Promise<FileMeta> {
+	return new Promise( async resolve => {
+		const fileSize = await getFileSize( fileName );
+
+		const basename = path.basename( fileName );
+		// TODO Validate File basename...  encodeURIComponent, maybe...?
+
+		const mimeType = await detectCompressedMimeType( fileName );
+		// TODO Only allow a subset of Mime Types...?
+
+		const isCompressed = [ 'application/zip', 'application/gzip' ].includes( mimeType );
+
+		resolve( {
+			basename,
+			fileName,
+			fileSize,
+			isCompressed,
+		} );
+	} );
+}
+
 export async function uploadImportSqlFileToS3( {
 	app,
 	env,
@@ -156,6 +177,7 @@ export async function uploadImportSqlFileToS3( {
 
 	return {
 		fileMeta,
+		md5,
 		result,
 	};
 }


### PR DESCRIPTION
## Description

Due to a bug on the backend, compressed files currently cannot be imported as the md5 hash calculation fails. This PR moves md5 calculation to take place just before the file is uploaded.

In addition, this PR skips validation and search replace when customers try to import compressed SQL file.

## Steps to Test

1. Check out PR.
2. Import compressed file to site 4361 (contains fixed jobs image): `vip import sql @4361.production data.sql.gz`
3. Import uncompressed file to site 4361 (contains fixed jobs image): `vip import sql @4361.production data.sql`
4. Verify that both imports work as expected


