### PR TITLE
dev-env start errantly claims my WordPress version is not up to date.

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -127,7 +127,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 	describe( 'processComponentOptionInput', () => {
 		it.each( [
 			{ // base tag
-				param: testReleaseWP,
+				param: testReleaseTag,
 				allowLocal: true,
 				expected: {
 					mode: 'image',
@@ -210,10 +210,10 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 		it.each( [
 			{
-				tag: testReleaseWP,
+				tag: testReleaseTag,
 				expected: {
 					mode: 'image',
-					tag: testReleaseWP,
+					tag: testReleaseTag,
 				},
 			},
 		] )( 'should return correct component for wordpress %p', async input => {
@@ -272,7 +272,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 					multisite: true,
 				},
 				default: {
@@ -281,7 +281,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 					multisite: false,
 				},
 				default: {
@@ -290,7 +290,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 				},
 				default: {
 					multisite: true,
@@ -299,7 +299,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 				},
 				default: {
 					multisite: false,
@@ -326,7 +326,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 					title: 'a',
 					multisite: true,
 					mediaRedirectDomain: 'a',
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 				},
 				default: {
 					mediaRedirectDomain: 'b',
@@ -336,7 +336,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				preselected: {
 					title: 'a',
 					multisite: true,
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 				},
 				default: {
 					mediaRedirectDomain: 'b',
@@ -362,7 +362,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 					mariadb: 'maria_a',
 					elasticsearch: 'elastic_a',
 				},
@@ -372,7 +372,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					title: 'a',
-					wordpress: testReleaseWP,
+					wordpress: testReleaseTag,
 				},
 				default: {
 					mariadb: 'maria_b',
@@ -393,38 +393,38 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				service: 'statsd',
 				preselected: true,
 				expected: true,
-				wordpress: testReleaseWP,
+				wordpress: testReleaseTag,
 			},
 			{
 				service: 'statsd',
 				expected: false,
-				wordpress: testReleaseWP,
+				wordpress: testReleaseTag,
 			},
 			{
 				service: 'statsd',
 				default: true,
 				expected: true,
-				wordpress: testReleaseWP,
+				wordpress: testReleaseTag,
 			},
 			{
 				service: 'statsd',
 				preselected: false,
 				default: true,
 				expected: false,
-				wordpress: testReleaseWP,
+				wordpress: testReleaseTag,
 			},
 			{
 				service: 'phpmyadmin',
 				preselected: true,
 				default: true,
 				expected: true,
-				wordpress: testReleaseWP,
+				wordpress: testReleaseTag,
 			},
 			{
 				service: 'xdebug',
 				default: true,
 				expected: true,
-				wordpress: testReleaseWP,
+				wordpress: testReleaseTag,
 			},
 		] )( 'should handle auxiliary services', async input => {
 			const preselected = {};

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -34,18 +34,12 @@ jest.mock( 'enquirer', () => {
 } );
 
 const testReleaseTag = '5.9';
-const testReleaseRef = '5.9.2';
+const testReleaseRef = '5.9';
 
 const scope = nock( 'https://raw.githubusercontent.com' )
 	.get( '/Automattic/vip-container-images/master/wordpress/versions.json' )
 	.reply( 200, [ {
-		ref: '5.9.1',
-		tag: '5.9.1',
-		cacheable: true,
-		locked: false,
-		prerelease: true,
-	}, {
-		ref: '5.9.2',
+		ref: '5.9',
 		tag: '5.9',
 		cacheable: true,
 		locked: false,
@@ -132,7 +126,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				expected: {
 					mode: 'image',
 					tag: testReleaseTag,
-					ref: testReleaseRef,
 				},
 			},
 			{ // if local is not allowed
@@ -213,6 +206,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				tag: testReleaseTag,
 				expected: {
 					mode: 'image',
+					ref: testReleaseRef,
 					tag: testReleaseTag,
 				},
 			},

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -33,7 +33,8 @@ jest.mock( 'enquirer', () => {
 	};
 } );
 
-const testReleaseWP = '5.9';
+const testReleaseTag = '5.9';
+const testReleaseRef = '5.9.2';
 
 const scope = nock( 'https://raw.githubusercontent.com' )
 	.get( '/Automattic/vip-container-images/master/wordpress/versions.json' )
@@ -130,7 +131,8 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				allowLocal: true,
 				expected: {
 					mode: 'image',
-					tag: testReleaseWP,
+					tag: testReleaseTag,
+					tag: testReleaseRef
 				},
 			},
 			{ // if local is not allowed

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -132,7 +132,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				expected: {
 					mode: 'image',
 					tag: testReleaseTag,
-					tag: testReleaseRef
+					ref: testReleaseRef,
 				},
 			},
 			{ // if local is not allowed

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -39,13 +39,13 @@ const testReleaseRef = '5.9.2';
 const scope = nock( 'https://raw.githubusercontent.com' )
 	.get( '/Automattic/vip-container-images/master/wordpress/versions.json' )
 	.reply( 200, [ {
-		ref: '3ae9f9ffe311e546b0fd5f82d456b3539e3b8e74',
+		ref: '5.9.1',
 		tag: '5.9.1',
 		cacheable: true,
 		locked: false,
 		prerelease: true,
 	}, {
-		ref: '5.9',
+		ref: '5.9.2',
 		tag: '5.9',
 		cacheable: true,
 		locked: false,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -333,6 +333,7 @@ export async function promptForComponent( component: string, allowLocal: boolean
 				initialTagIndex = defaultTagIndex;
 			}
 		}
+
 		const selectTag = new Select( {
 			message,
 			choices: formatted,
@@ -343,17 +344,24 @@ export async function promptForComponent( component: string, allowLocal: boolean
 		// Validate the input
 		// Some of the options are like: '5.7   →  5.7.5'
 		// Extract first occurrence of something that looks like a tag
-		const tagRgx = new RegExp( /(\d+\.\d+(?:\.\d+)?)/ );
-		const match = tagRgx.exec( option );
-		if ( ! Array.isArray( match ) || match.length < 2 ) {
+		const tagRgx = new RegExp( /^(\d+\.\d+(?:\.\d+)?)/ );
+		const refRgx = new RegExp( /(\d+\.\d+(?:\.\d+)?)$/ );
+		const tagMatch = tagRgx.exec( option );
+		const refMatch = refRgx.exec( option );
+		if ( ! Array.isArray( tagMatch ) || tagMatch.length < 2 ) {
 			throw new Error( `Invalid WordPress selection: ${ option }` );
 		}
+		const tag = tagMatch[ 1 ];
+		let ref = tag;
 
-		const tag = match[ 1 ];
+		if ( refMatch ) {
+			ref = refMatch[ 1 ];
+		}
 
 		return {
 			mode: modeResult,
 			tag,
+			ref,
 		};
 	}
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -445,11 +445,12 @@ export async function importMediaPath( slug: string, filePath: string ) {
 async function updateWordPressImage( slug ) {
 	const versions = await getVersionList();
 	const refRgx = new RegExp( /\d+\.\d+(?:\.\d+)?/ );
-	let message, envData, currentWordPressTag;
+	let message, envData, currentWordPressTag, currentWordPressRef;
 
 	// Get the current environment configuration
 	try {
 		envData = readEnvironmentData( slug );
+		currentWordPressRef = envData.wordpress.ref;
 		currentWordPressTag = envData.wordpress.tag;
 	} catch ( error ) {
 		// This can throw an exception if the env is build with older vip version
@@ -472,20 +473,20 @@ async function updateWordPressImage( slug ) {
 
 	// Newest WordPress Image
 	const newestWordPressImage = filteredVersions[ 0 ];
-	console.log( 'The most recent WordPress version available is: ' + chalk.green( newestWordPressImage.tag ) );
+	console.log( 'The most recent WordPress version available is: ' + chalk.green( newestWordPressImage.ref ) );
 
 	// If the currently used version is the most up to date: exit.
-	if ( currentWordPressTag === newestWordPressImage.ref ) {
-		console.log( 'Environment WordPress version is: ' + chalk.green( currentWordPressTag ) + '  ... 😎 nice! ' );
+	if ( currentWordPressRef === newestWordPressImage.ref ) {
+		console.log( 'Environment WordPress version is: ' + chalk.green( currentWordPressRef ) + '  ... 😎 nice! ' );
 		return false;
 	}
 
 	// Determine if there is an image available for the current WordPress version
-	const match = filteredVersions.find( ( { ref } ) => ref === currentWordPressTag );
+	const match = filteredVersions.find( ( { ref } ) => ref === currentWordPressRef );
 
 	// If there is no available image for the currently installed version, give user a path to change
 	if ( typeof match === 'undefined' ) {
-		console.log( `Installed WordPress: ${ currentWordPressTag } has no available container image in repository. ` );
+		console.log( `Installed WordPress: ${ currentWordPressRef } has no available container image in repository. ` );
 		console.log( 'You must select a new WordPress image to continue... ' );
 	} else {
 		console.log( 'Environment WordPress version is: ' + chalk.yellow( match.ref ) );
@@ -508,6 +509,7 @@ async function updateWordPressImage( slug ) {
 
 		// Write new data and stage for rebuild
 		envData.wordpress.tag = version.tag;
+		envData.wordpress.ref = version.ref;
 		await updateEnvironment( envData );
 
 		return true;

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -445,13 +445,11 @@ export async function importMediaPath( slug: string, filePath: string ) {
 async function updateWordPressImage( slug ) {
 	const versions = await getVersionList();
 	const refRgx = new RegExp( /\d+\.\d+(?:\.\d+)?/ );
-	let message, envData, currentWordPressTag, currentWordPressRef;
+	let message, envData;
 
 	// Get the current environment configuration
 	try {
 		envData = readEnvironmentData( slug );
-		currentWordPressRef = envData.wordpress.ref;
-		currentWordPressTag = envData.wordpress.tag;
 	} catch ( error ) {
 		// This can throw an exception if the env is build with older vip version
 		if ( 'ENOENT' === error.code ) {
@@ -476,17 +474,17 @@ async function updateWordPressImage( slug ) {
 	console.log( 'The most recent WordPress version available is: ' + chalk.green( newestWordPressImage.ref ) );
 
 	// If the currently used version is the most up to date: exit.
-	if ( currentWordPressRef === newestWordPressImage.ref ) {
-		console.log( 'Environment WordPress version is: ' + chalk.green( currentWordPressRef ) + '  ... 😎 nice! ' );
+	if ( envData.wordpress.ref === newestWordPressImage.ref ) {
+		console.log( 'Environment WordPress version is: ' + chalk.green( envData.wordpress.ref ) + '  ... 😎 nice! ' );
 		return false;
 	}
 
 	// Determine if there is an image available for the current WordPress version
-	const match = filteredVersions.find( ( { ref } ) => ref === currentWordPressRef );
+	const match = filteredVersions.find( ( { ref } ) => ref === envData.wordpress.ref );
 
 	// If there is no available image for the currently installed version, give user a path to change
 	if ( typeof match === 'undefined' ) {
-		console.log( `Installed WordPress: ${ currentWordPressRef } has no available container image in repository. ` );
+		console.log( `Installed WordPress: ${ envData.wordpress.ref } has no available container image in repository. ` );
 		console.log( 'You must select a new WordPress image to continue... ' );
 	} else {
 		console.log( 'Environment WordPress version is: ' + chalk.yellow( match.ref ) );
@@ -500,8 +498,8 @@ async function updateWordPressImage( slug ) {
 	} );
 
 	// If the user takes the new WP version path
-	if ( confirm.upgrade ) {
-		console.log( 'Upgrading from: ' + chalk.yellow( currentWordPressTag ) + ' to:' );
+	if ( confirm.hasOwnProperty( 'upgrade' ) && confirm.upgrade ) {
+		console.log( 'Upgrading from: ' + chalk.yellow( envData.wordpress.ref ) + ' to:' );
 
 		// Select a new image
 		const choice = await promptForComponent( 'wordpress' );


### PR DESCRIPTION
## Description

Fixed problem in dev-env start where the command would not recognize the correct wordpress version.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-dev-env-start.js --slug=test`
1. Verify WordPress version is observed as intended.

