### PR TITLE
Unifies lando and other dev-env debug logs

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -22,7 +22,7 @@ import App from 'lando/lib/app';
 /**
  * This file will hold all the interactions with lando library
  */
-const DEBUG_KEY = '@automattic/vip:bin:dev-environment-lando';
+const DEBUG_KEY = '@automattic/vip:bin:dev-environment';
 const debug = debugLib( DEBUG_KEY );
 
 let landoConfRoot;


### PR DESCRIPTION

## Description

We currently have 2 debug keys in dev-env `@automattic/vip:bin:dev-environment` and `@automattic/vip:bin:dev-environment-lando`. The lando was used for lando specific logs.

The distinction makes sense for us, but for the end-user that doesn't know/care about lando it is rather confusing, which is why we might want to unify them both under the same debug key.

## Steps to Test

`npm run build && ./dist/bin/vip-dev-env-list.js  --debug @automattic/vip:bin:dev-environment` 

Will show both lando and non-lando dev-env logs.

