### PR TITLE
[dev-env] enable lando debug on `--debug`

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -46,7 +46,9 @@ function getLandoConfig() {
 
 	debug( `Getting lando config, using path '${ landoPath }' for plugins` );
 
-	const logLevelConsole = ( process.env.DEBUG || '' ).includes( DEBUG_KEY ) ? 'debug' : 'warn';
+	const isLandoDebugSelected = ( process.env.DEBUG || '' ).includes( DEBUG_KEY );
+	const isAllDebugSelected = process.env.DEBUG === '*';
+	const logLevelConsole = ( isAllDebugSelected || isLandoDebugSelected ) ? 'debug' : 'warn';
 
 	return {
 		logLevelConsole,


### PR DESCRIPTION


## Description

Enable lando logs not only for:
`vip dev-env info --debug @automattic/vip:bin:dev-environment-lando`

But also for 
`vip dev-env info --debug`

The initial implementation would ignore the "ALL" debug option

## Steps to Test

Run the examples above

