### PR TITLE
[dev-env] Add check for wp folder map

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -41,7 +41,7 @@ services:
       command: run.sh
       working_dir: /wp
       healthcheck:
-        test: 'cat /wp/wp-settings.php'
+        test: 'cat /wp/wp-includes/pomo/mo.php'
       environment:
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
         STATSD: <%= statsd ? 'enable' : 'disable' %>

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -40,6 +40,8 @@ services:
       image: ghcr.io/automattic/vip-container-images/php-fpm:7.4
       command: run.sh
       working_dir: /wp
+      healthcheck:
+        test: 'cat /wp/wp-settings.php'
       environment:
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
         STATSD: <%= statsd ? 'enable' : 'disable' %>


### PR DESCRIPTION
## Description

We have had a long running and hard to reproduce issue that results in the following error:
```
Warning: require(/wp/wp-includes/pomo/mo.php): failed to open stream: No such file or directory in /wp/wp-settings.php on line 116 [$ /usr/local/bin/wp option get siteurl] [wp-settings.php:116 require(''), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1271 require('wp-settings.php'), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1192 WP_CLI\Runner-&gt;load_wordpress(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23 WP_CLI\Runner-&gt;start(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/bootstrap.php:77 WP_CLI\Bootstrap\LaunchRunner-&gt;process(), phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php:27 WP_CLI\bootstrap(), phar:///usr/local/binphp/boot-phar.php:11 include('phar:///usr/local/binvendor/wp-cli/wp-cli/php/wp-cli.php'), /usr/local/bin/wp:4 include('phar:///usr/local/binphp/boot-phar.php')]
```

We were not able to pinpoint the root cause at it seems to happen randomly and not very often. My suspicion is that the `rsync` from WordPress image isn't done by the time we run the initial setup - https://github.com/Automattic/vip/blob/e23e04a3d9f2e08b10c9c96b68124aa395838811/assets/dev-env.lando.template.yml.ejs#L129

In this PR we added a healthcheck on `php` container, which is the target of the mount. This healthcheck verifies that there is `/wp/wp-settings.php` file already mounted. If the above is the root cause of the issue this should force initial setup to not start until `wp` files are rsynced and correctly mounted.

## Steps to Test

Impossible...:)

1) create new env
2) start it 
3) See: 
```
Waiting for service database ...
Waiting for service php ...
Waiting for service vip-search ...
```
4) It should start up eventually
