### PR TITLE
Corrections of text for -h menu in dev-env create

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -30,11 +30,11 @@ const examples = [
 	},
 	{
 		usage: `vip @123.production ${ DEV_ENVIRONMENT_SUBCOMMAND } create`,
-		description: 'Creates a local dev environment for prodaction site for id 123',
+		description: 'Creates a local dev environment for production site for id 123',
 	},
 	{
-		usage: `vip @123.production ${ DEV_ENVIRONMENT_SUBCOMMAND } create --slug=my_site`,
-		description: 'Creates a local dev environment for prodaction site for id 123 aliased as "my_site"',
+		usage: `vip ${ DEV_ENVIRONMENT_SUBCOMMAND } create --slug=my_site`,
+		description: 'Creates a local dev environment aliased as "my_site"',
 	},
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --slug=test`,

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -38,7 +38,7 @@ const examples = [
 	},
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --slug=test`,
-		description: 'Creates a blank local dev environment with custom name "test", this enables to create multiple independent environments',
+		description: 'Assigning unique slugs to environments allows multiple environments to be created.',
 	},
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress="5.8" --client-code="~/git/my_code"`,

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -33,15 +33,15 @@ const examples = [
 		description: 'Creates a local dev environment for prodaction site for id 123',
 	},
 	{
-		usage: `vip @123.production ${ DEV_ENVIRONMENT_SUBCOMMAND } create --slug 'my_site'`,
+		usage: `vip @123.production ${ DEV_ENVIRONMENT_SUBCOMMAND } create --slug=my_site`,
 		description: 'Creates a local dev environment for prodaction site for id 123 aliased as "my_site"',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --slug test`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --slug=test`,
 		description: 'Creates a blank local dev environment with custom name "test", this enables to create multiple independent environments',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress "5.8" --client-code "~/git/my_code"`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress="5.8" --client-code="~/git/my_code"`,
 		description: 'Creates a local multisite dev environment using WP 5.8 and client code is expected to be in "~/git/my_code"',
 	},
 ];

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -28,7 +28,7 @@ const examples = [
 		description: 'Destroys the default local dev environment',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } destroy --slug foo`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } destroy --slug=foo`,
 		description: 'Destroys a local dev environment named foo',
 	},
 ];

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -23,7 +23,7 @@ const examples = [
 		description: 'Import contents of the given WP uploads folder file into the media library of the default dev environment',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import media path/to/wp-content/uploads --slug mysite`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import media path/to/wp-content/uploads --slug=mysite`,
 		description: 'Import contents of the given WP uploads folder file into the media library of a dev environment named `mysite`',
 	},
 ];

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -26,7 +26,7 @@ const examples = [
 		description: 'Import the contents of a WordPress database from an SQL file',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import sql wordpress.sql --slug my_site`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } import sql wordpress.sql --slug=my_site`,
 		description: 'Import the contents of a WordPress database from an SQL file into `my_site`',
 	},
 	{

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -22,7 +22,7 @@ const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 const examples = [
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info -all`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info --all`,
 		description: 'Return information about all local dev environments',
 	},
 	{
@@ -30,7 +30,7 @@ const examples = [
 		description: 'Return information about dev environment for site 123',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info -slug my_site`,
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info --slug=my_site`,
 		description: 'Return information about a local dev environment named "my_site"',
 	},
 ];


### PR DESCRIPTION
## Description

Makes a few corrections in the examples that are given when the user uses the command `vip dev-env create -h`

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `vip dev-env create -h`
1. Verify the text changes are satisfactory.

