### PR TITLE
Fix reconnect event listeners

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -62,7 +62,7 @@ const bindStreamEvents = ( { subShellRl, commonTrackingParams, isSubShell, stdou
 		commandRunning = false;
 
 		// TODO handle this better
-		console.log( 'Error: ' + err.message );
+		console.error( 'Error: ' + err.message );
 	} );
 
 	stdoutStream.on( 'end', async () => {
@@ -354,7 +354,7 @@ commandWrapper( {
 
 			bindStreamEvents( { subShellRl, commonTrackingParams, isSubShell, stdoutStream: currentJob.stdoutStream } );
 
-			currentJob.socket.on( 'reconnect', async () => {
+			currentJob.socket.io.on( 'reconnect', async () => {
 				// Close old streams
 				unpipeStreamsFromProcess( { stdin: currentJob.stdinStream, stdout: currentJob.stdoutStream } );
 
@@ -375,7 +375,7 @@ commandWrapper( {
 				subShellRl.resume();
 			} );
 
-			currentJob.socket.on( 'reconnect_attempt', () => {
+			currentJob.socket.io.on( 'reconnect_attempt', () => {
 				// create a new input stream so that we can still catch things like SIGINT while reconnectin
 				if ( currentJob.stdinStream ) {
 					process.stdin.unpipe( currentJob.stdinStream );


### PR DESCRIPTION
## Description

Since version 3, `socket.io-client` no longer forwards the events of its manager. So, the reconnect events need to be listened directly from the manager.

https://github.com/socketio/socket.io-client/blob/master/CHANGELOG.md#300-2020-11-05

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Run `./dist/bin/vip-wp long-running-command`
4. Deploy the public API while the above command is still running.
6. The command should resume after the public API is deployed.