### PR TITLE
Fix/duplicate shortcut parameter

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -331,7 +331,7 @@ export function addDevEnvConfigurationOptions( command ) {
 		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 		.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use' )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
-		.option( 'media-redirect-domain', 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' );
+		.option( [ 'm', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' );
 }
 
 function getWordpressImageTags(): string[] {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -331,7 +331,7 @@ export function addDevEnvConfigurationOptions( command ) {
 		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 		.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use' )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
-		.option( [ 'm', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' );
+		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' );
 }
 
 function getWordpressImageTags(): string[] {


### PR DESCRIPTION
## Description

`vip dev-env create -h` has two occurrences of suggesting the parameters `-M`

```
Usage: vip dev-env-create [options]

  Options:
    -c, --client-code            Use the client code from a local directory or VIP skeleton
    -e, --elasticsearch          Explicitly choose Elasticsearch version to use
    -h, --help                   Output the help for the (sub)command
    -M, --mariadb                Explicitly choose MariaDB version to use
    -M, --media-redirect-domain  Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.
```
This commit will change the second `-M` to be `-r` instead:

![Screen Shot 2022-02-17 at 11 42 37 AM](https://user-images.githubusercontent.com/46167019/154549282-e24fbbb2-5ecc-4f57-9464-e7d9b21c4bfe.png)

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `vip dev-env create -h`
1. Look at the usage options to confirm that there are not 2x`-M`.

