### PR TITLE
[dev-env] Added phpmyadmin proxy value

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -7,6 +7,8 @@ proxy:
 <% if ( multisite ) { %>
     - '*.<%= siteSlug %>.vipdev.lndo.site'
 <% } %>
+  phpmyadmin:
+    - <%= siteSlug %>-pma.vipdev.lndo.site
 services:
 
   devtools:


### PR DESCRIPTION
Adding a Proxy URL to access phpmyadmin.

This has been brought up as an issue where the client wants a permanent location for PMA, instead of having to change based on each new port used after stopping/starting local environment.

[Slack here.]( https://a8c.slack.com/archives/C020ESLSWAU/p1644489770373759?thread_ts=1644446771.522799&cid=C020ESLSWAU) 
