### PR TITLE
[dev-env] Adds domain validation during sql import

### DIFF
--- a/__fixtures__/validations/bad-sql-dev-env.sql
+++ b/__fixtures__/validations/bad-sql-dev-env.sql
@@ -2,3 +2,8 @@ CREATE DATABASE automatticians;
 
 -- for dev-env you should not switch database
 USE automatticians;
+
+INSERT INTO wp_options (option_name, option_value, autoload)
+    VALUES
+        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
+        ('home', 'https://super-empoyees.com', 'yes');

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -91,17 +91,22 @@ describe( 'lib/validations/sql', () => {
 			try {
 				output = '';
 				const sqlFileDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'bad-sql-dev-env.sql' );
-				await validate( sqlFileDumpPath, [] );
+				await validate( sqlFileDumpPath, {
+					isImport: false,
+					skipChecks: [],
+					extraCheckParams: { siteHomeUrlLando: 'test.domain' },
+				} );
 			} catch ( err ) {
 				debug( 'Error:', err.toString() );
 			}
 			debug( 'output', output );
 		} );
 		it( 'use statement', () => {
-			expect( output ).toContain( 'Siteurl/home options pointing to *.vipdev.lndo.site domain was not found' );
+			expect( output ).toContain( 'USE <DATABASE_NAME> statement on' );
 		} );
 		it( 'not correct siteUrl', () => {
-			expect( output ).toContain( 'Siteurl/home options pointing to *.vipdev.lndo.site domain was not found' );
+			expect( output ).toContain( 'Siteurl/home options not pointing to lando domain' );
+			expect( output ).toContain( 'Use \'--search-replace="super-empoyees.com,test.domain"\' switch to replace the domain' );
 		} );
 	} );
 } );

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -98,7 +98,10 @@ describe( 'lib/validations/sql', () => {
 			debug( 'output', output );
 		} );
 		it( 'use statement', () => {
-			expect( output ).toContain( 'USE <DATABASE_NAME> statement on line(s)' );
+			expect( output ).toContain( 'Siteurl/home options pointing to *.vipdev.lndo.site domain was not found' );
+		} );
+		it( 'not correct siteUrl', () => {
+			expect( output ).toContain( 'Siteurl/home options pointing to *.vipdev.lndo.site domain was not found' );
 		} );
 	} );
 } );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -60,7 +60,12 @@ command( {
 			const { resolvedPath, inContainerPath } = await resolveImportPath( slug, fileName, searchReplace, inPlace );
 
 			if ( ! opt.skipValidate ) {
-				await validate( resolvedPath, [] );
+				const expectedDomain = `${ slug }.vipdev.lndo.site`;
+				await validate( resolvedPath, {
+					isImport: false,
+					skipChecks: [],
+					extraCheckParams: { siteHomeUrlLando: expectedDomain },
+				} );
 			}
 
 			const importArg = [ 'wp', 'db', 'import', inContainerPath ];

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -60,7 +60,7 @@ command( {
 			const { resolvedPath, inContainerPath } = await resolveImportPath( slug, fileName, searchReplace, inPlace );
 
 			if ( ! opt.skipValidate ) {
-				await validate( fileName, [] );
+				await validate( resolvedPath, [] );
 			}
 
 			const importArg = [ 'wp', 'db', 'import', inContainerPath ];

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -26,6 +26,7 @@ export type PostLineExecutionProcessingParams = {
     envId?: number,
     fileName?: string,
     isImport?: boolean,
+	skipChecks?: string[],
 }
 
 function openFile( filename, flags = 'r', mode = 666 ) {

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -22,10 +22,10 @@ export type PerLineValidationObject = {
 };
 
 export type PostLineExecutionProcessingParams = {
-    appId?: number,
-    envId?: number,
-    fileName?: string,
-    isImport?: boolean,
+	appId?: number,
+	envId?: number,
+	fileName?: string,
+	isImport?: boolean,
 	skipChecks?: string[],
 }
 

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -251,7 +251,6 @@ const checks: Checks = {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",
 		matchHandler: ( lineNumber, results, expectedDomain ) => {
 			const foundDomain = results[ 2 ].replace( /https?:\/\//, '' );
-			console.log('Check', foundDomain, expectedDomain);
 			if ( ! foundDomain.trim() ) {
 				return { falsePositive: true };
 			}
@@ -403,7 +402,7 @@ const perLineValidations = ( line: string, options: ValidationOptions = DEFAULT_
 	checkForTableName( line );
 
 	const checkKeys = Object.keys( checks ).filter( checkItem => ! options.skipChecks.includes( checkItem ) );
-	for (const checkKey of checkKeys) {
+	for ( const checkKey of checkKeys ) {
 		const check: CheckType = checks[ checkKey ];
 		const results = line.match( check.matcher );
 		const extraCheckParams = options.extraCheckParams[ checkKey ];
@@ -414,7 +413,6 @@ const perLineValidations = ( line: string, options: ValidationOptions = DEFAULT_
 
 	lineNum += 1;
 };
-
 
 const postLineExecutionProcessing = async ( {
 	fileName,

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -215,6 +215,15 @@ const checks: Checks = {
 		excerpt: 'Siteurl/home options',
 		recommendation: '',
 	},
+	siteHomeUrlLando: {
+		matcher: "'(siteurl|home)',\\s?'([^']+vipdev.lndo.site)'",
+		matchHandler: ( lineNumber, results ) => results[ 2 ],
+		outputFormatter: requiredCheckFormatter,
+		results: [],
+		message: 'Siteurl/home options pointing to *.vipdev.lndo.site domain',
+		excerpt: 'Siteurl/home options pointing to lando domain',
+		recommendation: 'Use search-replace to change environment\'s domain',
+	},
 	engineInnoDB: {
 		matcher: / ENGINE=(?!(InnoDB))/i,
 		matchHandler: lineNumber => lineNumber,
@@ -227,6 +236,7 @@ const checks: Checks = {
 			"We suggest you search for all 'ENGINE=X' entries and replace them with 'ENGINE=InnoDB'!",
 	},
 };
+const DEV_ENV_SPECIFIC_CHECKS = [ 'useStatement', 'siteHomeUrlLando' ];
 
 export const postValidation = async ( filename: string, isImport: boolean = false ) => {
 	await trackEvent( 'import_validate_sql_command_execute', { is_import: isImport } );
@@ -346,7 +356,7 @@ const perLineValidations = ( line: string, runAsImport: boolean, skipChecks: str
 	lineNum += 1;
 };
 
-const execute = ( line: string, isImport: boolean = true, skipChecks: string[] = [ 'useStatement' ] ) => {
+const execute = ( line: string, isImport: boolean = true, skipChecks: string[] = DEV_ENV_SPECIFIC_CHECKS ) => {
 	perLineValidations( line, isImport, skipChecks );
 };
 
@@ -363,7 +373,7 @@ export const staticSqlValidations = {
 };
 
 // For standalone SQL validations
-export const validate = async ( filename: string, skipChecks: string[] = [ 'useStatement' ] ) => {
+export const validate = async ( filename: string, skipChecks: string[] = DEV_ENV_SPECIFIC_CHECKS ) => {
 	const readInterface = await getReadInterface( filename );
 	readInterface.on( 'line', line => {
 		execute( line, false, skipChecks );

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -216,7 +216,7 @@ const checks: Checks = {
 		recommendation: '',
 	},
 	siteHomeUrlLando: {
-		matcher: "'(siteurl|home)',\\s?'([^']+vipdev.lndo.site)'",
+		matcher: "'(siteurl|home)',\\s*'([^']+vipdev\\.lndo\\.site)'",
 		matchHandler: ( lineNumber, results ) => results[ 2 ],
 		outputFormatter: requiredCheckFormatter,
 		results: [],

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -422,7 +422,7 @@ const postLineExecutionProcessing = async ( {
 };
 
 export const staticSqlValidations = {
-	perLineValidations,
+	execute: perLineValidations,
 	postLineExecutionProcessing,
 };
 


### PR DESCRIPTION
## Description

This change adds a validation that detects if siteURL is pointing to lando subdomain during DB import. 

If the siteUrl will be kept pointing to a live environment, WordPress will redirect there resulting to local dev-env not actually being used (which is quite confusing). 

## Steps to Test
Should fail without search and replace
```
npm run build && ./dist/bin/vip-dev-env-import-sql.js ~/Downloads/data 
```

Should work after search and replace
```
npm run build && ./dist/bin/vip-dev-env-import-sql.js ~/Downloads/data  --search-replace="pschoffer-develop.go-vip.net,vip-local.vipdev.lndo.site"
```

