### PR TITLE
WP-CLI: Reattach Reconnect-Related Events After a Successful Reconnection

### DIFF
--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -10,6 +10,7 @@ import SocketIO from 'socket.io-client';
 import IOStream from 'socket.io-stream';
 import readline from 'readline';
 import { Writable } from 'stream';
+import debugLib from 'debug';
 
 /**
  * Internal dependencies
@@ -23,6 +24,8 @@ import { trackEvent } from 'lib/tracker';
 import Token from '../lib/token';
 import { rollbar } from 'lib/rollbar';
 import createSocksProxyAgent from 'lib/http/socks-proxy-agent';
+
+const debug = debugLib( '@automattic/vip:wp' );
 
 const appQuery = `id, name,
 	organization {
@@ -201,7 +204,8 @@ const launchCommandAndGetStreams = async ( { guid, inputToken, offset = 0 } ) =>
 
 const bindReconnectEvents = ( { cliCommand, inputToken, subShellRl, commonTrackingParams, isSubShell } ) => {
 	currentJob.socket.io.on( 'reconnect', async () => {
-		console.log( '-------- reconnect' );
+		debug( '-------- reconnect' );
+
 		// Close old streams
 		unpipeStreamsFromProcess( { stdin: currentJob.stdinStream, stdout: currentJob.stdoutStream } );
 
@@ -225,7 +229,7 @@ const bindReconnectEvents = ( { cliCommand, inputToken, subShellRl, commonTracki
 	} );
 
 	currentJob.socket.on( 'retry', async () => {
-		console.log( '-------- retry' );
+		debug( '-------- retry' );
 
 		setTimeout( () => {
 			currentJob.socket.io.engine.close();

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -205,6 +205,7 @@ const launchCommandAndGetStreams = async ( { guid, inputToken, offset = 0 } ) =>
 const bindReconnectEvents = ( { cliCommand, inputToken, subShellRl, commonTrackingParams, isSubShell } ) => {
 	currentJob.socket.io.on( 'reconnect', async () => {
 		debug( '-------- reconnect' );
+		rollbar.info( 'WP-CLI socket.io.on( \'reconnect\' )', { custom: { code: 'wp-cli-on-reconnect', commandGuid: cliCommand.guid } } );
 
 		// Close old streams
 		unpipeStreamsFromProcess( { stdin: currentJob.stdinStream, stdout: currentJob.stdoutStream } );
@@ -230,6 +231,7 @@ const bindReconnectEvents = ( { cliCommand, inputToken, subShellRl, commonTracki
 
 	currentJob.socket.on( 'retry', async () => {
 		debug( '-------- retry' );
+		rollbar.info( 'WP-CLI socket.io.on( \'retry\' )', { custom: { code: 'wp-cli-on-retry', commandGuid: cliCommand.guid } } );
 
 		setTimeout( () => {
 			currentJob.socket.io.engine.close();

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -233,7 +233,7 @@ const bindReconnectEvents = ( { cliCommand, inputToken, subShellRl, commonTracki
 	} );
 
 	currentJob.socket.io.on( 'reconnect_attempt', () => {
-		// create a new input stream so that we can still catch things like SIGINT while reconnectin
+		// create a new input stream so that we can still catch things like SIGINT while reconnecting
 		if ( currentJob.stdinStream ) {
 			process.stdin.unpipe( currentJob.stdinStream );
 		}

--- a/src/bin/vip-wp.js
+++ b/src/bin/vip-wp.js
@@ -231,6 +231,17 @@ const bindReconnectEvents = ( { cliCommand, inputToken, subShellRl, commonTracki
 		}, 5000 );
 	} );
 
+	currentJob.socket.on( 'exit', async ( { exitCode, message } ) => {
+		debug( 'socket: exit. Code: %d. Message: %s', exitCode, message );
+
+		if ( message ) {
+			console.log( message );
+		}
+
+		currentJob.socket.close();
+		process.exit( exitCode );
+	} );
+
 	currentJob.socket.io.on( 'reconnect_attempt', attempt => {
 		console.error( 'There was an error connecting to the server. Retrying...' );
 


### PR DESCRIPTION
## Description

Currently, when a connection to the back end is broken and the client successfully reconnects a first time, the event listeners are not reset to allow subsequent reconnections to succeed.  This change re-binds the listeners, so additional reconnections per run are possible.

Also, in case the `cli` receives an `exit` signal, it will exit accordingly to the code and message received.

This change also adds some logging so we can monitor these situations and further improve the experience.

## Steps to Test

### Testing reattach reconnect-related events
1. Check out PR.
2. Run npm run build
3. Run ./dist/bin/vip-wp long-running-command
4. Simulate a network issue
5. Wait for the until to reconnect
6. Simulate another network issue
7. Wait for the until to reconnect
8. The command should resume/reconnect multiple times.

### Testing exit code

1. Check out PR.
2. Run npm run build
3. Run ./dist/bin/vip-wp long-running-command
4. Deploy a new version of the site
5. An error message should appear
6. Run `echo $?`
7. The output should be `101`