### PR TITLE
[dev-env] Updated list of available wordpress images for dev-env

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -335,5 +335,13 @@ export function addDevEnvConfigurationOptions( command ) {
 }
 
 function getWordpressImageTags(): string[] {
-	return [ '5.8.1', '5.8', '5.7.3', '5.7.2' ];
+	return [
+		'5.9',
+		'5.8.3',
+		'5.8.2',
+		'5.8.1',
+		'5.8',
+		'5.7.3',
+		'5.7.2',
+	];
 }


### PR DESCRIPTION
## Description

Updates the list of available WordPress Images in dev-env Including:
  * 5.9,
  * 5.8.3,
  * 5.8.2

![Screen Shot 2022-01-19 at 9 41 12 AM](https://user-images.githubusercontent.com/46167019/150175197-11e286ab-848d-4769-b5d4-2ab60f8c5805.png)
 
## Steps to Test

1. Check out PR
2. `npm run build`
3. `node ./dist/bin/vip-dev-env-create.js --slug=test`
4. Verify 5.9, 5.8.3, 5.8.2 are among the list of available images

