### PR TITLE
Add ability to choose a PHP image to use

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -37,7 +37,7 @@ services:
   php:
     type: compose
     services:
-      image: ghcr.io/automattic/vip-container-images/php-fpm:7.4
+      image: <%= php %>
       command: run.sh
       working_dir: /wp
       healthcheck:

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -20,7 +20,7 @@ import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { addDevEnvConfigurationOptions, handleCLIException, promptForArguments } from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
 import { doesEnvironmentExist, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
-import { DEV_ENVIRONMENT_NOT_FOUND } from '../lib/constants/dev-environment';
+import { DEV_ENVIRONMENT_NOT_FOUND, DEV_ENVIRONMENT_PHP_VERSIONS } from '../lib/constants/dev-environment';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -60,7 +60,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
 			wordpress: currentInstanceData.wordpress.tag,
 			elasticsearch: currentInstanceData.elasticsearch,
-			php: currentInstanceData.php,
+			php: currentInstanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default,
 			mariadb: currentInstanceData.mariadb,
 			statsd: currentInstanceData.statsd,
 			phpmyadmin: currentInstanceData.phpmyadmin,

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -60,6 +60,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
 			wordpress: currentInstanceData.wordpress.tag,
 			elasticsearch: currentInstanceData.elasticsearch,
+			php: currentInstanceData.php,
 			mariadb: currentInstanceData.mariadb,
 			statsd: currentInstanceData.statsd,
 			phpmyadmin: currentInstanceData.phpmyadmin,

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -6,6 +6,7 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	multisite: false,
 	elasticsearchVersion: '7.10.1',
 	mariadbVersion: '10.3',
+	phpImage: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
 };
 
 export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up your local dev environment.\n\n' +

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -6,7 +6,7 @@ export const DEV_ENVIRONMENT_DEFAULTS = {
 	multisite: false,
 	elasticsearchVersion: '7.10.1',
 	mariadbVersion: '10.3',
-	phpImage: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
+	phpImage: 'default',
 };
 
 export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up your local dev environment.\n\n' +
@@ -24,3 +24,11 @@ export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
+export const DEV_ENVIRONMENT_PHP_VERSIONS = {
+	default: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
+	// eslint-disable-next-line quote-props -- flow does nit support non-string keys
+	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:7.4',
+	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.0',
+	// eslint-disable-next-line quote-props
+	'8.1': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.1',
+};

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -140,6 +140,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		wpTitle: preselectedOptions.title || await promptForText( 'WordPress site title', defaultOptions.title || DEV_ENVIRONMENT_DEFAULTS.title ),
 		multisite: 'multisite' in preselectedOptions ? preselectedOptions.multisite : await promptForBoolean( multisiteText, !! multisiteDefault ),
 		elasticsearch: preselectedOptions.elasticsearch || defaultOptions.elasticsearch || DEV_ENVIRONMENT_DEFAULTS.elasticsearchVersion,
+		php: preselectedOptions.php || defaultOptions.php || DEV_ENVIRONMENT_DEFAULTS.phpVersion,
 		mariadb: preselectedOptions.mariadb || defaultOptions.mariadb || DEV_ENVIRONMENT_DEFAULTS.mariadbVersion,
 		mediaRedirectDomain: preselectedOptions.mediaRedirectDomain || '',
 		wordpress: {
@@ -373,7 +374,8 @@ export function addDevEnvConfigurationOptions( command ) {
 		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
 		.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use' )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
-		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' );
+		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
+		.option( 'php', 'Explicitly choose PHP version to use' );
 }
 
 /**

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -30,6 +30,7 @@ import {
 	DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI,
 	DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY,
 	DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL,
+	DEV_ENVIRONMENT_PHP_VERSIONS,
 } from '../constants/dev-environment';
 import type { AppInfo, InstanceData } from './types';
 
@@ -143,8 +144,9 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.mediaRedirectDomain = `https://${ instanceData.mediaRedirectDomain }`;
 	}
 
-	instanceData.enterpiseSearchEnabled = instanceData.enterpiseSearchEnabled || false;
+	newInstanceData.enterpriseSearchEnabled = instanceData.enterpriseSearchEnabled || false;
 
+	newInstanceData.php = instanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default;
 	return newInstanceData;
 }
 

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -7,6 +7,7 @@ export interface InstanceOptions {
 	clientCode?: string;
 	elasticsearch?: string;
 	mariadb?: string;
+	php?: string;
 	mediaRedirectDomain?: string;
 	statsd?: boolean;
 	phpmyadmin?: boolean;
@@ -52,4 +53,5 @@ export interface InstanceData {
 	xdebug: boolean;
 	elasticsearch: string;
 	mariadb: string;
+	php: string;
 }


### PR DESCRIPTION
## Description

This PR adds an option to choose a PHP image to use; by default, we use `ghcr.io/automattic/vip-container-images/php-fpm:7.4`.

With this option, users can try newer versions of PHP in their development environment.

## Steps to Test

After checking this PR out and building the files, `node ./dist/bin/vip-dev-env-create.js -P ghcr.io/automattic/vip-container-images/php-fpm-alt:8.0` should pull the new image, and `node ./dist/bin/vip-dev-env-start.js` should start it. There is a bug in the php-fpm-alt:8.0 which prevents WP from being installed, I am working on it (Automattic/vip-container-images#195).
