### PR TITLE
[dev-env] Skip the trunk from the prompt about the latest available WordPress versions

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -467,10 +467,10 @@ async function updateWordPressImage( slug ) {
 	}
 
 	// sort
-	versions.sort( ( before, after ) => ( before.tag < after.tag ) ? 1 : -1 );
+	versions.sort( ( before, after ) => before.tag < after.tag ? 1 : -1 );
 
-	// Newest WordPress Image
-	const newestWordPressImage = versions[ 0 ];
+	// Newest WordPress Image but that is not trunk
+	const newestWordPressImage = versions.find( ( { tag } ) => tag !== 'trunk' );
 	console.log( 'The most recent WordPress version available is: ' + chalk.green( newestWordPressImage.tag ) );
 
 	// If the currently used version is the most up to date: exit.


### PR DESCRIPTION
## Description

`trunk`  shouldn't show up as the latest version. Technically it's always the latest code, however, we only want to present actual versions (E.g. 6.0, 5.9.3) when displaying the upgrade notice.

1. Check out PR.
1. Run `npm run build && npm link`
1. Run `vip dev-env start ` on an older environment
1. Verify that trunk is not showing up as the most recent version and is the last 

