### PR TITLE
Add debug call to dev-envs handleCLIException

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -44,6 +44,7 @@ export function handleCLIException( exception: Error ) {
 		// if the message has already ERROR prefix we should drop it as we are adding our own cool red Error-prefix
 		message = message.replace( 'ERROR: ', '' );
 
+		debug( exception );
 		console.log( errorPrefix, message );
 	}
 }

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -44,8 +44,15 @@ export function handleCLIException( exception: Error ) {
 		// if the message has already ERROR prefix we should drop it as we are adding our own cool red Error-prefix
 		message = message.replace( 'ERROR: ', '' );
 
-		debug( exception );
 		console.log( errorPrefix, message );
+
+		if ( ! process.env.DEBUG ) {
+			console.log( 'Please re-run the command with "' + chalk.bold( "DEBUG=@automattic/vip:bin:dev-environment" ) + '" prepended to it and provide the stack trace on the support ticket.' );
+			console.log( chalk.bold( '\nExample:\n' ) );
+			console.log( 'DEBUG=@automattic/vip:bin:dev-environment vip dev-env create\n' );
+		}
+
+		debug( exception );
 	}
 }
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -47,7 +47,7 @@ export function handleCLIException( exception: Error ) {
 		console.log( errorPrefix, message );
 
 		if ( ! process.env.DEBUG ) {
-			console.log( 'Please re-run the command with "' + chalk.bold( "DEBUG=@automattic/vip:bin:dev-environment" ) + '" prepended to it and provide the stack trace on the support ticket.' );
+			console.log( `Please re-run the command with "${ chalk.bold( 'DEBUG=@automattic/vip:bin:dev-environment' ) }" prepended to it and provide the stack trace on the support ticket.` );
 			console.log( chalk.bold( '\nExample:\n' ) );
 			console.log( 'DEBUG=@automattic/vip:bin:dev-environment vip dev-env create\n' );
 		}


### PR DESCRIPTION
## Description

Currently in dev-env's exception handler, we're not providing any good means to debug, this PR aims to address that by adding a `debug` call as well as providing the user with instructions.

When an exception happens and the DEBUG is not set it'll provide with the following prompt:

```
Please re-run the command with "DEBUG=@automattic/vip:bin:dev-environment" prepended to it and provide the stack trace on the support ticket.

Example:

DEBUG=@automattic/vip:bin:dev-environment vip dev-env create
```

If the DEBUG is passed correctly it'll just show the stack trace:

```
  @automattic/vip:bin:dev-environment Error: Environment not found.
  @automattic/vip:bin:dev-environment     at stopEnvironment (/Users/rinat/projects/vip-go-platform-stack/vip/dist/lib/dev-environment/dev-environment-core.js:110:11)
  @automattic/vip:bin:dev-environment     at /Users/rinat/projects/vip-go-platform-stack/vip/dist/bin/vip-dev-env-stop.js:40:51
  @automattic/vip:bin:dev-environment     at Args._args.default.argv (/Users/rinat/projects/vip-go-platform-stack/vip/dist/lib/cli/command.js:500:17)
  @automattic/vip:bin:dev-environment     at Object.<anonymous> (/Users/rinat/projects/vip-go-platform-stack/vip/dist/bin/vip-dev-env-stop.js:35:97)
  @automattic/vip:bin:dev-environment     at Module._compile (internal/modules/cjs/loader.js:1085:14)
```

## Testing 

It's a bit tricky to trigger an exception except the case of not existing environment, so the quickest way to test would be to move the block under the else condition, this way the Not found exception would result in the error.

E.g.

```
 DEBUG=@automattic/vip:bin:dev-environment vip dev-env stop --slug 1337-site
```