### PR TITLE
[dev-env] Validate docker installed

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -24,6 +24,7 @@ import {
 	addDevEnvConfigurationOptions,
 	getOptionsFromAppInfo,
 	handleCLIException,
+	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
 
@@ -61,6 +62,8 @@ addDevEnvConfigurationOptions( cmd );
 
 cmd.examples( examples );
 cmd.argv( process.argv, async ( arg, opt ) => {
+	await validateDependencies();
+
 	const slug = getEnvironmentName( opt );
 	debug( 'Args: ', arg, 'Options: ', opt );
 

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -22,6 +22,7 @@ import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import {
 	getEnvTrackingInfo,
 	handleCLIException,
+	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -42,6 +43,7 @@ command()
 	.option( 'soft', 'Keep config files needed to start an environment intact' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
+		await validateDependencies();
 		const slug = getEnvironmentName( opt );
 
 		const trackingInfo = getEnvTrackingInfo( slug );

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -17,7 +17,7 @@ import command from 'lib/cli/command';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { exec } from 'lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import { getEnvTrackingInfo } from '../lib/dev-environment/dev-environment-cli';
+import { getEnvTrackingInfo, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 
 const examples = [
 	{
@@ -38,6 +38,7 @@ command( { wildcardCommand: true } )
 	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
+		await validateDependencies();
 		const slug = getEnvironmentName( opt );
 
 		const trackingInfo = getEnvTrackingInfo( slug );

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -14,7 +14,7 @@
  */
 import { trackEvent } from 'lib/tracker';
 import command from '../lib/cli/command';
-import { getEnvironmentName, getEnvTrackingInfo, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
+import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 import { importMediaPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 
@@ -35,6 +35,7 @@ command( {
 	.examples( examples )
 	.option( 'slug', 'Custom name of the dev environment' )
 	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
+		await validateDependencies();
 		const [ filePath ] = unmatchedArgs;
 		const slug = getEnvironmentName( opt );
 

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -15,7 +15,7 @@ import fs from 'fs';
  */
 import { trackEvent } from 'lib/tracker';
 import command from '../lib/cli/command';
-import { getEnvironmentName, getEnvTrackingInfo, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
+import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import { validate } from '../lib/validations/sql';
@@ -48,6 +48,7 @@ command( {
 	.option( 'skip-validate', 'Do not perform file validation.' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
+		await validateDependencies();
 		const [ fileName ] = unmatchedArgs;
 		const { searchReplace, inPlace } = opt;
 		const slug = getEnvironmentName( opt );

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -18,7 +18,7 @@ import command from 'lib/cli/command';
 import { printEnvironmentInfo, printAllEnvironmentsInfo } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
-import { getEnvTrackingInfo } from '../lib/dev-environment/dev-environment-cli';
+import { getEnvTrackingInfo, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -42,6 +42,7 @@ command()
 	.option( 'all', 'Show Info for all local dev environments' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
+		await validateDependencies();
 		const slug = getEnvironmentName( opt );
 
 		const trackingInfo = opt.all ? { all: true } : getEnvTrackingInfo( slug );

--- a/src/bin/vip-dev-env-list.js
+++ b/src/bin/vip-dev-env-list.js
@@ -17,6 +17,7 @@ import command from 'lib/cli/command';
 import { printAllEnvironmentsInfo } from 'lib/dev-environment/dev-environment-core';
 import { handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
+import { validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 
 const examples = [
 	{
@@ -28,6 +29,7 @@ const examples = [
 command()
 	.examples( examples )
 	.argv( process.argv, async () => {
+		await validateDependencies();
 		const trackingInfo = { all: true };
 		await trackEvent( 'dev_env_list_command_execute', trackingInfo );
 

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -18,9 +18,8 @@ import { exec } from 'child_process';
 import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
 import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
-import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import { getEnvTrackingInfo } from '../lib/dev-environment/dev-environment-cli';
+import { getEnvTrackingInfo, validateDependencies, getEnvironmentName, handleCLIException} from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -39,6 +38,8 @@ command()
 	.option( 'skip-rebuild', 'Only start stopped services' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
+		await validateDependencies();
+
 		const startProcessing = new Date();
 		const slug = getEnvironmentName( opt );
 

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -19,7 +19,7 @@ import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
 import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import { getEnvTrackingInfo, validateDependencies, getEnvironmentName, handleCLIException} from '../lib/dev-environment/dev-environment-cli';
+import { getEnvTrackingInfo, validateDependencies, getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 

--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -18,6 +18,7 @@ import command from 'lib/cli/command';
 import { stopEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
+import { validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -32,6 +33,7 @@ command()
 	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
+		await validateDependencies();
 		const slug = getEnvironmentName( opt );
 
 		debug( 'Args: ', arg, 'Options: ', opt );

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -18,7 +18,7 @@ import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
 import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import { addDevEnvConfigurationOptions, getEnvTrackingInfo, handleCLIException, promptForArguments } from '../lib/dev-environment/dev-environment-cli';
+import { addDevEnvConfigurationOptions, getEnvTrackingInfo, handleCLIException, promptForArguments, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
 import { doesEnvironmentExist, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND, DEV_ENVIRONMENT_PHP_VERSIONS } from '../lib/constants/dev-environment';
@@ -37,6 +37,7 @@ addDevEnvConfigurationOptions( cmd );
 
 cmd.examples( examples );
 cmd.argv( process.argv, async ( arg, opt ) => {
+	await validateDependencies();
 	const slug = getEnvironmentName( opt );
 
 	const trackingInfo = getEnvTrackingInfo( slug );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -30,7 +30,7 @@ import {
 } from '../constants/dev-environment';
 import { getVersionList, readEnvironmentData } from './dev-environment-core';
 import type { AppInfo, ComponentConfig, InstanceOptions, EnvironmentNameOptions, InstanceData } from './types';
-import { ensureDockerInstalled } from './dev-environment-lando';
+import { validateDockerInstalled } from './dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -71,7 +71,7 @@ export async function handleCLIException( exception: Error, trackKey?: string, t
 
 export const validateDependencies = async () => {
 	try {
-		await ensureDockerInstalled();
+		await validateDockerInstalled();
 	} catch ( exception ) {
 		exit.withError( exception.message );
 	}

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -17,6 +17,7 @@ import os from 'os';
 /**
  * Internal dependencies
  */
+import * as exit from 'lib/cli/exit';
 import { trackEvent } from '../tracker';
 import {
 	DEV_ENVIRONMENT_FULL_COMMAND,
@@ -29,6 +30,7 @@ import {
 } from '../constants/dev-environment';
 import { getVersionList, readEnvironmentData } from './dev-environment-core';
 import type { AppInfo, ComponentConfig, InstanceOptions, EnvironmentNameOptions, InstanceData } from './types';
+import { ensureDockerInstalled } from './dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -66,6 +68,14 @@ export async function handleCLIException( exception: Error, trackKey?: string, t
 		debug( exception );
 	}
 }
+
+export const validateDependencies = async () => {
+	try {
+		await ensureDockerInstalled();
+	} catch ( exception ) {
+		exit.withError( exception.message );
+	}
+};
 
 export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 	if ( options.slug ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -20,7 +20,7 @@ import copydir from 'copy-dir';
 /**
  * Internal dependencies
  */
-import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild, ensureDockerInstalled } from './dev-environment-lando';
+import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild } from './dev-environment-lando';
 import { searchAndReplace } from '../search-and-replace';
 import { handleCLIException, printTable, promptForComponent, resolvePath } from './dev-environment-cli';
 import app from '../api/app';

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -20,7 +20,7 @@ import copydir from 'copy-dir';
 /**
  * Internal dependencies
  */
-import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild } from './dev-environment-lando';
+import { landoDestroy, landoInfo, landoExec, landoStart, landoStop, landoRebuild, ensureDockerInstalled } from './dev-environment-lando';
 import { searchAndReplace } from '../search-and-replace';
 import { handleCLIException, printTable, promptForComponent, resolvePath } from './dev-environment-cli';
 import app from '../api/app';

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -14,6 +14,7 @@ import landoUtils from 'lando/plugins/lando-core/lib/utils';
 import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import chalk from 'chalk';
 import App from 'lando/lib/app';
+import { console } from "inspector";
 
 /**
  * Internal dependencies
@@ -293,4 +294,18 @@ async function ensureNoOrphantProxyContainer( lando ) {
 	}
 
 	await proxyContainer.remove();
+}
+
+export async function ensureDockerInstalled() {
+	const lando = new Lando( getLandoConfig() );
+	await lando.bootstrap();
+
+	lando.log.verbose( 'docker-engine exists: %s', lando.engine.dockerInstalled );
+	if ( lando.engine.dockerInstalled === false ) {
+		throw Error( 'docker could not be located!' );
+	}
+	lando.log.verbose( 'docker-compose exists: %s', lando.engine.composeInstalled );
+	if ( lando.engine.composeInstalled === false ) {
+		throw Error( 'docker-compose could not be located!' );
+	}
 }

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -14,7 +14,6 @@ import landoUtils from 'lando/plugins/lando-core/lib/utils';
 import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import chalk from 'chalk';
 import App from 'lando/lib/app';
-import { console } from "inspector";
 
 /**
  * Internal dependencies

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -295,16 +295,16 @@ async function ensureNoOrphantProxyContainer( lando ) {
 	await proxyContainer.remove();
 }
 
-export async function ensureDockerInstalled() {
+export async function validateDockerInstalled() {
 	const lando = new Lando( getLandoConfig() );
 	await lando.bootstrap();
 
 	lando.log.verbose( 'docker-engine exists: %s', lando.engine.dockerInstalled );
 	if ( lando.engine.dockerInstalled === false ) {
-		throw Error( 'docker could not be located!' );
+		throw Error( 'docker could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/' );
 	}
 	lando.log.verbose( 'docker-compose exists: %s', lando.engine.composeInstalled );
 	if ( lando.engine.composeInstalled === false ) {
-		throw Error( 'docker-compose could not be located!' );
+		throw Error( 'docker-compose could not be located! Please follow the following instructions to install it - https://docs.docker.com/compose/install/' );
 	}
 }


### PR DESCRIPTION
## Description

This change mimics [lando native](https://github.com/Automattic/lando-cli/blob/57d2cd8a23e73b3e5165c3e2862b42aa0881ef2f/lib/cli.js#L327) check for docker and docker-compose. We can give user a sensible error rather than failing in the middle with a stack trace.

## Steps to Test

Uninstall docker/docker-compose e.g. `sudo mv /usr/share/lando/bin/docker-compose /usr/share/lando/bin/docker-compose-back` 

Run start/create command.

