### PR TITLE
fix problem where option input is not tag

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -324,7 +324,18 @@ export async function promptForComponent( component: string, allowLocal: boolean
 			choices: tagChoices,
 			initial: initialTagIndex,
 		} );
-		const tag = await selectTag.run();
+		const option = await selectTag.run();
+
+		// Validate the input
+		// Some of the options are like: '5.7   →  5.7.5'
+		// Extract first occurrence of something that looks like a tag
+		const tagRgx = new RegExp( /(\d+\.\d+(?:\.\d+)?)/ );
+		const match = tagRgx.exec( option );
+		if ( match.length < 2 ) {
+			throw new Error( `Invalid WordPress Selection: ${ option }` );
+		}
+
+		const tag = match[ 1 ];
 
 		return {
 			mode: modeResult,


### PR DESCRIPTION
## Description

When the user selects an option for which WordPress version, to use in a new environment, if they select one of the stapled images, it tries to use that entire text as the option for the image, so the .lando.yml file looks like this:

```yml
  wordpress:
    type: compose
    services:
      image: ghcr.io/automattic/vip-container-images/wordpress:5.7   →  5.7.5
      command: sh -c "rsync -a /wp/ /shared/; chown www-data -R /shared; sleep infinity"
      volumes:
        - ./wordpress:/shared
        - type: volume
          source: scripts
          target: /scripts
          volume:
            nocopy: true
```

And that obviously will not work :-)

This change extracts the actual image tag from that string, and it throws a fatal error if it cannot.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-dev-env-create.js --slug=test`
1. Select WordPress Version:5.7   →  5.7.5
1. Finish the create sequence.
1. Run `./dist/bin/vip-dev-env-start.js --slug=test`
1. Verify the WordPress 5.7 image gets pulled successfully.

