### PR TITLE
PIE-3126 - Adds Pendo analytics client

### DIFF
--- a/src/lib/analytics/clients/pendo.js
+++ b/src/lib/analytics/clients/pendo.js
@@ -1,0 +1,97 @@
+// @flow
+
+/**
+ * External dependencies
+ */
+const debug = require( 'debug' )( '@automattic/vip:analytics:clients:pendo' );
+
+/**
+ * Internal dependencies
+ */
+import type { AnalyticsClient } from './client';
+import API from 'lib/api';
+
+/**
+ * Pendo analytics client.
+ */
+
+export default class Pendo implements AnalyticsClient {
+	eventPrefix: string;
+	userAgent: string;
+	userId: string;
+	context: { [ key: string ]: string } = {};
+
+	static get ENDPOINT() {
+		return '/pendo';
+	}
+
+	constructor( {
+		userId,
+		eventPrefix,
+		env,
+	}: {
+		userId: string,
+		eventPrefix: string,
+		env: { [ key: string ]: string }
+	} ) {
+		this.eventPrefix = eventPrefix;
+		this.userAgent = env.userAgent;
+		this.userId = userId;
+		this.context = { ...env };
+	}
+
+	async trackEvent(
+		eventName: string,
+		eventProps: { [ key: string ]: string } = {}
+	): Promise<any> {
+		if ( ! eventName.startsWith( this.eventPrefix ) ) {
+			eventName = this.eventPrefix + eventName;
+		}
+
+		debug( 'trackEvent()', eventProps );
+
+		this.context = {
+			...this.context,
+			org_id: eventProps.org_slug,
+			org_slug: eventProps.org_slug,
+			userAgent: this.userAgent,
+			userId: this.userId,
+		};
+
+		try {
+			return await this.send( eventName, eventProps );
+		} catch ( error ) {
+			debug( error );
+		}
+
+		// Resolve to false instead of rejecting
+		return Promise.resolve( false );
+	}
+
+	async send( eventName: string, eventProps: {} ): Promise<any> {
+		const body = {
+			accountId: this.context.accountId,
+			context: this.context,
+			event: eventName,
+			properties: eventProps,
+			timestamp: Date.now(),
+			type: 'track',
+			visitorId: `${ this.context.userId }`,
+		};
+
+		debug( 'send()', body );
+
+		const { apiFetch } = await API();
+
+		const response = await apiFetch( Pendo.ENDPOINT, {
+			method: 'POST',
+			body,
+		} );
+
+		const responseText = await response.text();
+
+		debug( 'response', responseText );
+
+		return responseText;
+	}
+}

--- a/src/lib/analytics/clients/pendo.js
+++ b/src/lib/analytics/clients/pendo.js
@@ -70,7 +70,6 @@ export default class Pendo implements AnalyticsClient {
 
 	async send( eventName: string, eventProps: {} ): Promise<any> {
 		const body = {
-			accountId: this.context.accountId,
 			context: this.context,
 			event: eventName,
 			properties: eventProps,

--- a/src/lib/analytics/index.js
+++ b/src/lib/analytics/index.js
@@ -15,14 +15,18 @@ const client_info = {
 
 export default class Analytics {
 	constructor( {
-		tracks = new AnalyticsClientStub(),
+		clients = new AnalyticsClientStub(),
 	} ) {
-		this.tracks = tracks;
+		this.clients = clients;
 	}
 
 	async trackEvent( name, props = {} ): Promise {
-		return Promise.all( [
-			this.tracks.trackEvent( name, Object.assign( {}, client_info, props ) ),
-		] );
+		return Promise.all( this.clients.map( client => {
+			return client.trackEvent( name, {
+				// eslint-disable-next-line camelcase
+				...client_info,
+				...props,
+			} );
+		} ) );
 	}
 }

--- a/src/lib/tracker.js
+++ b/src/lib/tracker.js
@@ -8,6 +8,7 @@ const debug = require( 'debug' )( '@automattic/vip:analytics' );
  */
 import Analytics from './analytics/index';
 import Tracks from './analytics/clients/tracks';
+import Pendo from './analytics/clients/pendo';
 import Token from 'lib/token';
 import config from 'root/config/config.json';
 import env from './env';
@@ -17,15 +18,22 @@ let analytics = null;
 async function init(): Promise<Analytics> {
 	const uuid = await Token.uuid();
 
-	const clients = {};
+	const clients = [];
 
 	const tracksUserType = config.tracksUserType;
 	const tracksEventPrefix = config.tracksEventPrefix;
+
 	if ( tracksUserType && tracksEventPrefix ) {
-		clients.tracks = new Tracks( uuid, tracksUserType, tracksEventPrefix, env );
+		clients.push( new Tracks( uuid, tracksUserType, tracksEventPrefix, env ) );
+
+		clients.push( new Pendo( {
+			env,
+			eventPrefix: tracksEventPrefix,
+			userId: uuid,
+		} ) );
 	}
 
-	analytics = new Analytics( clients );
+	analytics = new Analytics( { clients } );
 
 	return analytics;
 }


### PR DESCRIPTION
## Description

This PR introduces Pendo as a new analytics client in addition to the already existent Tracks client.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Run `DEBUG=* ./dist/bin/vip-whoami.js`
4. Verify that logs from `@automattic/vip:analytics:clients:pendo` show up
5. If you have access to Pendo, you can verify that the events were sent, but Pendo may take over one hours to consolidate the data.

