### PR TITLE
dev-env: updateWordPress image improvements

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -47,9 +47,9 @@ export function handleCLIException( exception: Error ) {
 		console.log( errorPrefix, message );
 
 		if ( ! process.env.DEBUG ) {
-			console.log( `Please re-run the command with "${ chalk.bold( 'DEBUG=@automattic/vip:bin:dev-environment' ) }" prepended to it and provide the stack trace on the support ticket.` );
+			console.log( `Please re-run the command with "--debug ${ chalk.bold( '@automattic/vip:bin:dev-environment' ) }" appended to it and provide the stack trace on the support ticket.` );
 			console.log( chalk.bold( '\nExample:\n' ) );
-			console.log( 'DEBUG=@automattic/vip:bin:dev-environment vip dev-env create\n' );
+			console.log( 'DEBUG=@automattic/vip:bin:dev-environment vip dev-env create --debug @automattic/vip:bin:dev-environment \n' );
 		}
 
 		debug( exception );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -49,7 +49,7 @@ export function handleCLIException( exception: Error ) {
 		if ( ! process.env.DEBUG ) {
 			console.log( `Please re-run the command with "--debug ${ chalk.bold( '@automattic/vip:bin:dev-environment' ) }" appended to it and provide the stack trace on the support ticket.` );
 			console.log( chalk.bold( '\nExample:\n' ) );
-			console.log( 'DEBUG=@automattic/vip:bin:dev-environment vip dev-env create --debug @automattic/vip:bin:dev-environment \n' );
+			console.log( 'vip dev-env create --debug @automattic/vip:bin:dev-environment \n' );
 		}
 
 		debug( exception );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -8,7 +8,7 @@
  */
 import chalk from 'chalk';
 import formatters from 'lando/lib/formatters';
-import { prompt, Confirm, Select, Choice } from 'enquirer';
+import { prompt, Confirm, Select } from 'enquirer';
 import debugLib from 'debug';
 import fs from 'fs';
 import path from 'path';
@@ -352,7 +352,7 @@ export async function getTagChoices() {
 		return [ '5.9', '5.8', '5.7', '5.6', '5.5' ];
 	}
 
-	const choices = versions.map( ( version ) => {
+	const choices = versions.map( version => {
 		let mapping;
 		const tagFormatted = version.tag.padEnd( 8 - version.tag.length );
 		const prerelease = version.prerelease ? '(Pre-Release)' : '';

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -444,13 +444,12 @@ export async function importMediaPath( slug: string, filePath: string ) {
  */
 async function updateWordPressImage( slug ) {
 	const versions = await getVersionList();
-	let message, envData, currentWordPressTag, currentWordPressRef;
+	let message, envData, currentWordPressTag;
 
 	// Get the current environment configuration
 	try {
 		envData = readEnvironmentData( slug );
 		currentWordPressTag = envData.wordpress.tag;
-		currentWordPressRef = envData.wordpress.ref || envData.wordpress.tag;
 	} catch ( error ) {
 		// This can throw an exception if the env is build with older vip version
 		if ( 'ENOENT' === error.code ) {
@@ -471,20 +470,20 @@ async function updateWordPressImage( slug ) {
 	console.log( 'The most recent WordPress version available is: ' + chalk.green( newestWordPressImage.tag ) );
 
 	// If the currently used version is the most up to date: exit.
-	if ( currentWordPressTag === newestWordPressImage.tag && currentWordPressRef === newestWordPressImage.ref ) {
+	if ( currentWordPressTag === newestWordPressImage.tag ) {
 		console.log( 'Environment WordPress version is: ' + chalk.green( currentWordPressTag ) + '  ... 😎 nice! ' );
 		return false;
 	}
 
 	// Determine if there is an image available for the current WordPress version
-	const match = versions.find( ( { ref, tag } ) => ref === currentWordPressRef && tag === currentWordPressTag );
+	const match = versions.find( ( { tag } ) => tag === currentWordPressTag );
 
 	// If there is no available image for the currently installed version, give user a path to change
 	if ( typeof match === 'undefined' ) {
-		console.log( `Installed WordPress: ${ currentWordPressTag } (${ currentWordPressRef }) has no available container image in repository. ` );
+		console.log( `Installed WordPress: ${ currentWordPressTag } has no available container image in repository. ` );
 		console.log( 'You must select a new WordPress image to continue... ' );
 	} else {
-		console.log( 'Environment WordPress version is: ' + chalk.yellow( match.ref ) );
+		console.log( 'Environment WordPress version is: ' + chalk.yellow( `${ match.tag } (${ match.ref })`) );
 		if ( envData.wordpress.doNotUpgrade || false ) {
 			return false;
 		}

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -555,6 +555,7 @@ export async function getVersionList() {
 	let res;
 	const mainEnvironmentPath = xdgBasedir.data || os.tmpdir();
 	const cacheFile = path.join( mainEnvironmentPath, 'vip', DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
+
 	// Handle from cache
 	try {
 		// If the cache doesn't exist, create it

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -497,7 +497,7 @@ async function updateWordPressImage( slug ) {
 		choices: [
 			'yes',
 			'no',
-			"don't ask anymore",
+			"no (don't ask anymore)",
 		],
 	} );
 
@@ -516,7 +516,7 @@ async function updateWordPressImage( slug ) {
 
 		return true;
 	}
-	if ( confirm.upgrade === "don't ask anymore" ) {
+	if ( confirm.upgrade === "no (don't ask anymore)" ) {
 		envData.wordpress.doNotUpgrade = true;
 		console.log( "We won't ask about upgrading this environment anymore." );
 		console.log( 'To manually upgrade please run:' + `${ chalk.yellow( `vip dev-env update --slug=${ slug }` ) }` );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -444,7 +444,8 @@ export async function importMediaPath( slug: string, filePath: string ) {
  */
 async function updateWordPressImage( slug ) {
 	const versions = await getVersionList();
-	const refRgx = new RegExp( /\d+\.\d+(?:\.\d+)?/ );
+	// Either a tag (e.g. 5.7.5) or a git SHA from the official repository.
+	const refRgx = new RegExp( /(\d+\.\d+(?:\.\d+)|[a-z0-9]{40})/ );
 	let message, envData, currentWordPressTag;
 
 	// Get the current environment configuration

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -519,6 +519,7 @@ async function updateWordPressImage( slug ) {
 	if ( confirm.upgrade === "don't ask anymore" ) {
 		envData.wordpress.doNotUpgrade = true;
 		console.log( "We won't ask about upgrading this environment anymore." );
+		console.log( 'To manually upgrade please run:' + `${ chalk.yellow( `vip dev-env update --slug=${ slug }` ) }` );
 		await updateEnvironment( envData );
 	}
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -483,7 +483,7 @@ async function updateWordPressImage( slug ) {
 		console.log( `Installed WordPress: ${ currentWordPressTag } has no available container image in repository. ` );
 		console.log( 'You must select a new WordPress image to continue... ' );
 	} else {
-		console.log( 'Environment WordPress version is: ' + chalk.yellow( `${ match.tag } (${ match.ref })`) );
+		console.log( 'Environment WordPress version is: ' + chalk.yellow( `${ match.tag } (${ match.ref })` ) );
 		if ( envData.wordpress.doNotUpgrade || false ) {
 			return false;
 		}


### PR DESCRIPTION
## Description

This PR addresses a few issues:

The most critical is that the selection didn't work properly when a `ref` was pointing to the commit. It's fixed by removing extra filtering that relied on regex. 

Also introduces `don't ask anymore` option to avoid being repeatedly asked whether an upgrade is desired if not on the latest version.

## Steps to Test

Edit `~/.local/share/vip/dev-environment/wordpress-versions.json` to include the following:

```
  {
    "ref": "2be90dc589a1c2e2bde5efa691eafe5407d0f753",
    "tag": "6.0",
    "cacheable": true,
    "locked": true,
    "prerelease": true
  },
```

Either create a new environment or start an existing one and follow the prompts, you should be able to create an environment using 6.0 prerelease.
