### PR TITLE
[dev-env] Validate sql on import

### DIFF
--- a/__fixtures__/validations/bad-sql-dev-env.sql
+++ b/__fixtures__/validations/bad-sql-dev-env.sql
@@ -1,0 +1,4 @@
+CREATE DATABASE automatticians;
+
+-- for dev-env you should not switch database
+USE automatticians;

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -67,6 +67,9 @@ describe( 'lib/validations/sql', () => {
 		it( 'instances of ENGINE != InnoDB', () => {
 			expect( output ).toContain( 'ENGINE != InnoDB on line(s) 14' );
 		} );
+		it( 'use statement should be ok', () => {
+			expect( output ).not.toContain( '\'USE <DATABASE_NAME>\' should not be present (case-insensitive)' );
+		} );
 	} );
 	describe( 'it fails when the SQL has (using bad-sql-duplicate-tables.sql)', () => {
 		beforeAll( async () => {
@@ -81,6 +84,21 @@ describe( 'lib/validations/sql', () => {
 		} );
 		it( 'duplicate tables names found', () => {
 			expect( output ).toContain( 'Duplicate table names were found: wp_users' );
+		} );
+	} );
+	describe( 'it fails when the SQL for dev-env has (using bad-sql-dev-env.sql)', () => {
+		beforeAll( async () => {
+			try {
+				output = '';
+				const sqlFileDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'bad-sql-dev-env.sql' );
+				await validate( sqlFileDumpPath, [] );
+			} catch ( err ) {
+				debug( 'Error:', err.toString() );
+			}
+			debug( 'output', output );
+		} );
+		it( 'use statement', () => {
+			expect( output ).toContain( 'USE <DATABASE_NAME> statement on line(s)' );
 		} );
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10595,7 +10595,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -18,6 +18,7 @@ import command from '../lib/cli/command';
 import { getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+import { validate } from '../lib/validations/sql';
 
 const examples = [
 	{
@@ -44,6 +45,7 @@ command( {
 	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'search-replace', 'Perform Search and Replace on the specified SQL file' )
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
+	.option( 'skip-validate', 'Do not perform file validation.' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
 		const [ fileName ] = unmatchedArgs;
@@ -52,6 +54,10 @@ command( {
 
 		try {
 			const { resolvedPath, inContainerPath } = await resolveImportPath( slug, fileName, searchReplace, inPlace );
+
+			if ( ! opt.skipValidate ) {
+				await validate( fileName, [] );
+			}
 
 			const importArg = [ 'wp', 'db', 'import', inContainerPath ];
 			await exec( slug, importArg );


### PR DESCRIPTION

## Description

Mostly it is just lifting the same validation rules we have for production import.

One exception is the addition of validation for "USE <database_name>;". We saw this as one of the often issue with import files when the import is done to an incorrect database thanks to this.


## Steps to Test
Download example SQL:
```

USE something;

DROP TABLE IF EXISTS `wp_a8c_cron_control_jobs`;
/*!40101 SET @saved_cs_client     = @@character_set_client */;
/*!40101 SET character_set_client = utf8 */;
CREATE TABLE `wp_a8c_cron_control_jobs` (
  `ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `timestamp` bigint(20) unsigned NOT NULL,
  `action` varchar(255) NOT NULL,
  `action_hashed` varchar(32) NOT NULL,
  `instance` varchar(32) NOT NULL,
  `args` longtext NOT NULL,
  `schedule` varchar(255) DEFAULT NULL,
  `interval` int(10) unsigned DEFAULT 0,
  `status` varchar(32) NOT NULL DEFAULT 'pending',
  `created` datetime NOT NULL,
  `last_modified` datetime NOT NULL,
  PRIMARY KEY (`ID`),
  UNIQUE KEY `ts_action_instance_status` (`timestamp`,`action`(191),`instance`,`status`),
  KEY `status` (`status`)
) ENGINE=InnoDB AUTO_INCREMENT=104 DEFAULT CHARSET=latin1;
/*!40101 SET character_set_client = @saved_cs_client */;

```


Example:

1. Check out PR.
1. Run `npm run build && ./dist/bin/vip-dev-env-import-sql.js ~/Downloads/test.sql`

