### PR TITLE
Add Error prefix for "Failed to fetch logs" msg

### DIFF
--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 // @flow
+
+/**
+ * External dependencies
+ */
+import chalk from 'chalk';
+
 /**
  * Internal dependencies
  */
@@ -91,7 +97,7 @@ export async function followLogs( opt ): Promise<void> {
 			// Increase the delay on errors to avoid overloading the server, up to a max of 5 minutes
 			delay += DEFAULT_POLLING_DELAY_IN_SECONDS;
 			delay = Math.min( delay, MAX_POLLING_DELAY_IN_SECONDS );
-			console.error( `Failed to fetch logs. Trying again in ${ delay } seconds` );
+			console.error( `${ chalk.red( 'Error:' ) } Failed to fetch logs. Trying again in ${ delay } seconds` );
 			rollbar.error( error );
 		}
 

--- a/src/bin/vip-logs.js
+++ b/src/bin/vip-logs.js
@@ -91,13 +91,13 @@ export async function followLogs( opt ): Promise<void> {
 
 			// If the first request fails we don't want to retry (it's probably not recoverable)
 			if ( isFirstRequest ) {
-				console.error( 'Error fetching initial logs' );
+				console.error( `${ chalk.red( 'Error:' ) } Failed to fetch logs.` );
 				break;
 			}
 			// Increase the delay on errors to avoid overloading the server, up to a max of 5 minutes
 			delay += DEFAULT_POLLING_DELAY_IN_SECONDS;
 			delay = Math.min( delay, MAX_POLLING_DELAY_IN_SECONDS );
-			console.error( `${ chalk.red( 'Error:' ) } Failed to fetch logs. Trying again in ${ delay } seconds` );
+			console.error( `${ chalk.red( 'Error:' ) } Failed to fetch logs. Trying again in ${ delay } seconds.` );
 			rollbar.error( error );
 		}
 


### PR DESCRIPTION
For consistency with other errors.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-logs.js @309 --follow`
1. Turn off wifi
2. Wait
3. Should show two error messages both prefixed with "Error:"

