### PR TITLE
[dev-env] prompt On Unselected Env

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -7,6 +7,7 @@
  */
 import xdgBasedir from 'xdg-basedir';
 import fs from 'fs';
+import enquirer from 'enquirer';
 import os from 'os';
 import path from 'path';
 
@@ -27,6 +28,7 @@ import { DEV_ENVIRONMENT_NOT_FOUND } from '../../../src/lib/constants/dev-enviro
 
 jest.mock( 'xdg-basedir', () => ( {} ) );
 jest.mock( 'fs' );
+jest.mock( 'enquirer' );
 jest.mock( '../../../src/lib/api/app' );
 jest.mock( '../../../src/lib/search-and-replace' );
 jest.mock( '../../../src/lib/dev-environment/dev-environment-cli' );
@@ -233,6 +235,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			},
 		] )( 'should parse query result %p', async input => {
 			app.mockResolvedValue( input.response );
+
+			enquirer.prompt = jest.fn().mockResolvedValue( { env: '' } );
 
 			const result = await getApplicationInformation( input.appId, input.envType );
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -325,6 +325,16 @@ export async function getApplicationInformation( appId: number, envType: string 
 			envData = environments.find( candidateEnv => candidateEnv.type === envType );
 		} else if ( 1 === environments.length ) {
 			envData = environments[ 0 ];
+		} else {
+			const choices = environments.map( candidateEnv => candidateEnv.type );
+
+			const { env } = await prompt( {
+				type: 'select',
+				name: 'env',
+				message: 'Which environment?',
+				choices,
+			} );
+			envData = environments.find( candidateEnv => candidateEnv.type === env );
 		}
 
 		if ( envData ) {


### PR DESCRIPTION

## Description

If on dev-env users provides only app id `@123` but not the env we used to ignore env settings.

This change prompts user to choose from existing envs


## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build && ./dist/bin/vip-dev-env-create.js @123`
