### PR TITLE
[dev-env] Fix failure tracking

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -50,7 +50,7 @@ export async function handleCLIException( exception: Error, trackKey?: string, t
 
 		if ( trackKey ) {
 			try {
-				const errorTrackingInfo = { ...trackBaseInfo, error: message };
+				const errorTrackingInfo = { ...trackBaseInfo, failure: message };
 				await trackEvent( trackKey, errorTrackingInfo );
 			} catch ( trackException ) {
 				console.log( errorPrefix, `Failed to record track event ${ trackKey }`, trackException.message );


### PR DESCRIPTION
## Description

After some digging and help from data-engineering folks, we tracked down the issue. Turns out that any event that has `error` in a custom property is filtered out by some step in the data pipeline. 

To side-step the problem I renamed the property to `failure`.

## Steps to Test

Try to cause some error. E.g. provide path to image instead of folder in media import
`npm run build && ./dist/bin/vip-dev-env-import-media.js ~/Downloads/polar-bear-155118_1280.png --debug`
