### PR TITLE
Move DO_NOT_TRACK handling to Analytics lib

### DIFF
--- a/__tests__/lib/analytics/clients/tracks.js
+++ b/__tests__/lib/analytics/clients/tracks.js
@@ -34,7 +34,6 @@ describe( 'lib/analytics/tracks', () => {
 		beforeEach( () => {
 			jest.resetModules();
 			process.env = { ...OLD_ENV };
-			delete process.env.DO_NOT_TRACK;
 		} );
 
 		afterEach( () => {
@@ -63,20 +62,6 @@ describe( 'lib/analytics/tracks', () => {
 				} );
 
 			return tracksClient.send( params );
-		} );
-
-		it( 'should not send request when DO_NOT_TRACK is truthy', async () => {
-			process.env.DO_NOT_TRACK = 1;
-
-			const tracksClient = new Tracks( 123, 'vip', '', {
-				userAgent: 'vip-cli',
-			} );
-
-			let fetchCalled = false;
-			buildNock().reply( 200, () => fetchCalled = true );
-			const result = await tracksClient.send( { extra: 'param' } );
-			expect( fetchCalled ).toEqual( false );
-			expect( result ).toEqual( 'tracks disabled per DO_NOT_TRACK variable' );
 		} );
 	} );
 

--- a/__tests__/lib/analytics/index.js
+++ b/__tests__/lib/analytics/index.js
@@ -1,0 +1,51 @@
+/**
+ * Internal dependencies
+ */
+import Analytics from 'lib/analytics';
+import AnalyticsClientStub from 'lib/analytics/clients/stub';
+
+describe( 'lib/analytics', () => {
+	describe( '.trackEvent()', () => {
+		const OLD_ENV = process.env;
+
+		afterEach( () => {
+			process.env = OLD_ENV;
+		} );
+
+		it( 'should track events for all clients', async () => {
+			const stubClient1 = new AnalyticsClientStub();
+			const stubClient1Spy = jest.spyOn( stubClient1, 'trackEvent' );
+			const stubClient2 = new AnalyticsClientStub();
+			const stubClient2Spy = jest.spyOn( stubClient2, 'trackEvent' );
+			const analytics = new Analytics( {
+				clients: [
+					stubClient1,
+					stubClient2,
+				],
+			} );
+
+			const result = analytics.trackEvent( 'test_event', {} );
+
+			await expect( result ).resolves.toStrictEqual( [ true, true ] );
+			expect( stubClient1Spy ).toHaveBeenCalledTimes( 1 );
+			expect( stubClient2Spy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should not track events when DO_NOT_TRACK is set', async () => {
+			process.env.DO_NOT_TRACK = 1;
+
+			const stubClient = new AnalyticsClientStub();
+			const stubClientSpy = jest.spyOn( stubClient, 'trackEvent' );
+			const analytics = new Analytics( {
+				clients: [
+					stubClient,
+				],
+			} );
+
+			const result = analytics.trackEvent( 'test_event', {} );
+
+			await expect( result ).resolves.toBe( 'Skipping trackEvent for test_event (DO_NOT_TRACK)' );
+			expect( stubClientSpy ).toHaveBeenCalledTimes( 0 );
+		} );
+	} );
+} );

--- a/src/lib/analytics/clients/stub.js
+++ b/src/lib/analytics/clients/stub.js
@@ -6,6 +6,6 @@ import type { AnalyticsClient } from './client';
 export default class AnalyticsClientStub implements AnalyticsClient {
 	// eslint-disable-next-line no-unused-vars
 	trackEvent( name: string, props: {} ): Promise<Response> {
-		return new Promise( resolve => resolve() );
+		return new Promise( resolve => resolve( true ) );
 	}
 }

--- a/src/lib/analytics/clients/tracks.js
+++ b/src/lib/analytics/clients/tracks.js
@@ -107,12 +107,6 @@ export default class Tracks implements AnalyticsClient {
 	}
 
 	send( extraParams: {} ): Promise<any> {
-		if ( process.env.DO_NOT_TRACK ) {
-			debug( 'send() => skipping per DO_NOT_TRACK variable' );
-
-			return Promise.resolve( 'tracks disabled per DO_NOT_TRACK variable' );
-		}
-
 		const params = Object.assign( {}, this.baseParams, extraParams );
 
 		const method = 'POST';

--- a/src/lib/analytics/index.js
+++ b/src/lib/analytics/index.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies
+ */
+import debugLib from 'debug';
+
+/**
  * Internal dependencies
  */
 import AnalyticsClientStub from './clients/stub';
 import env from '../env';
+
+const debug = debugLib( '@automattic/vip:analytics' );
 
 /* eslint-disable camelcase */
 const client_info = {
@@ -21,6 +28,12 @@ export default class Analytics {
 	}
 
 	async trackEvent( name, props = {} ): Promise {
+		if ( process.env.DO_NOT_TRACK ) {
+			debug( `trackEvent() for ${ name } => skipping per DO_NOT_TRACK variable` );
+
+			return Promise.resolve( `Skipping trackEvent for ${ name } (DO_NOT_TRACK)` );
+		}
+
 		return Promise.all( this.clients.map( client => {
 			return client.trackEvent( name, {
 				// eslint-disable-next-line camelcase


### PR DESCRIPTION
This way each client does not have to bother with implementing it and it's easier to enforce. Without this, for example, we were inadvertently sending stuff to Pendo since it did not factor in DO_NOT_TRACK.

```
DO_NOT_TRACK=1 DEBUG=@automattic/vip:analytics* ./dist/bin/vip-whoami.js
  @automattic/vip:analytics trackEvent() for whoami_command_execute => skipping per DO_NOT_TRACK variable +0ms
  @automattic/vip:analytics trackEvent() for whoami_command_success => skipping per DO_NOT_TRACK variable +375ms
```

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `DEBUG=* ./dist/bin/vip-whoami.js` <= should see analytics tracking
1. Run `DO_NOT_TRACK=1 DEBUG=* ./dist/bin/vip-whoami.js` <= should see debug messages saying tracking was skipped.

