### PR TITLE
[dev-env] Add Enterprise Search, XDebug, phpMyAdmin options to the config wizard.

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -7,7 +7,6 @@
  */
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import nock from 'nock';
-
 /**
  * Internal dependencies
  */
@@ -309,9 +308,9 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const result = await promptForArguments( input.preselected, input.default );
 
 			if ( 'multisite' in input.preselected ) {
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 0 );
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 3 );
 			} else {
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 1 );
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 4 );
 			}
 
 			const expectedValue = 'multisite' in input.preselected ? input.preselected.multisite : input.default.multisite;
@@ -346,9 +345,9 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const result = await promptForArguments( input.preselected, input.default );
 
 			if ( input.preselected.mediaRedirectDomain ) {
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 0 );
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 3 );
 			} else {
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 1 );
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 4 );
 			}
 
 			const expectedValue = input.preselected.mediaRedirectDomain ? input.preselected.mediaRedirectDomain : input.default.mediaRedirectDomain;
@@ -385,60 +384,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 
 			expect( result.mariadb ).toStrictEqual( expectedMaria );
 			expect( result.elasticsearch ).toStrictEqual( expectedElastic );
-		} );
-		it.each( [
-			{
-				service: 'statsd',
-				preselected: true,
-				expected: true,
-				wordpress: testReleaseWP,
-			},
-			{
-				service: 'statsd',
-				expected: false,
-				wordpress: testReleaseWP,
-			},
-			{
-				service: 'statsd',
-				default: true,
-				expected: true,
-				wordpress: testReleaseWP,
-			},
-			{
-				service: 'statsd',
-				preselected: false,
-				default: true,
-				expected: false,
-				wordpress: testReleaseWP,
-			},
-			{
-				service: 'phpmyadmin',
-				preselected: true,
-				default: true,
-				expected: true,
-				wordpress: testReleaseWP,
-			},
-			{
-				service: 'xdebug',
-				default: true,
-				expected: true,
-				wordpress: testReleaseWP,
-			},
-		] )( 'should handle auxiliary services', async input => {
-			const preselected = {};
-			const defaultOptions = {};
-			if ( 'preselected' in input ) {
-				preselected[ input.service ] = input.preselected;
-			}
-			if ( 'default' in input ) {
-				defaultOptions[ input.service ] = input.default;
-			}
-			if ( 'wordpress' in input ) {
-				preselected.wordpress = input.wordpress;
-			}
-			const result = await promptForArguments( preselected, defaultOptions );
-
-			expect( result[ input.service ] ).toStrictEqual( input.expected );
 		} );
 	} );
 } );

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -22,7 +22,6 @@ services:
     volumes:
       devtools: {}
       scripts:
-
   nginx:
     type: compose
     ssl: true

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -95,7 +95,7 @@ services:
       environment:
         UPLOAD_LIMIT: 4G
 <% } %>
-
+<% if ( enterpriseSearchEnabled ) { %>
   vip-search:
     type: compose
     services:
@@ -115,7 +115,7 @@ services:
         - search_data:/usr/share/elasticsearch/data
     volumes:
       search_data:
-
+<% } %>
 <% if ( statsd ) { %>
   statsd:
     type: compose

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -39,8 +39,6 @@ services:
       image: ghcr.io/automattic/vip-container-images/php-fpm:7.4
       command: run.sh
       working_dir: /wp
-      healthcheck:
-        test: 'cat /wp/wp-includes/pomo/mo.php'
       environment:
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
         STATSD: <%= statsd ? 'enable' : 'disable' %>

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -70,6 +70,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	}
 
 	let defaultOptions: $Shape<InstanceOptions> = {};
+
 	try {
 		if ( opt.app ) {
 			const appInfo = await getApplicationInformation( opt.app, opt.env );

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -22,4 +22,3 @@ export const DEV_ENVIRONMENT_WORDPRESS_VERSIONS_URI = '/Automattic/vip-container
 export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
-

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -161,7 +161,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 	const promptLabels = {
 		xdebug: 'XDebug',
 		phpmyadmin: 'phpMyAdmin',
-	}
+	};
 
 	if ( ! instanceData.mediaRedirectDomain && defaultOptions.mediaRedirectDomain ) {
 		const mediaRedirectPromptText = `Would you like to redirect to ${ defaultOptions.mediaRedirectDomain } for missing media files?`;

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -155,7 +155,13 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		phpmyadmin: false,
 		xdebug: false,
 		siteSlug: '',
+		enterpriseSearchEnabled: preselectedOptions.enterpriseSearchEnabled || defaultOptions.enterpriseSearchEnabled,
 	};
+
+	const promptLabels = {
+		xdebug: 'XDebug',
+		phpmyadmin: 'phpMyAdmin',
+	}
 
 	if ( ! instanceData.mediaRedirectDomain && defaultOptions.mediaRedirectDomain ) {
 		const mediaRedirectPromptText = `Would you like to redirect to ${ defaultOptions.mediaRedirectDomain } for missing media files?`;
@@ -177,11 +183,16 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		instanceData[ component ] = result;
 	}
 
-	for ( const service of [ 'statsd', 'phpmyadmin', 'xdebug' ] ) {
-		if ( service in preselectedOptions ) {
-			instanceData[ service ] = preselectedOptions[ service ];
-		} else if ( service in defaultOptions ) {
-			instanceData[ service ] = defaultOptions[ service ];
+	instanceData.enterpriseSearchEnabled = await promptForBoolean( 'Enable Enterprise Search?', defaultOptions.enterpriseSearchEnabled );
+	if ( instanceData.enterpriseSearchEnabled ) {
+		instanceData.statsd = preselectedOptions.statsd || defaultOptions.statsd || false;
+	} else {
+		instanceData.statsd = false;
+	}
+
+	for ( const service of [ 'phpmyadmin', 'xdebug' ] ) {
+		if ( service in instanceData ) {
+			instanceData[ service ] = await promptForBoolean( `Enable ${ promptLabels[ service ] || service }`, instanceData[ service ] );
 		}
 	}
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -143,6 +143,8 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.mediaRedirectDomain = `https://${ instanceData.mediaRedirectDomain }`;
 	}
 
+	instanceData.enterpiseSearchEnabled = instanceData.enterpiseSearchEnabled || false;
+
 	return newInstanceData;
 }
 


### PR DESCRIPTION
## Description

This PR adds Enterprise Search, XDebug, and phpMyAdmin as selectable options in the `create` and `update` commands, with defaults to false.

Additionally, this PR removes a PHP healthcheck which was not helpful, instead of the healthcheck we now wait for the core files to be present instead of in https://github.com/Automattic/vip-container-images/pull/197.


## Steps to Test


1. Check out PR.
1. Run `npm run build`
1. Run `npm run link` (this is the easiest)
1. `vip dev-env create --slug=wizard`
1. Verify that the prompts are being displayed
1. Verify that `vip-search` is either present or absent in the generated .lando.yml
1. Verify that older versions of the environment start up as expected (the template file now relies on new `enterpriseSearchEnabled` instance var. 

