### PR TITLE
[dev-env] Add login info and documentation link to `dev-env info`

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -162,7 +162,6 @@ export async function landoInfo( instancePath: string ) {
 	const frontEndUrl = app.info
 		.find( service => 'nginx' === service.service )
 		?.urls[ 0 ];
-	const loginUrl = `${ frontEndUrl }wp-admin/`;
 
 	const extraService = await getExtraServicesConnections( lando, app );
 	appInfo = {
@@ -175,10 +174,16 @@ export async function landoInfo( instancePath: string ) {
 	// Drop vipdev prefix
 	appInfo.name = appInfo.name.replace( /^vipdev/, '' );
 
-	// Add login information and documentation link
-	appInfo[ 'Login URL' ] = loginUrl;
-	appInfo[ 'Default username' ] = 'vipgo';
-	appInfo[ 'Default password' ] = 'password';
+	// Add login information
+	if ( frontEndUrl ) {
+		const loginUrl = `${ frontEndUrl }wp-admin/`;
+
+		appInfo[ 'Login URL' ] = loginUrl;
+		appInfo[ 'Default username' ] = 'vipgo';
+		appInfo[ 'Default password' ] = 'password';
+	}
+
+	// Add documentation link
 	appInfo.Documentation = 'https://docs.wpvip.com/technical-references/vip-local-development-environment/tips/';
 
 	return appInfo;

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -159,6 +159,10 @@ export async function landoInfo( instancePath: string ) {
 	reachableServices.forEach( service => appInfo[ `${ service.service } urls` ] = service.urls );
 
 	const isUp = await isEnvUp( app );
+	const frontEndUrl = app.info
+		.find( service => 'nginx' === service.service )
+		?.urls[ 0 ];
+	const loginUrl = `${ frontEndUrl }wp-admin/`;
 
 	const extraService = await getExtraServicesConnections( lando, app );
 	appInfo = {
@@ -170,6 +174,12 @@ export async function landoInfo( instancePath: string ) {
 
 	// Drop vipdev prefix
 	appInfo.name = appInfo.name.replace( /^vipdev/, '' );
+
+	// Add login information and documentation link
+	appInfo[ 'Login URL' ] = loginUrl;
+	appInfo[ 'Default username' ] = 'vipgo';
+	appInfo[ 'Default password' ] = 'password';
+	appInfo.Documentation = 'https://docs.wpvip.com/technical-references/vip-local-development-environment/tips/';
 
 	return appInfo;
 }


### PR DESCRIPTION
## Description

I use `dev-env` infrequently, and I never remember the default login credentials and they are a hassle to track down. Providing this information feels like it would aid a central use case and streamline usage of `dev-env`.

This info is also helpfully printed when running `dev-env start`.

```
> node dist/bin/vip-dev-env-info.js
 NAME              vip-local
 LOCATION          /Users/czarate/.local/share/vip/dev-environment/vip-local
 SERVICES          devtools, nginx, php, database, memcached, wordpress, mu-plugins
 NGINX URLS        http://vip-local.vipdev.lndo.site/
                   https://vip-local.vipdev.lndo.site/
                   http://*.vip-local.vipdev.lndo.site/
                   https://*.vip-local.vipdev.lndo.site/
 DATABASE          127.0.0.1:57724
 STATUS            UP
 LOGIN URL         http://vip-local.vipdev.lndo.site/wp-admin/
 DEFAULT USERNAME  vipgo
 DEFAULT PASSWORD  password
 DOCUMENTATION     https://docs.wpvip.com/technical-references/vip-local-development-environment/tips/
```

I don't want to overload this output, but this feels very readable and useful.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-dev-env-info`
1. Verify cookies are delicious.
