### PR TITLE
Set fileMeta.fileName to latest fileNameToUpload

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -504,6 +504,8 @@ Processing the SQL import for your environment...
 			progressTracker.setUploadPercentage( percentage );
 		};
 
+		fileMeta.fileName = fileNameToUpload;
+
 		try {
 			const {
 				fileMeta: { basename },
@@ -512,7 +514,6 @@ Processing the SQL import for your environment...
 			} = await uploadImportSqlFileToS3( {
 				app,
 				env,
-				fileName: fileNameToUpload,
 				fileMeta,
 				progressCallback,
 			} );

--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -122,7 +122,6 @@ export async function getFileMeta( fileName: string ): Promise<FileMeta> {
 export async function uploadImportSqlFileToS3( {
 	app,
 	env,
-	fileName,
 	fileMeta,
 	progressCallback,
 }: UploadArguments ) {


### PR DESCRIPTION
## Description

When we execute search-replace as part of an import, we can write the file to another location. Due to recent changes, the wrong fileName was passed to the upload function so the md5 calculation failed.

## Steps to Test

1. Check out PR.
2. Verify that the following imports work:

- compressed file
- uncompressed file
- uncompressed file with search-replace
- uncompressed file larger than 16MB
- uncompressed file larger than 16MB with search-replace

