### PR TITLE
[dev-env] Dynamic WordPress Image List

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -188,10 +188,10 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 		it.each( [
 			{
-				tag: '5.6',
+				tag: '5.9',
 				expected: {
 					mode: 'image',
-					tag: '5.6',
+					tag: '5.9',
 				},
 			},
 		] )( 'should return correct component for wordpress %p', async input => {

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -34,6 +34,7 @@ jest.mock( 'enquirer', () => {
 
 describe( 'lib/dev-environment/dev-environment-cli', () => {
 	beforeEach( () => {
+		jest.setTimeout(60000);
 		prompt.mockReset();
 		confirmRunMock.mockReset();
 	} );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -14,8 +14,6 @@ import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import { getEnvironmentName, getEnvironmentStartCommand, processComponentOptionInput, promptForText, promptForComponent } from 'lib/dev-environment/dev-environment-cli';
 import { promptForArguments } from '../../../src/lib/dev-environment/dev-environment-cli';
 
-jest.setTimeout( 10000 );
-
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
 	const SelectClass = class {};

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
+import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -31,6 +32,61 @@ jest.mock( 'enquirer', () => {
 		confirmRunMock: _confirmRunMock,
 	};
 } );
+
+const scope = nock('https://raw.githubusercontent.com')
+  .get('/Automattic/vip-container-images/master/wordpress/versions.json')
+  .reply( 200, [
+		{
+			"ref": "5.8.3",
+			"tag": "5.8",
+			"cacheable": true,
+			"locked": false,
+			"prerelease": false
+		},
+		{
+			"ref": "5.9",
+			"tag": "5.9",
+			"cacheable": true,
+			"locked": false,
+			"prerelease": false
+		},
+		{
+			"ref": "5.5.8",
+			"tag": "5.5",
+			"cacheable": true,
+			"locked": true,
+			"prerelease": false
+		},
+		{
+			"ref": "5.6.7",
+			"tag": "5.6",
+			"cacheable": true,
+			"locked": true,
+			"prerelease": false
+		},
+		{
+			"ref": "5.7.5",
+			"tag": "5.7",
+			"cacheable": true,
+			"locked": true,
+			"prerelease": false
+		},
+		{
+			"ref": "5.8.3",
+			"tag": "5.8.3",
+			"cacheable": true,
+			"locked": true,
+			"prerelease": false
+		},
+		{
+			"ref": "3ae9f9ffe311e546b0fd5f82d456b3539e3b8e74",
+			"tag": "5.9.1",
+			"cacheable": true,
+			"locked": true,
+			"prerelease": true
+		}
+	],
+);
 
 describe( 'lib/dev-environment/dev-environment-cli', () => {
 	beforeEach( () => {

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -33,60 +33,16 @@ jest.mock( 'enquirer', () => {
 	};
 } );
 
-const scope = nock('https://raw.githubusercontent.com')
-  .get('/Automattic/vip-container-images/master/wordpress/versions.json')
-  .reply( 200, [
-		{
-			"ref": "5.8.3",
-			"tag": "5.8",
-			"cacheable": true,
-			"locked": false,
-			"prerelease": false
-		},
-		{
-			"ref": "5.9",
-			"tag": "5.9",
-			"cacheable": true,
-			"locked": false,
-			"prerelease": false
-		},
-		{
-			"ref": "5.5.8",
-			"tag": "5.5",
-			"cacheable": true,
-			"locked": true,
-			"prerelease": false
-		},
-		{
-			"ref": "5.6.7",
-			"tag": "5.6",
-			"cacheable": true,
-			"locked": true,
-			"prerelease": false
-		},
-		{
-			"ref": "5.7.5",
-			"tag": "5.7",
-			"cacheable": true,
-			"locked": true,
-			"prerelease": false
-		},
-		{
-			"ref": "5.8.3",
-			"tag": "5.8.3",
-			"cacheable": true,
-			"locked": true,
-			"prerelease": false
-		},
-		{
-			"ref": "3ae9f9ffe311e546b0fd5f82d456b3539e3b8e74",
-			"tag": "5.9.1",
-			"cacheable": true,
-			"locked": true,
-			"prerelease": true
-		}
-	],
-);
+const scope = nock( 'https://raw.githubusercontent.com' )
+	.get( '/Automattic/vip-container-images/master/wordpress/versions.json' )
+	.reply( 200, [ {
+		ref: '5.9',
+		tag: '5.9',
+		cacheable: true,
+		locked: false,
+		prerelease: false,
+	} ] );
+scope.persist( true );
 
 describe( 'lib/dev-environment/dev-environment-cli', () => {
 	beforeEach( () => {

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -106,11 +106,11 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 	describe( 'processComponentOptionInput', () => {
 		it.each( [
 			{ // base tag
-				param: 5.6,
+				param: 5.9,
 				allowLocal: true,
 				expected: {
 					mode: 'image',
-					tag: '5.6',
+					tag: '5.9',
 				},
 			},
 			{ // if local is not allowed

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -46,7 +46,6 @@ scope.persist( true );
 
 describe( 'lib/dev-environment/dev-environment-cli', () => {
 	beforeEach( () => {
-		jest.setTimeout( 60000 );
 		prompt.mockReset();
 		confirmRunMock.mockReset();
 	} );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -14,6 +14,8 @@ import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import { getEnvironmentName, getEnvironmentStartCommand, processComponentOptionInput, promptForText, promptForComponent } from 'lib/dev-environment/dev-environment-cli';
 import { promptForArguments } from '../../../src/lib/dev-environment/dev-environment-cli';
 
+jest.setTimeout( 10000 );
+
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
 	const SelectClass = class {};

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -34,7 +34,7 @@ jest.mock( 'enquirer', () => {
 
 describe( 'lib/dev-environment/dev-environment-cli', () => {
 	beforeEach( () => {
-		jest.setTimeout(60000);
+		jest.setTimeout( 60000 );
 		prompt.mockReset();
 		confirmRunMock.mockReset();
 	} );

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -14,3 +14,9 @@ export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up
 export const DEV_ENVIRONMENT_NOT_FOUND = 'Environment not found.';
 
 export const DEV_ENVIRONMENT_COMPONENTS = [ 'wordpress', 'muPlugins', 'clientCode' ];
+
+export const DEV_ENVIRONMENT_RAW_GITHUB_HOST = 'raw.githubusercontent.com';
+
+export const DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI = '/Automattic/vip-container-images/master/wordpress/versions.json';
+
+export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'worpress-versions.json';

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -20,3 +20,5 @@ export const DEV_ENVIRONMENT_RAW_GITHUB_HOST = 'raw.githubusercontent.com';
 export const DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI = '/Automattic/vip-container-images/master/wordpress/versions.json';
 
 export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'worpress-versions.json';
+
+export const DEV_ENVIRONMENT_WORDPRESS_VERSION_FILE = 'wordpress/wp-includes/version.php';

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -362,7 +362,6 @@ async function getVersionList() {
 	let res;
 	const local = xdgBasedir.data || os.tmpdir();
 	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
-	console.log( DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
 	const cacheFile = path.join( local, 'vip', DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
 
 	// Try to retrieve the file from cache or cache it if invalid

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -346,7 +346,7 @@ async function populateWordPressVersionList( versionList ) {
 		const https = require( 'https' );
 		const req = https.request( apiOptions, res => {
 			let data = '';
-			let tag, tagFormatted, locked, prerelease, mapping;
+			let tag, tagFormatted, prerelease, mapping;
 
 			res.on( 'data', chunk => {
 				data += chunk;
@@ -356,17 +356,16 @@ async function populateWordPressVersionList( versionList ) {
 				try {
 					const list = JSON.parse( data );
 					list.forEach( image => {
-						tagFormatted = image.tag.padEnd(8 -  image.tag.length);
-						locked = ( image.locked ) ? '🔒' : ' ';
-						prerelease = ( image.prerelease ) ? '(Pre-Release)' : '             ';
+						tagFormatted = image.tag.padEnd(8 -  image.tag.length)
+						prerelease = ( image.prerelease ) ? '(Pre-Release)' : '';
 
 						if ( image.tag !== image.ref ) {
-							mapping = `→ ${image.ref}`;
+							mapping = `→ ${prerelease} ${image.ref}`;
 						} else {
 							mapping = '';
 						}
 
-						versionList.push( `${tagFormatted} ${locked} ${prerelease} ${mapping}` );
+						versionList.push( `${tagFormatted} ${mapping}` );
 					} );
 				} catch {
 					console.log( chalk.yellow( 'Warning:' ), 'Could not load remote list of WordPress images.' );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -409,6 +409,9 @@ async function getTagChoices() {
 	const tagChoices = [];
 	let tagFormatted, prerelease, mapping;
 	const versions = await getVersionList();
+	if ( versions.length < 1 ) {
+		return [ '5.9', '5.8', '5.7', '5.6', '5.5' ];
+	}
 
 	for ( const version of versions ) {
 		tagFormatted = version.tag.padEnd( 8 - version.tag.length );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -348,7 +348,7 @@ export function addDevEnvConfigurationOptions( command ) {
  * Makes a web call to raw.githubusercontent.com
  */
 async function fetchVersionList() {
-	const host = 'raw.githubusercontent.com';
+	const host = 'raw.fakegithubusercontent.com';
 	const uri = '/Automattic/vip-container-images/master/wordpress/versions.json';
 	return fetch( `https://${ host }${ uri }`, { method: 'GET' } ).then( res => res.text() );
 }
@@ -357,8 +357,8 @@ async function fetchVersionList() {
  * Uses a cache file to keep the version list in tow until it is ultimately outdated
  */
 async function getVersionList() {
-	let res;
-	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
+	let res, fetchErr;
+	const cacheTtl = 1; // number of seconds that the cache can be considered active.
 	const local = xdgBasedir.data || os.tmpdir();
 	const cacheDir = path.join( local, 'vip' );
 	const cacheKey = 'worpress-versions.json';
@@ -388,7 +388,8 @@ async function getVersionList() {
 	} catch ( err ) {
 		// Soft error handling here, since it's still possible to use a previously cached file.
 		console.log( chalk.yellow( 'fetchWordPressVersionList failed to retrieve an updated version list' ) );
-		debug( err );
+		fetchErr = err;
+		debug( fetchErr );
 	}
 
 	// Try to parse the cached file if it exists
@@ -396,7 +397,8 @@ async function getVersionList() {
 	try {
 		return JSON.parse( fs.readFileSync( cacheFile ) );
 	} catch ( err ) {
-		console.error( err );
+		console.log( fetchErr );
+		console.log( err );
 		process.exit( 1 );
 	}
 }

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -346,8 +346,8 @@ export function addDevEnvConfigurationOptions( command ) {
 
 async function fetchVersionList() {
 	const host = 'raw.githubusercontent.com';
-	const path = '/Automattic/vip-container-images/master/wordpress/versions.json';
-	return fetch( `https://${ host }${ path }`, { method: 'GET' } ).then( res => res.text() );
+	const uri = '/Automattic/vip-container-images/master/wordpress/versions.json';
+	return fetch( `https://${ host }${ uri }`, { method: 'GET' } ).then( res => res.text() );
 }
 
 /**
@@ -355,11 +355,11 @@ async function fetchVersionList() {
  */
 async function getVersionList() {
 	let res;
-	const cacheTtl = 86400 //number of seconds that the cache can be considered active.
+	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
 	const local = xdgBasedir.data || os.tmpdir();
 	const cacheDir = path.join( local, 'vip' );
 	const cacheKey = 'worpress-versions.json';
-	const cacheFile = path.join(cacheDir, cacheKey);
+	const cacheFile = path.join( cacheDir, cacheKey );
 
 	try {
 		// If the cache doesn't exist, create it
@@ -383,7 +383,7 @@ async function getVersionList() {
 		}
 	} catch ( err ) {
 		// Use the cache file if it exists
-		console.log( chalk.yellow( `fetchWordPressVersionList failed to retrieve an updated version list` ) );
+		console.log( chalk.yellow( 'fetchWordPressVersionList failed to retrieve an updated version list' ) );
 		debug( err );
 	}
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -399,6 +399,7 @@ async function getVersionList() {
 	} catch ( err ) {
 		debug( fetchErr );
 		debug( err );
+		return [];
 	}
 }
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -13,6 +13,7 @@ import debugLib from 'debug';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import https from 'https';
 
 /**
  * Internal dependencies
@@ -343,7 +344,6 @@ async function populateWordPressVersionList( versionList ) {
 	};
 
 	return new Promise( resolve => {
-		const https = require( 'https' );
 		const req = https.request( apiOptions, res => {
 			let data = '';
 			let tag, tagFormatted, prerelease, mapping;

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -358,13 +358,13 @@ async function populateWordPressVersionList( versionList ) {
 					list.forEach( image => {
 						tag = image.tag;
 
-						if ( image.locked === true ) {
+						if ( image.locked ) {
 							tag += ' 🔒';
 						} else {
 							tag += '  ';
 						}
 
-						if ( image.prerelease === true ) {
+						if ( image.prerelease ) {
 							tag += ' (Pre-Release)';
 						}
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -346,21 +346,27 @@ async function populateWordPressVersionList( versionList ) {
 			} );
 
 			res.on( 'end', () => {
-				const list = JSON.parse( data );
-				list.forEach( item => {
-					if ( item.metadata.container.tags.length > 0 ) {
-						item.metadata.container.tags.forEach( tag => {
-							versionList.push( tag );
-						} );
-					}
-				} );
+				try {
+					const list = JSON.parse( data );
+					list.forEach( item => {
+						if ( item.metadata.container.tags.length > 0 ) {
+							item.metadata.container.tags.forEach( tag => {
+								versionList.push( tag );
+							} );
+						}
+					} );
+				} catch {
+					console.log( chalk.yellow( 'Warning:' ), 'Could not load remote list of WordPress images.' );
+					versionList.push( '5.9', '5.8', '5.7', '5.6' );
+				}
+
 				versionList.sort().reverse();
 				resolve();
 			} );
 		} );
 
 		req.on( 'error', error => {
-			console.error( error );
+			console.log( chalk.yellow( 'Warning:' ), error );
 		} );
 
 		req.end();
@@ -374,7 +380,7 @@ function getImageApiOptions() {
 		path: '/orgs/Automattic/packages/container/vip-container-images%2Fwordpress/versions?per_page=100&repo=vip-container-images&package_type=container',
 		method: 'GET',
 		headers: {
-			Authorization: 'Bearer ghp_XXXXXXXXXXXXXXXXXXXX',
+			Authorization: 'Bearer ghp_XXXXXXXXXXXXXXXXXXXXXX',
 			'User-Agent': 'VIP',
 			Accept: 'application/vnd.github.v3+json',
 		},

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -26,6 +26,9 @@ import {
 	DEV_ENVIRONMENT_PROMPT_INTRO,
 	DEV_ENVIRONMENT_COMPONENTS,
 	DEV_ENVIRONMENT_NOT_FOUND,
+	DEV_ENVIRONMENT_RAW_GITHUB_HOST,
+	DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI,
+	DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY,
 } from '../constants/dev-environment';
 import { InstanceOptions, EnvironmentNameOptions, InstanceData } from './types';
 
@@ -348,9 +351,8 @@ export function addDevEnvConfigurationOptions( command ) {
  * Makes a web call to raw.githubusercontent.com
  */
 async function fetchVersionList() {
-	const host = 'raw.githubusercontent.com';
-	const uri = '/Automattic/vip-container-images/master/wordpress/versions.json';
-	return fetch( `https://${ host }${ uri }`, { method: 'GET' } ).then( res => res.text() );
+	const url = `https://${ DEV_ENVIRONMENT_RAW_GITHUB_HOST }${ DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI }`;
+	return fetch( url ).then( res => res.text() );
 }
 
 /**
@@ -358,11 +360,10 @@ async function fetchVersionList() {
  */
 async function getVersionList() {
 	let res, fetchErr;
-	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
 	const local = xdgBasedir.data || os.tmpdir();
-	const cacheDir = path.join( local, 'vip' );
-	const cacheKey = 'worpress-versions.json';
-	const cacheFile = path.join( cacheDir, cacheKey );
+	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
+	console.log( DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
+	const cacheFile = path.join( local, 'vip', DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
 
 	// Try to retrieve the file from cache or cache it if invalid
 	try {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -349,7 +349,9 @@ async function populateWordPressVersionList( versionList ) {
 				let list = JSON.parse(data)
 				list.forEach( item => {
 					if ( item.metadata.container.tags.length > 0 ) {
-						versionList.push(item.metadata.container.tags[0])
+						item.metadata.container.tags.forEach( tag => {
+							versionList.push(tag)
+						})
 					}
 				})
 				versionList.sort().reverse()

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -346,7 +346,7 @@ async function populateWordPressVersionList( versionList ) {
 	return new Promise( resolve => {
 		const req = https.request( apiOptions, res => {
 			let data = '';
-			let tag, tagFormatted, prerelease, mapping;
+			let tagFormatted, prerelease, mapping;
 
 			res.on( 'data', chunk => {
 				data += chunk;
@@ -356,16 +356,16 @@ async function populateWordPressVersionList( versionList ) {
 				try {
 					const list = JSON.parse( data );
 					list.forEach( image => {
-						tagFormatted = image.tag.padEnd(8 -  image.tag.length)
+						tagFormatted = image.tag.padEnd( 8 - image.tag.length );
 						prerelease = ( image.prerelease ) ? '(Pre-Release)' : '';
 
 						if ( image.tag !== image.ref ) {
-							mapping = `→ ${prerelease} ${image.ref}`;
+							mapping = `→ ${ prerelease } ${ image.ref }`;
 						} else {
 							mapping = '';
 						}
 
-						versionList.push( `${tagFormatted} ${mapping}` );
+						versionList.push( `${ tagFormatted } ${ mapping }` );
 					} );
 				} catch {
 					console.log( chalk.yellow( 'Warning:' ), 'Could not load remote list of WordPress images.' );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -346,7 +346,7 @@ async function populateWordPressVersionList( versionList ) {
 		const https = require( 'https' );
 		const req = https.request( apiOptions, res => {
 			let data = '';
-			let tag;
+			let tag, tagFormatted, locked, prerelease, mapping;
 
 			res.on( 'data', chunk => {
 				data += chunk;
@@ -356,19 +356,17 @@ async function populateWordPressVersionList( versionList ) {
 				try {
 					const list = JSON.parse( data );
 					list.forEach( image => {
-						tag = image.tag;
+						tagFormatted = image.tag.padEnd(8 -  image.tag.length);
+						locked = ( image.locked ) ? '🔒' : ' ';
+						prerelease = ( image.prerelease ) ? '(Pre-Release)' : '             ';
 
-						if ( image.locked ) {
-							tag += ' 🔒';
+						if ( image.tag !== image.ref ) {
+							mapping = `→ ${image.ref}`;
 						} else {
-							tag += '  ';
+							mapping = '';
 						}
 
-						if ( image.prerelease ) {
-							tag += ' (Pre-Release)';
-						}
-
-						versionList.push( tag );
+						versionList.push( `${tagFormatted} ${locked} ${prerelease} ${mapping}` );
 					} );
 				} catch {
 					console.log( chalk.yellow( 'Warning:' ), 'Could not load remote list of WordPress images.' );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -294,8 +294,8 @@ export async function promptForComponent( component: string, allowLocal: boolean
 	// image with selection
 	if ( component === 'wordpress' ) {
 		const message = `${ messagePrefix }Which version would you like`;
-		const tagChoices = []
-		await populateWordPressVersionList(tagChoices);
+		const tagChoices = [];
+		await populateWordPressVersionList( tagChoices );
 		let initialTagIndex = 0;
 		if ( defaultObject?.tag ) {
 			const defaultTagIndex = tagChoices.indexOf( defaultObject.tag );
@@ -336,47 +336,47 @@ export function addDevEnvConfigurationOptions( command ) {
 }
 
 async function populateWordPressVersionList( versionList ) {
-	return new Promise(( resolve, reject ) =>  {
-		const https = require( 'https' )
-		const req = https.request(getImageApiOptions(), res => {
-			let data = ''
+	return new Promise( resolve => {
+		const https = require( 'https' );
+		const req = https.request( getImageApiOptions(), res => {
+			let data = '';
 
 			res.on( 'data', chunk => {
-				data += chunk
-			})
+				data += chunk;
+			} );
 
 			res.on( 'end', () => {
-				let list = JSON.parse( data )
+				const list = JSON.parse( data );
 				list.forEach( item => {
 					if ( item.metadata.container.tags.length > 0 ) {
 						item.metadata.container.tags.forEach( tag => {
-							versionList.push( tag )
-						})
+							versionList.push( tag );
+						} );
 					}
-				})
-				versionList.sort().reverse()
-				resolve()
-			})
-		})
+				} );
+				versionList.sort().reverse();
+				resolve();
+			} );
+		} );
 
-		req.on('error', error => {
-			console.error( error )
-		})
+		req.on( 'error', error => {
+			console.error( error );
+		} );
 
-		req.end()
-    });
+		req.end();
+	} );
 }
 
 function getImageApiOptions() {
-	return  {
+	return {
 		hostname: 'api.github.com',
 		port: 443,
 		path: '/orgs/Automattic/packages/container/vip-container-images%2Fwordpress/versions?per_page=100&repo=vip-container-images&package_type=container',
 		method: 'GET',
 		headers: {
-			'Authorization': 'Bearer ghp_XXXXXXXXXXXXXXXXXXXX',
+			Authorization: 'Bearer ghp_XXXXXXXXXXXXXXXXXXXX',
 			'User-Agent': 'VIP',
-			'Accept': 'application/vnd.github.v3+json',
-		}
-	}
+			Accept: 'application/vnd.github.v3+json',
+		},
+	};
 }

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -382,12 +382,19 @@ async function getVersionList() {
 			fs.writeFileSync( cacheFile, res );
 		}
 
-		// the result is cached
-		return JSON.parse( fs.readFileSync( cacheFile ) );
 	} catch ( err ) {
 		// Use the cache file if it exists
 		console.log( chalk.yellow( 'fetchWordPressVersionList failed to retrieve an updated version list' ) );
 		debug( err );
+	}
+
+	// Try to parse the cached file if it exists
+	// if not, something worse than a failed request happend; bail.
+	try {
+		return JSON.parse( fs.readFileSync( cacheFile ) );
+	} catch ( err ) {
+		console.error( err );
+		process.exit( 1 );
 	}
 }
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -340,13 +340,13 @@ async function populateWordPressVersionList( versionList ) {
 		hostname: 'raw.githubusercontent.com',
 		path: '/Automattic/vip-container-images/master/wordpress/versions.json',
 		method: 'GET',
-	}
+	};
 
 	return new Promise( resolve => {
 		const https = require( 'https' );
 		const req = https.request( apiOptions, res => {
 			let data = '';
-			let tag, locked, prerelease;
+			let tag;
 
 			res.on( 'data', chunk => {
 				data += chunk;
@@ -358,18 +358,17 @@ async function populateWordPressVersionList( versionList ) {
 					list.forEach( image => {
 						tag = image.tag;
 
-						if ( image.locked == true ) {
+						if ( image.locked === true ) {
 							tag += ' 🔒';
 						} else {
 							tag += '  ';
 						}
 
-						if ( image.prerelease == true ) {
+						if ( image.prerelease === true ) {
 							tag += ' (Pre-Release)';
 						}
 
 						versionList.push( tag );
-
 					} );
 				} catch {
 					console.log( chalk.yellow( 'Warning:' ), 'Could not load remote list of WordPress images.' );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -359,7 +359,7 @@ async function fetchVersionList() {
  * Uses a cache file to keep the version list in tow until it is ultimately outdated
  */
 async function getVersionList() {
-	let res, fetchErr;
+	let res;
 	const local = xdgBasedir.data || os.tmpdir();
 	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
 	console.log( DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
@@ -389,8 +389,7 @@ async function getVersionList() {
 	} catch ( err ) {
 		// Soft error handling here, since it's still possible to use a previously cached file.
 		console.log( chalk.yellow( 'fetchWordPressVersionList failed to retrieve an updated version list' ) );
-		fetchErr = err;
-		debug( fetchErr );
+		debug( err );
 	}
 
 	// Try to parse the cached file if it exists

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -337,7 +337,7 @@ export function addDevEnvConfigurationOptions( command ) {
 
 async function populateWordPressVersionList( versionList ) {
 	return new Promise(( resolve, reject ) =>  {
-		const https = require('https')
+		const https = require( 'https' )
 		const req = https.request(getImageApiOptions(), res => {
 			let data = ''
 
@@ -346,11 +346,11 @@ async function populateWordPressVersionList( versionList ) {
 			})
 
 			res.on( 'end', () => {
-				let list = JSON.parse(data)
+				let list = JSON.parse( data )
 				list.forEach( item => {
 					if ( item.metadata.container.tags.length > 0 ) {
 						item.metadata.container.tags.forEach( tag => {
-							versionList.push(tag)
+							versionList.push( tag )
 						})
 					}
 				})
@@ -360,7 +360,7 @@ async function populateWordPressVersionList( versionList ) {
 		})
 
 		req.on('error', error => {
-			console.error(error)
+			console.error( error )
 		})
 
 		req.end()

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -345,7 +345,7 @@ export function addDevEnvConfigurationOptions( command ) {
 }
 
 async function fetchVersionList() {
-	const host = 'raw.fakegithubusercontent.com';
+	const host = 'raw.githubusercontent.com';
 	const path = '/Automattic/vip-container-images/master/wordpress/versions.json';
 	return fetch( `https://${ host }${ path }`, { method: 'GET' } ).then( res => res.text() );
 }
@@ -373,11 +373,10 @@ async function getVersionList() {
 		debug( `WordPress Version List cache last modified: ${ stats.mtime }` );
 
 		// If the cache is expired, fetch the list again and cache it
-		const ts = Date.now();
-		const lastModified = new Date( stats.mtime );
-		const expire = new Date( ts - cacheTtl );
+		const expire = new Date( stats.mtime );
+		expire.setSeconds( expire.getSeconds() + cacheTtl );
 
-		if ( expire > lastModified ) {
+		if ( +new Date > expire ) {
 			debug( `WordPress Version List cache is expired: ${ expire }` );
 			res = await fetchVersionList();
 			fs.writeFileSync( cacheFile, res );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -341,7 +341,7 @@ async function populateWordPressVersionList( versionList ) {
 		const req = https.request(getImageApiOptions(), res => {
 			let data = ''
 
-			res.on( 'data', (chunk) => {
+			res.on( 'data', chunk => {
 				data += chunk
 			})
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -297,7 +297,15 @@ export async function promptForComponent( component: string, allowLocal: boolean
 		const message = `${ messagePrefix }Which version would you like`;
 		const tagChoices = [];
 		await populateWordPressVersionList( tagChoices );
-		let initialTagIndex = 0;
+
+		// First tag not: "Pre-Release"
+		const firstNonPreRelease = tagChoices.find( tag => {
+			return ! tag.match( /Pre\-Release/g );
+		} );
+
+		// Set initialTagIndex as the first non Pre-Release
+		let initialTagIndex = tagChoices.indexOf( firstNonPreRelease );
+
 		if ( defaultObject?.tag ) {
 			const defaultTagIndex = tagChoices.indexOf( defaultObject.tag );
 			if ( defaultTagIndex !== -1 ) {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -344,6 +344,9 @@ export function addDevEnvConfigurationOptions( command ) {
 		.option( 'media-redirect-domain', 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' );
 }
 
+/**
+ * Makes a web call to raw.githubusercontent.com
+ */
 async function fetchVersionList() {
 	const host = 'raw.githubusercontent.com';
 	const uri = '/Automattic/vip-container-images/master/wordpress/versions.json';
@@ -361,6 +364,7 @@ async function getVersionList() {
 	const cacheKey = 'worpress-versions.json';
 	const cacheFile = path.join( cacheDir, cacheKey );
 
+	// Try to retrieve the file from cache or cache it if invalid
 	try {
 		// If the cache doesn't exist, create it
 		if ( ! fs.existsSync( cacheFile ) ) {
@@ -381,9 +385,8 @@ async function getVersionList() {
 			res = await fetchVersionList();
 			fs.writeFileSync( cacheFile, res );
 		}
-
 	} catch ( err ) {
-		// Use the cache file if it exists
+		// Soft error handling here, since it's still possible to use a previously cached file.
 		console.log( chalk.yellow( 'fetchWordPressVersionList failed to retrieve an updated version list' ) );
 		debug( err );
 	}
@@ -398,6 +401,9 @@ async function getVersionList() {
 	}
 }
 
+/**
+ * Provides the list of tag choices for selection
+ */
 async function getTagChoices() {
 	const tagChoices = [];
 	let tagFormatted, prerelease, mapping;

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -381,14 +381,14 @@ async function getVersionList() {
 			res = await fetchVersionList();
 			fs.writeFileSync( cacheFile, res );
 		}
+
+		// the result is cached
+		return JSON.parse( fs.readFileSync( cacheFile ) );
 	} catch ( err ) {
 		// Use the cache file if it exists
 		console.log( chalk.yellow( 'fetchWordPressVersionList failed to retrieve an updated version list' ) );
 		debug( err );
 	}
-
-	// the result is cached
-	return JSON.parse( fs.readFileSync( cacheFile ) );
 }
 
 async function getTagChoices() {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -397,9 +397,8 @@ async function getVersionList() {
 	try {
 		return JSON.parse( fs.readFileSync( cacheFile ) );
 	} catch ( err ) {
-		console.log( fetchErr );
-		console.log( err );
-		process.exit( 1 );
+		debug( fetchErr );
+		debug( err );
 	}
 }
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -397,7 +397,6 @@ async function getVersionList() {
 	try {
 		return JSON.parse( fs.readFileSync( cacheFile ) );
 	} catch ( err ) {
-		debug( fetchErr );
 		debug( err );
 		return [];
 	}

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -348,7 +348,7 @@ export function addDevEnvConfigurationOptions( command ) {
  * Makes a web call to raw.githubusercontent.com
  */
 async function fetchVersionList() {
-	const host = 'raw.fakegithubusercontent.com';
+	const host = 'raw.githubusercontent.com';
 	const uri = '/Automattic/vip-container-images/master/wordpress/versions.json';
 	return fetch( `https://${ host }${ uri }`, { method: 'GET' } ).then( res => res.text() );
 }
@@ -358,7 +358,7 @@ async function fetchVersionList() {
  */
 async function getVersionList() {
 	let res, fetchErr;
-	const cacheTtl = 1; // number of seconds that the cache can be considered active.
+	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
 	const local = xdgBasedir.data || os.tmpdir();
 	const cacheDir = path.join( local, 'vip' );
 	const cacheKey = 'worpress-versions.json';

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -444,7 +444,7 @@ export async function importMediaPath( slug: string, filePath: string ) {
  * @param  {Object=} options options
  */
 async function updateWordPressImage( instancePath, options ) {
-	let choice, version, tag, res;
+	let choice, version;
 	const versions = await getVersionList();
 	const refRgx = new RegExp( /\d+\.\d+(?:\.\d+)?/ );
 	const vsnRgx = new RegExp( /\$wp_version \= \'(.*)\'\;/ );
@@ -452,13 +452,13 @@ async function updateWordPressImage( instancePath, options ) {
 	const versionFile = `${ instancePath }/${ DEV_ENVIRONMENT_WORDPRESS_VERSION_FILE }`;
 
 	// If versionFile doesn't exist it means that the environment has not been initiated.
-	if ( ! fs.existsSync( versionFile ) )  {
+	if ( ! fs.existsSync( versionFile ) ) {
 		return;
 	}
 
 	// filter
-	const filteredVersions = versions.filter( version => {
-		return refRgx.test( version.ref );
+	const filteredVersions = versions.filter( vsn => {
+		return refRgx.test( vsn.ref );
 	} );
 
 	// sort
@@ -515,7 +515,7 @@ async function updateWordPressImage( instancePath, options ) {
 
 		// Change the lando file and rebuild.
 		const data = fs.readFileSync( landoFile, { encoding: 'utf8', flag: 'r' } );
-		const edit = data.replace( /ghcr\.io\/.*wordpress\:.*\d+\.\d+(?:\.\d+)?/g,  selectedImage );
+		const edit = data.replace( /ghcr\.io\/.*wordpress\:.*\d+\.\d+(?:\.\d+)?/g, selectedImage );
 		fs.writeFileSync( landoFile, edit );
 
 		// Stage for rebuild
@@ -535,6 +535,9 @@ export async function fetchVersionList() {
 
 /**
  * Encapsulates the logic for determining if a file is expired by an arbitrary TTL
+ * @param  {string} cacheFile uri of cache file
+ * @param  {number} ttl time to live in seconds
+ * @returns {boolean} version list expired true/false
  */
 function isVersionListExpired( cacheFile, ttl ) {
 	const stats = fs.statSync( cacheFile );
@@ -562,7 +565,6 @@ export async function getVersionList() {
 
 		// If the cache is expired, refresh it
 		if ( isVersionListExpired( cacheFile, DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL ) ) {
-			debug( `WordPress Version List cache is expired: ${ expire }` );
 			res = await fetchVersionList();
 			fs.writeFileSync( cacheFile, res );
 		}

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -444,7 +444,6 @@ export async function importMediaPath( slug: string, filePath: string ) {
  * @param  {Object=} options options
  */
 async function updateWordPressImage( instancePath, options ) {
-	let choice, version;
 	const versions = await getVersionList();
 	const refRgx = new RegExp( /\d+\.\d+(?:\.\d+)?/ );
 	const vsnRgx = new RegExp( /\$wp_version \= \'(.*)\'\;/ );
@@ -486,14 +485,14 @@ async function updateWordPressImage( instancePath, options ) {
 	}
 
 	// Determine if there is an image available for the current WordPress version
-	version = filteredVersions.find( ( { ref } ) => ref === currentWordPressVersion );
+	const match = filteredVersions.find( ( { ref } ) => ref === currentWordPressVersion );
 
 	// If there is no available image for the currently installed version, give user a path to change
-	if ( typeof version === 'undefined' ) {
+	if ( typeof match === 'undefined' ) {
 		console.log( `Installed WordPress: ${ currentWordPressVersion } has no available container image in repository. ` );
 		console.log( 'You must select a new WordPress image to continue... ' );
 	} else {
-		console.log( 'Environment WordPress version is: ' + chalk.yellow( version.ref ) );
+		console.log( 'Environment WordPress version is: ' + chalk.yellow( match.ref ) );
 	}
 
 	// Prompt the user to select a new WordPress Version
@@ -505,11 +504,11 @@ async function updateWordPressImage( instancePath, options ) {
 
 	// If the user takes the new WP version path
 	if ( confirm.upgrade ) {
-		console.log( 'Upgrading from: ' + chalk.yellow( version.ref ) + ' to:' );
+		console.log( 'Upgrading from: ' + chalk.yellow( match.ref ) + ' to:' );
 
 		// Select a new image
-		choice = await promptForComponent( 'wordpress' );
-		version = filteredVersions.find( ( { tag } ) => tag.trim() === choice.tag.trim() );
+		const choice = await promptForComponent( 'wordpress' );
+		const version = filteredVersions.find( ( { tag } ) => tag.trim() === choice.tag.trim() );
 		const selectedImage = `ghcr.io/automattic/vip-container-images/wordpress:${ version.tag }`;
 
 		// Change the lando file and rebuild.

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -32,7 +32,7 @@ import {
 	DEV_ENVIRONMENT_WORDPRESS_VERSION_FILE,
 	DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL,
 } from '../constants/dev-environment';
-import type { AppInfo, InstanceData } from './types'
+import type { AppInfo, InstanceData } from './types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -8,6 +8,7 @@
  */
 import debugLib from 'debug';
 import xdgBasedir from 'xdg-basedir';
+import fetch from 'node-fetch';
 import os from 'os';
 import fs from 'fs';
 import ejs from 'ejs';
@@ -23,7 +24,12 @@ import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild
 import { searchAndReplace } from '../search-and-replace';
 import { printTable, resolvePath } from './dev-environment-cli';
 import app from '../api/app';
-import { DEV_ENVIRONMENT_NOT_FOUND } from '../constants/dev-environment';
+import {
+	DEV_ENVIRONMENT_NOT_FOUND,
+	DEV_ENVIRONMENT_RAW_GITHUB_HOST,
+	DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI,
+	DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY,
+} from '../constants/dev-environment';
 import type { InstanceData } from './types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -48,6 +54,20 @@ type SQLImportPaths = {
 	inContainerPath: string
 }
 
+/**
+ * Uses the WordPress versions manifest on github.com
+ * Informs the user several things:
+ *   - If the WordPress image their env uses is no longer available
+ *     - A Path to using an image that is available
+ *   - If there is a new WordPress image available
+ *   - If there is a newer version of the WordPress version currently used
+ */
+async function updateWordPressImage( instancePath, options ) {
+	console.log( `instancePath: ${ instancePath }` );
+	console.log( 'options:' );
+	console.log( options );
+}
+
 export async function startEnvironment( slug: string, options: StartEnvironmentOptions ) {
 	debug( 'Will start an environment', slug );
 
@@ -60,6 +80,8 @@ export async function startEnvironment( slug: string, options: StartEnvironmentO
 	if ( ! environmentExists ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
+
+	await updateWordPressImage( instancePath, options );
 
 	if ( options.skipRebuild ) {
 		await landoStart( instancePath );
@@ -411,4 +433,58 @@ export async function importMediaPath( slug: string, filePath: string ) {
 	console.log( `${ chalk.yellow( '-' ) } Started copying files` );
 	copydir.sync( resolvedPath, uploadsPath );
 	console.log( `${ chalk.green( '✓' ) } Files successfully copied to ${ uploadsPath }.` );
+}
+
+/**
+ * Makes a web call to raw.githubusercontent.com
+ */
+export async function fetchVersionList() {
+	const url = `https://${ DEV_ENVIRONMENT_RAW_GITHUB_HOST }${ DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI }`;
+	return fetch( url ).then( res => res.text() );
+}
+
+/**
+ * Uses a cache file to keep the version list in tow until it is ultimately outdated
+ */
+export async function getVersionList() {
+	let res;
+	const mainEnvironmentPath = xdgBasedir.data || os.tmpdir();
+	const cacheTtl = 86400; // number of seconds that the cache can be considered active.
+	const cacheFile = path.join( mainEnvironmentPath, 'vip', DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
+
+	// Try to retrieve the file from cache or cache it if invalid
+	try {
+		// If the cache doesn't exist, create it
+		if ( ! fs.existsSync( cacheFile ) ) {
+			res = await fetchVersionList();
+			fs.writeFileSync( cacheFile, res );
+		}
+
+		// Last modified
+		const stats = fs.statSync( cacheFile );
+		debug( `WordPress Version List cache last modified: ${ stats.mtime }` );
+
+		// If the cache is expired, fetch the list again and cache it
+		const expire = new Date( stats.mtime );
+		expire.setSeconds( expire.getSeconds() + cacheTtl );
+
+		if ( +new Date > expire ) {
+			debug( `WordPress Version List cache is expired: ${ expire }` );
+			res = await fetchVersionList();
+			fs.writeFileSync( cacheFile, res );
+		}
+	} catch ( err ) {
+		// Soft error handling here, since it's still possible to use a previously cached file.
+		console.log( chalk.yellow( 'fetchWordPressVersionList failed to retrieve an updated version list' ) );
+		debug( err );
+	}
+
+	// Try to parse the cached file if it exists
+	// if not, something worse than a failed request happend; bail.
+	try {
+		return JSON.parse( fs.readFileSync( cacheFile ) );
+	} catch ( err ) {
+		debug( err );
+		return [];
+	}
 }

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -491,8 +491,7 @@ async function updateWordPressImage( instancePath, options ) {
 	// If there is no available image for the currently installed version, give user a path to change
 	if ( typeof version === 'undefined' ) {
 		console.log( `Installed WordPress: ${ currentWordPressVersion } has no available container image in repository. ` );
-		console.log( 'Using this environment will not be possible without an edit to the .lando.yml file at: ' );
-		console.log( `    ${ landoFile }` );
+		console.log( 'You must select a new WordPress image to continue... ' );
 	} else {
 		console.log( 'Environment WordPress version is: ' + chalk.yellow( version.ref ) );
 	}


### PR DESCRIPTION
## Description
* On `vip dev-env create` The list of available WordPress Images will be produced dynamically based on a real time call to the images manifest on github.
* Will show a "Pre-Release" tag for images that are pre-release
* The default selection will always be the most recent stable release unless another version was selected.

![Screen Shot 2022-02-03 at 1 17 14 PM](https://user-images.githubusercontent.com/46167019/152422315-f3e978ba-cb67-4e2c-bfc8-8df83bb4102e.png)

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `vip dev-env create`
1. Verify  list of WordPress Images are up to date on the 3rd question of the form.

