### PR TITLE
[dev-env] Optimize tracking

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -68,7 +68,7 @@ command()
 			await startEnvironment( slug, options );
 
 			const processingTime = new Date() - startProcessing;
-			const successTrackingInfo = { ...trackingInfo, processingTime };
+			const successTrackingInfo = { ...trackingInfo, processing_time: processingTime };
 			await trackEvent( 'dev_env_start_command_success', successTrackingInfo );
 		} catch ( error ) {
 			await handleCLIException( error, 'dev_env_start_command_error', trackingInfo );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -434,7 +434,7 @@ export function getEnvTrackingInfo( slug: string ): any {
 		for ( const key of Object.keys( envData ) ) {
 			// track doesnt like camelCase
 			const snakeCasedKey = key.replace( /[A-Z]/g, letter => `_${ letter.toLowerCase() }` );
-			const value = typeof envData[ key ] === 'object' ? JSON.stringify( envData[ key ] ) : envData[ key ];
+			const value = DEV_ENVIRONMENT_COMPONENTS.includes( key ) ? JSON.stringify( envData[ key ] ) : envData[ key ];
 
 			result[ snakeCasedKey ] = value;
 		}

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -434,7 +434,9 @@ export function getEnvTrackingInfo( slug: string ): any {
 		for ( const key of Object.keys( envData ) ) {
 			// track doesnt like camelCase
 			const snakeCasedKey = key.replace( /[A-Z]/g, letter => `_${ letter.toLowerCase() }` );
-			result[ snakeCasedKey ] = envData[ key ];
+			const value = typeof envData[ key ] === 'object' ? JSON.stringify( envData[ key ] ) : envData[ key ];
+
+			result[ snakeCasedKey ] = value;
 		}
 
 		return result;


### PR DESCRIPTION

## Description

Two track related fixes:
* Renames `processingTime` => `processing_time` to avoid event being dropped for camelCase
* JSON stringify complex object to record those too

## Steps to Test

Run with `--debug @automattic/vip:analytics:clients:tracks`

