### PR TITLE
Fix in caching version list.

### DIFF
--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -19,5 +19,7 @@ export const DEV_ENVIRONMENT_RAW_GITHUB_HOST = 'raw.githubusercontent.com';
 
 export const DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI = '/Automattic/vip-container-images/master/wordpress/versions.json';
 
-export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'worpress-versions.json';
+export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
+
+export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 60;
 

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -21,5 +21,5 @@ export const DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI = '/Automattic/vip-container
 
 export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 
-export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 60;
+export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 


### PR DESCRIPTION
## Description
  * TTL was undefined because errantly imported from dev-environment constants
  * fixed typo in cache file

## Steps to Test

Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-dev-env-create.js --slug="newnew"`
1. Verify cache file is being refreshed every 60 seconds: `/Users/username/.local/share/vip/wordpress-versions.json`

