### PR TITLE
PIE-3135 - Re-calculate the fileMeta if file gets changed by the searchAndReplace

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -39,6 +39,7 @@ import { formatEnvironment, formatSearchReplaceValues, getGlyphForStatus } from 
 import { ProgressTracker } from 'lib/cli/progress';
 import { isFile } from '../lib/client-file-uploader';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
+import { rollbar } from 'lib/rollbar';
 
 export type WPSiteListType = {
 	id: string,
@@ -378,7 +379,7 @@ command( {
 		const { id: envId, appId } = env;
 		const [ fileName ] = arg;
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
-		const fileMeta = await getFileMeta( fileName );
+		let fileMeta = await getFileMeta( fileName );
 
 		if ( fileMeta.isCompressed ) {
 			console.log(
@@ -464,6 +465,9 @@ Processing the SQL import for your environment...
 			setProgressTrackerPrefixAndSuffix();
 			progressTracker.stopPrinting();
 			progressTracker.print( { clearAfter: true } );
+
+			rollbar.error( failureError );
+
 			exit.withError( failureError );
 		};
 
@@ -487,6 +491,8 @@ Processing the SQL import for your environment...
 			}
 
 			fileNameToUpload = outputFileName;
+			fileMeta = await getFileMeta( fileNameToUpload );
+
 			progressTracker.stepSuccess( 'replace' );
 		} else {
 			progressTracker.stepSkipped( 'replace' );


### PR DESCRIPTION
## Description

This PR fixes a BUG when importing a SQL file using the search and replace method. When using `searchAndReplace`, the file size differs after the fact, and we were using the same fileSize as the original file. This works for most cases, but when the search and replace makes a more significant difference in the file size, the upload part fails because AWS S3 always expects the original file size.

We now re-calculate the complete fileMeta, if the user uses the `searchAndReplace` method.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Run `./dist/bin/vip-import-sql.js @SITEID.develop test-file.sql  --search-replace="https://old-url,htts://new-url --search-replace="https://another-search-and-replace-url,htts://new-search-and-replace-new-url`
4. The import should work always

