### PR TITLE
[dev-env] Adding tracking for create and destroy sub commands

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -21,10 +21,10 @@ import { createEnvironment, printEnvironmentInfo, getApplicationInformation, doe
 import { getEnvironmentName, promptForArguments, getEnvironmentStartCommand } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
 import {
-  addDevEnvConfigurationOptions,
-  getOptionsFromAppInfo,
-  handleCLIException,
-} from "../lib/dev-environment/dev-environment-cli";
+	addDevEnvConfigurationOptions,
+	getOptionsFromAppInfo,
+	handleCLIException,
+} from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -14,6 +14,7 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
+import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
 import * as exit from 'lib/cli/exit';
 import { createEnvironment, printEnvironmentInfo, getApplicationInformation, doesEnvironmentExist } from 'lib/dev-environment/dev-environment-core';
@@ -59,6 +60,9 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	const slug = getEnvironmentName( opt );
 	debug( 'Args: ', arg, 'Options: ', opt );
 
+	const trackingInfo = { slug };
+	await trackEvent( 'dev_env_create_command_execute', trackingInfo );
+
 	const startCommand = chalk.bold( getEnvironmentStartCommand( opt ) );
 
 	const environmentAlreadyExists = doesEnvironmentExist( slug );
@@ -93,7 +97,11 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 		const message = '\n' + chalk.green( '✓' ) + ` environment created.\n\nTo start it please run:\n\n${ startCommand }\n`;
 		console.log( message );
+
+		await trackEvent( 'dev_env_create_command_success', trackingInfo );
 	} catch ( error ) {
+		const errorTrackingInfo = Object.assign( {}, trackingInfo, { error: error.message } );
+		await trackEvent( 'dev_env_create_command_error', errorTrackingInfo );
 		exit.withError( error.message );
 	}
 } );

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -20,7 +20,11 @@ import * as exit from 'lib/cli/exit';
 import { createEnvironment, printEnvironmentInfo, getApplicationInformation, doesEnvironmentExist } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, promptForArguments, getEnvironmentStartCommand } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
-import { addDevEnvConfigurationOptions, getOptionsFromAppInfo } from '../lib/dev-environment/dev-environment-cli';
+import {
+  addDevEnvConfigurationOptions,
+  getOptionsFromAppInfo,
+  handleCLIException,
+} from "../lib/dev-environment/dev-environment-cli";
 import type { InstanceOptions } from '../lib/dev-environment/types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -100,8 +104,6 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 		await trackEvent( 'dev_env_create_command_success', trackingInfo );
 	} catch ( error ) {
-		const errorTrackingInfo = Object.assign( {}, trackingInfo, { error: error.message } );
-		await trackEvent( 'dev_env_create_command_error', errorTrackingInfo );
-		exit.withError( error.message );
+		await handleCLIException( error, 'dev_env_create_command_error', trackingInfo );
 	}
 } );

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -16,14 +16,13 @@ import chalk from 'chalk';
  */
 import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
-import * as exit from 'lib/cli/exit';
 import { destroyEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import {
-  getEnvTrackingInfo,
-  handleCLIException,
-} from "../lib/dev-environment/dev-environment-cli";
+	getEnvTrackingInfo,
+	handleCLIException,
+} from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -20,7 +20,10 @@ import * as exit from 'lib/cli/exit';
 import { destroyEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import { getEnvTrackingInfo } from '../lib/dev-environment/dev-environment-cli';
+import {
+  getEnvTrackingInfo,
+  handleCLIException,
+} from "../lib/dev-environment/dev-environment-cli";
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -55,8 +58,6 @@ command()
 			console.log( message );
 			await trackEvent( 'dev_env_destroy_command_success', trackingInfo );
 		} catch ( error ) {
-			const errorTrackingInfo = Object.assign( {}, trackingInfo, { error: error.message } );
-			await trackEvent( 'dev_env_destroy_command_error', errorTrackingInfo );
-			exit.withError( error.message );
+			await handleCLIException( error, 'dev_env_destroy_command_error', trackingInfo );
 		}
 	} );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -68,11 +68,9 @@ command()
 			await startEnvironment( slug, options );
 
 			const processingTime = new Date() - startProcessing;
-			const successTrackingInfo = Object.assign( {}, trackingInfo, { processingTime } );
+			const successTrackingInfo = { ...trackingInfo, processingTime };
 			await trackEvent( 'dev_env_start_command_success', successTrackingInfo );
 		} catch ( error ) {
-			const errorTrackingInfo = Object.assign( {}, trackingInfo, { error: error.message } );
-			await trackEvent( 'dev_env_start_command_error', errorTrackingInfo );
-			handleCLIException( error );
+			await handleCLIException( error, 'dev_env_start_command_error', trackingInfo );
 		}
 	} );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -45,7 +45,6 @@ command()
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_start_command_execute', trackingInfo );
 
-
 		debug( 'Args: ', arg, 'Options: ', opt );
 
 		const options = {

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -43,7 +43,6 @@ command()
 		const slug = getEnvironmentName( opt );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
-
 		await trackEvent( 'dev_env_start_command_execute', trackingInfo );
 
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -17,6 +17,7 @@ import os from 'os';
 /**
  * Internal dependencies
  */
+import { trackEvent } from '../tracker';
 import {
 	DEV_ENVIRONMENT_FULL_COMMAND,
 	DEV_ENVIRONMENT_SUBCOMMAND,
@@ -33,7 +34,7 @@ const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 const DEFAULT_SLUG = 'vip-local';
 
-export function handleCLIException( exception: Error ) {
+export async function handleCLIException( exception: Error, trackKey?: string, trackBaseInfo?: any = {} ) {
 	const errorPrefix = chalk.red( 'Error:' );
 	if ( DEV_ENVIRONMENT_NOT_FOUND === exception.message ) {
 		const createCommand = chalk.bold( DEV_ENVIRONMENT_FULL_COMMAND + ' create' );
@@ -46,6 +47,15 @@ export function handleCLIException( exception: Error ) {
 		message = message.replace( 'ERROR: ', '' );
 
 		console.log( errorPrefix, message );
+
+		if ( trackKey ) {
+			try {
+				const errorTrackingInfo = { ...trackBaseInfo, error: message };
+				await trackEvent( trackKey, errorTrackingInfo );
+			} catch ( trackException ) {
+				console.log( errorPrefix, `Failed to record track event ${ trackKey }`, trackException.message );
+			}
+		}
 
 		if ( ! process.env.DEBUG ) {
 			console.log( `Please re-run the command with "--debug ${ chalk.bold( '@automattic/vip:bin:dev-environment' ) }" appended to it and provide the stack trace on the support ticket.` );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -26,7 +26,7 @@ import {
 	DEV_ENVIRONMENT_NOT_FOUND,
 	DEV_ENVIRONMENT_PHP_VERSIONS,
 } from '../constants/dev-environment';
-import { getVersionList } from './dev-environment-core';
+import { getVersionList, readEnvironmentData } from './dev-environment-core';
 import type { AppInfo, ComponentConfig, InstanceOptions, EnvironmentNameOptions, InstanceData } from './types';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -415,4 +415,15 @@ export async function getTagChoices() {
 			value: version.tag,
 		};
 	} );
+}
+
+export function getEnvTrackingInfo( slug: string ): any {
+	try {
+		const envData = readEnvironmentData( slug );
+		return Object.assign( {}, envData, { slug } );
+	} catch ( err ) {
+		return {
+			slug,
+		};
+	}
 }

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -420,7 +420,14 @@ export async function getTagChoices() {
 export function getEnvTrackingInfo( slug: string ): any {
 	try {
 		const envData = readEnvironmentData( slug );
-		return Object.assign( {}, envData, { slug } );
+		const result = { slug };
+		for ( const key of Object.keys( envData ) ) {
+			// track doesnt like camelCase
+			const snakeCasedKey = key.replace( /[A-Z]/g, letter => `_${ letter.toLowerCase() }` );
+			result[ snakeCasedKey ] = envData[ key ];
+		}
+
+		return result;
 	} catch ( err ) {
 		return {
 			slug,


### PR DESCRIPTION
## Description

In order to get insights into how is dev-env being used we are adding tracking mechanism used in other subcommand.

Also, this PR adds parsing of env data to send more information to track.

## Steps to Test

1) `export DEBUG=@automattic/vip:analytics:clients:tracks`
2)  `npm run build && ./dist/bin/vip-dev-env-create.js`

or

check https://mc.a8c.com/tracks/live/?eventname=vip_cli_dev%25&user=&useragent=