### PR TITLE
Adds optional channing since `progress` can be null as per GraphQL schema

### DIFF
--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -282,7 +282,7 @@ ${ maybeExitPrompt }
 					return resolve( 'No import job found' );
 				}
 
-				jobStatus = importJob.progress?.status ?? 'unkown';
+				jobStatus = importJob.progress?.status ?? 'unknown';
 				jobSteps = importJob.progress?.steps ?? [];
 				createdAt = importJob.createdAt;
 				completedAt = importJob.completedAt;

--- a/src/lib/site-import/status.js
+++ b/src/lib/site-import/status.js
@@ -282,8 +282,8 @@ ${ maybeExitPrompt }
 					return resolve( 'No import job found' );
 				}
 
-				jobStatus = importJob.progress.status;
-				jobSteps = importJob.progress.steps;
+				jobStatus = importJob.progress?.status ?? 'unkown';
+				jobSteps = importJob.progress?.steps ?? [];
 				createdAt = importJob.createdAt;
 				completedAt = importJob.completedAt;
 


### PR DESCRIPTION
## Description

As per the GraphQL schema, the `Job.progress` field is not guaranteed to be defined. This PR adds optional chaining to prevent issues in case that comes as `null` or `undefined`.

## Steps to Test - TODO

1. Check out PR.
2. Run `npm run build`
3. Trigger a SQL import
4. Run `./dist/bin/vip-import-sql-status.js @3800.production`
5. Verify it reports the status correctly.

