### PR TITLE
[dev-env] adds tracking to stop subcommand

### DIFF
--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -14,10 +14,12 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
+import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
 import { stopEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
+import { getEnvTrackingInfo } from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -36,12 +38,17 @@ command()
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 
+		const trackingInfo = getEnvTrackingInfo( slug );
+		await trackEvent( 'dev_env_stop_command_execute', trackingInfo );
+
 		try {
 			await stopEnvironment( slug );
 
 			const message = chalk.green( '✓' ) + ' environment stopped.\n';
 			console.log( message );
+
+			await trackEvent( 'dev_env_stop_command_success', trackingInfo );
 		} catch ( error ) {
-			handleCLIException( error );
+			handleCLIException( error, 'dev_env_stop_command_error', trackingInfo );
 		}
 	} );


### PR DESCRIPTION
## Description

Adds tracking to stop subcommand

## Steps to Test
`npm run build && ./dist/bin/vip-dev-env-stop.js --debug`

