### PR TITLE
CI: Node version updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,25 @@ workflows:
       - lint
       - flow
       - test:
-          version: 12
+          version: '12'
           name: node-12
           requires:
             - lint
             - flow
       - test:
-          version: 14
+          version: '14'
           name: node-14
           requires:
             - lint
             - flow
       - test:
-          version: 16
+          version: '16'
           name: node-16
           requires:
             - lint
             - flow
       - test:
-          version: 17
+          version: '17'
           name: node-17
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: cimg/node:current-stretch
+      - image: cimg/node:current
 
     working_directory: ~/repo
 
@@ -46,7 +46,7 @@ jobs:
           
   flow:
     docker:
-      - image: cimg/node:current-stretch
+      - image: cimg/node:current
 
     working_directory: ~/repo
 
@@ -63,7 +63,7 @@ jobs:
         type: string
 
     docker:
-      - image: circleci/node:<< parameters.version >>
+      - image: cimg/node:<< parameters.version >>
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,26 +6,26 @@ workflows:
       - lint
       - flow
       - test:
-          version: 10-stretch
-          name: 10-stretch
+          version: 12
+          name: node-12
           requires:
             - lint
             - flow
       - test:
-          version: 12-stretch
-          name: 12-stretch
+          version: 14
+          name: node-14
           requires:
             - lint
             - flow
       - test:
-          version: lts-stretch
-          name: lts-stretch
+          version: 16
+          name: node-16
           requires:
             - lint
             - flow
       - test:
-          version: current-stretch
-          name: current-stretch
+          version: 17
+          name: node-17
           requires:
             - lint
             - flow
@@ -33,7 +33,7 @@ workflows:
 jobs:
   lint:
     docker:
-      - image: circleci/node:current-stretch
+      - image: cimg/node:current-stretch
 
     working_directory: ~/repo
 
@@ -46,7 +46,7 @@ jobs:
           
   flow:
     docker:
-      - image: circleci/node:current-stretch
+      - image: cimg/node:current-stretch
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Drop 10 since it's long-gone. Add explict testing for Node 14/16/17.

## Steps to Test

CI