### PR TITLE
[dev-env] track dev-env start time in seconds

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -68,7 +68,7 @@ command()
 
 			await startEnvironment( slug, options );
 
-			const processingTime = new Date() - startProcessing;
+			const processingTime = Math.ceil( ( new Date() - startProcessing ) / 1000 ); // in secods
 			const successTrackingInfo = { ...trackingInfo, processing_time: processingTime };
 			await trackEvent( 'dev_env_start_command_success', successTrackingInfo );
 		} catch ( error ) {

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -68,7 +68,7 @@ command()
 
 			await startEnvironment( slug, options );
 
-			const processingTime = Math.ceil( ( new Date() - startProcessing ) / 1000 ); // in secods
+			const processingTime = Math.ceil( ( new Date() - startProcessing ) / 1000 ); // in seconds
 			const successTrackingInfo = { ...trackingInfo, processing_time: processingTime };
 			await trackEvent( 'dev_env_start_command_success', successTrackingInfo );
 		} catch ( error ) {


### PR DESCRIPTION

## Description

We used to track processing_time in milliseconds, which is a bit harder to read for a human (I am told :) ). This change switches to seconds. 

## Steps to Test

```
 npm run build && ./dist/bin/vip-dev-env-start.js --debug @automattic/vip:analytics:clients:tracks
```

