### PR TITLE
Adding webP to the list of accepted extensions for files

### DIFF
--- a/src/lib/vip-import-validate-files.js
+++ b/src/lib/vip-import-validate-files.js
@@ -69,6 +69,7 @@ export const acceptedExtensions = [
 	'onetoc', ' onetoc2', 'onetmp', 'onepkg', 'oxps',
 	'xps',
 	'odt', 'odp', 'ods', 'odg', 'odc', 'odb', 'odf',
+	'webp',
 	'wp', 'wpd',
 	'key', 'numbers', 'pages',
 ];


### PR DESCRIPTION
## Description

This is meant to add in support for webP files against which the import validator is run. As per [our docs](https://docs.wpvip.com/technical-references/vip-go-files-system/supported-file-types/), it should be a supported format.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Acquire a webP file from [here](https://developers.google.com/speed/webp/gallery1), along with some other extensions and put in a folder in the format of `uploads/YYYY`  
4. Run `node ./dist/bin/vip import validate-files uploads`
5. Verify that no errors related to the file extension of webP are thrown

