### PR TITLE
Add --debug flag to all commands

### DIFF
--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -25,6 +25,7 @@ import pager from 'lib/cli/pager';
 import { parseEnvAliasFromArgv } from './envAlias';
 import { rollbar } from '../rollbar';
 import * as exit from './exit';
+import debugLib from 'debug';
 
 function uncaughtError( err ) {
 	// Error raised when trying to write to an already closed stream
@@ -57,7 +58,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 	//   Usage: vip command subcommand <arg1> <arg2> [options]
 	const name = _opts.usage || null;
 
-	const options = this.parse( parsedAlias.argv, { help: false, name, version: false } );
+	const options = this.parse( parsedAlias.argv, { help: false, name, version: false, debug: false } );
 
 	if ( options.h || options.help ) {
 		this.showHelp();
@@ -65,6 +66,10 @@ args.argv = async function( argv, cb ): Promise<any> {
 
 	if ( options.v || options.version ) {
 		this.showVersion();
+	}
+
+	if ( options.debug ) {
+	  debugLib.enable(options.debug === true ? '*' : options.debug );
 	}
 
 	// If we have both an --app/--env and an alias, we need to give a warning
@@ -98,6 +103,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		switch ( command.usage ) {
 			case 'help':
 			case 'version':
+		  	case 'debug':
 				return false;
 
 			default:
@@ -522,6 +528,7 @@ export default function( opts: any ): args {
 	// Add help and version to all subcommands
 	args.option( 'help', 'Output the help for the (sub)command' );
 	args.option( 'version', 'Output the version number' );
+  	args.option( 'debug', 'Activate debug output' );
 
 	return args;
 }

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -68,8 +68,8 @@ args.argv = async function( argv, cb ): Promise<any> {
 		this.showVersion();
 	}
 
-	if ( options.debug ) {
-	  debugLib.enable(options.debug === true ? '*' : options.debug );
+	if ( options.debug || options.d ) {
+		debugLib.enable( options.debug === true ? '*' : options.debug );
 	}
 
 	// If we have both an --app/--env and an alias, we need to give a warning
@@ -103,7 +103,7 @@ args.argv = async function( argv, cb ): Promise<any> {
 		switch ( command.usage ) {
 			case 'help':
 			case 'version':
-		  	case 'debug':
+			case 'debug':
 				return false;
 
 			default:
@@ -528,7 +528,7 @@ export default function( opts: any ): args {
 	// Add help and version to all subcommands
 	args.option( 'help', 'Output the help for the (sub)command' );
 	args.option( 'version', 'Output the version number' );
-  	args.option( 'debug', 'Activate debug output' );
+	args.option( 'debug', 'Activate debug output' );
 
 	return args;
 }


### PR DESCRIPTION
## Description

This PR adds a `--debug` flag to all commands, in order to simplify turning on debug output. There are other options to turn on debug, but it's done differently on Mac/Linux and Windows machine, thus we want to introduce this flag.

NOTE: When we use `DEBUG=* vip app list` debug output is enabled since the very start of code execution, while the newly introduced flag enables it in the command module. For this reason, in some edge cases we might still have to ask customers to run commands using `DEBUG=*`.

## Steps to Test

1. Check out PR.
2. Build the new version
3. Run any VIP command with debug option and test different combinations:
- `vip app list -d`: should show all debug output 
- `vip app list --debug`: same as above
- `vip app list -d="@automattic/*"`: should show only @automattic/* debug output

