### PR TITLE
Use latest fileName when calculating md5 hash in SQL Imports

### DIFF
--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -167,7 +167,7 @@ export async function uploadImportSqlFileToS3( {
 	}
 
 	debug( 'Calculating file md5 checksum...' );
-	const md5 = await getFileMD5Hash( fileName );
+	const md5 = await getFileMD5Hash( fileMeta.fileName );
 	debug( `Calculated file md5 checksum: ${ md5 }\n` );
 
 	const result =


### PR DESCRIPTION
## Description

In the latest release, we moved md5 calculation to happen just before the file is uploaded. Unfortunately, it still used the original fileName. For files bigger than 16MB, we compress the file, and because of this the fileName changes. This PR addresses the issue.

Due to a backend workaround, this issue only affects VIPd.

## Steps to Test

1. Check out PR.
2. Run  import on a VIPd site
3. Verify that md5 hash calculation does not fail and import succeeds

