### PR TITLE
WIP: functionality for dynamic wordpress version list

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -188,10 +188,10 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 		it.each( [
 			{
-				tag: '5.6',
+				tag: '5.9',
 				expected: {
 					mode: 'image',
-					tag: '5.6',
+					tag: '5.9',
 				},
 			},
 		] )( 'should return correct component for wordpress %p', async input => {

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -14,8 +14,6 @@ import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import { getEnvironmentName, getEnvironmentStartCommand, processComponentOptionInput, promptForText, promptForComponent } from 'lib/dev-environment/dev-environment-cli';
 import { promptForArguments } from '../../../src/lib/dev-environment/dev-environment-cli';
 
-jest.setTimeout( 10000 );
-
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
 	const SelectClass = class {};

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -106,11 +106,11 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 	describe( 'processComponentOptionInput', () => {
 		it.each( [
 			{ // base tag
-				param: 5.6,
+				param: 5.9,
 				allowLocal: true,
 				expected: {
 					mode: 'image',
-					tag: '5.6',
+					tag: '5.9',
 				},
 			},
 			{ // if local is not allowed

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -14,6 +14,8 @@ import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import { getEnvironmentName, getEnvironmentStartCommand, processComponentOptionInput, promptForText, promptForComponent } from 'lib/dev-environment/dev-environment-cli';
 import { promptForArguments } from '../../../src/lib/dev-environment/dev-environment-cli';
 
+jest.setTimeout( 10000 );
+
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
 	const SelectClass = class {};

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -346,21 +346,27 @@ async function populateWordPressVersionList( versionList ) {
 			} );
 
 			res.on( 'end', () => {
-				const list = JSON.parse( data );
-				list.forEach( item => {
-					if ( item.metadata.container.tags.length > 0 ) {
-						item.metadata.container.tags.forEach( tag => {
-							versionList.push( tag );
-						} );
-					}
-				} );
+				try {
+					const list = JSON.parse( data );
+					list.forEach( item => {
+						if ( item.metadata.container.tags.length > 0 ) {
+							item.metadata.container.tags.forEach( tag => {
+								versionList.push( tag );
+							} );
+						}
+					} );
+				} catch {
+					console.log( chalk.yellow( 'Warning:' ), 'Could not load remote list of WordPress images.' );
+					versionList.push( '5.9', '5.8', '5.7', '5.6' );
+				}
+
 				versionList.sort().reverse();
 				resolve();
 			} );
 		} );
 
 		req.on( 'error', error => {
-			console.error( error );
+			console.log( chalk.yellow( 'Warning:' ), error );
 		} );
 
 		req.end();
@@ -374,7 +380,7 @@ function getImageApiOptions() {
 		path: '/orgs/Automattic/packages/container/vip-container-images%2Fwordpress/versions?per_page=100&repo=vip-container-images&package_type=container',
 		method: 'GET',
 		headers: {
-			Authorization: 'Bearer ghp_XXXXXXXXXXXXXXXXXXXX',
+			Authorization: 'Bearer ghp_XXXXXXXXXXXXXXXXXXXXXX',
 			'User-Agent': 'VIP',
 			Accept: 'application/vnd.github.v3+json',
 		},

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -349,7 +349,9 @@ async function populateWordPressVersionList( versionList ) {
 				let list = JSON.parse(data)
 				list.forEach( item => {
 					if ( item.metadata.container.tags.length > 0 ) {
-						versionList.push(item.metadata.container.tags[0])
+						item.metadata.container.tags.forEach( tag => {
+							versionList.push(tag)
+						})
 					}
 				})
 				versionList.sort().reverse()

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -294,8 +294,8 @@ export async function promptForComponent( component: string, allowLocal: boolean
 	// image with selection
 	if ( component === 'wordpress' ) {
 		const message = `${ messagePrefix }Which version would you like`;
-		const tagChoices = []
-		await populateWordPressVersionList(tagChoices);
+		const tagChoices = [];
+		await populateWordPressVersionList( tagChoices );
 		let initialTagIndex = 0;
 		if ( defaultObject?.tag ) {
 			const defaultTagIndex = tagChoices.indexOf( defaultObject.tag );
@@ -336,47 +336,47 @@ export function addDevEnvConfigurationOptions( command ) {
 }
 
 async function populateWordPressVersionList( versionList ) {
-	return new Promise(( resolve, reject ) =>  {
-		const https = require( 'https' )
-		const req = https.request(getImageApiOptions(), res => {
-			let data = ''
+	return new Promise( resolve => {
+		const https = require( 'https' );
+		const req = https.request( getImageApiOptions(), res => {
+			let data = '';
 
 			res.on( 'data', chunk => {
-				data += chunk
-			})
+				data += chunk;
+			} );
 
 			res.on( 'end', () => {
-				let list = JSON.parse( data )
+				const list = JSON.parse( data );
 				list.forEach( item => {
 					if ( item.metadata.container.tags.length > 0 ) {
 						item.metadata.container.tags.forEach( tag => {
-							versionList.push( tag )
-						})
+							versionList.push( tag );
+						} );
 					}
-				})
-				versionList.sort().reverse()
-				resolve()
-			})
-		})
+				} );
+				versionList.sort().reverse();
+				resolve();
+			} );
+		} );
 
-		req.on('error', error => {
-			console.error( error )
-		})
+		req.on( 'error', error => {
+			console.error( error );
+		} );
 
-		req.end()
-    });
+		req.end();
+	} );
 }
 
 function getImageApiOptions() {
-	return  {
+	return {
 		hostname: 'api.github.com',
 		port: 443,
 		path: '/orgs/Automattic/packages/container/vip-container-images%2Fwordpress/versions?per_page=100&repo=vip-container-images&package_type=container',
 		method: 'GET',
 		headers: {
-			'Authorization': 'Bearer ghp_XXXXXXXXXXXXXXXXXXXX',
+			Authorization: 'Bearer ghp_XXXXXXXXXXXXXXXXXXXX',
 			'User-Agent': 'VIP',
-			'Accept': 'application/vnd.github.v3+json',
-		}
-	}
+			Accept: 'application/vnd.github.v3+json',
+		},
+	};
 }

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -337,7 +337,7 @@ export function addDevEnvConfigurationOptions( command ) {
 
 async function populateWordPressVersionList( versionList ) {
 	return new Promise(( resolve, reject ) =>  {
-		const https = require('https')
+		const https = require( 'https' )
 		const req = https.request(getImageApiOptions(), res => {
 			let data = ''
 
@@ -346,11 +346,11 @@ async function populateWordPressVersionList( versionList ) {
 			})
 
 			res.on( 'end', () => {
-				let list = JSON.parse(data)
+				let list = JSON.parse( data )
 				list.forEach( item => {
 					if ( item.metadata.container.tags.length > 0 ) {
 						item.metadata.container.tags.forEach( tag => {
-							versionList.push(tag)
+							versionList.push( tag )
 						})
 					}
 				})
@@ -360,7 +360,7 @@ async function populateWordPressVersionList( versionList ) {
 		})
 
 		req.on('error', error => {
-			console.error(error)
+			console.error( error )
 		})
 
 		req.end()

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -341,7 +341,7 @@ async function populateWordPressVersionList( versionList ) {
 		const req = https.request(getImageApiOptions(), res => {
 			let data = ''
 
-			res.on( 'data', (chunk) => {
+			res.on( 'data', chunk => {
 				data += chunk
 			})
 


### PR DESCRIPTION
## Description

This PR adds functionality to dynamically populate the list of available WordPress versions for dev-env.
The new code accomplishes this in the following steps:
1. Make a call to the Github REST Api to see what packages are available.
2. Sort the resulting response.
3. Display the response to the user as a list of available options for installing WordPress

![Screen Shot 2022-01-19 at 4 05 13 PM](https://user-images.githubusercontent.com/46167019/150232601-b7c0f6cb-316c-4536-8489-21472cb52a46.png)

## Steps to Test
1. Check out PR.
1. Run `npm run build; node ./dist/bin/vip-dev-env-create.js --slug=test`
1. Proceed through the first two  config options
2. Verify that the list of available images was loaded dynamically (should pause momentarily for the web request)

