### PR TITLE
[dev-env] Fix healthchecks

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -70,6 +70,8 @@ services:
         - ":3306"
       healthcheck:
         test: 'mysql -uroot --silent --execute "SHOW DATABASES;"'
+        interval: 2s
+        retries: 60
       environment:
         MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
       volumes:
@@ -108,6 +110,8 @@ services:
         - ":9200"
       healthcheck:
         test: "curl --noproxy '*' -XGET localhost:9200"
+        interval: 2s
+        retries: 60
       volumes:
         - search_data:/usr/share/elasticsearch/data
     volumes:

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -109,6 +109,10 @@ async function healthcheckHook( app: App, lando: Lando ) {
 			const containersWithHealthCheck = list.filter( container => container.status.includes( 'health' ) );
 			const notHealthyContainers = containersWithHealthCheck.filter( container => ! container.status.includes( 'healthy' ) );
 
+			for ( const container of containersWithHealthCheck ) {
+				debug( `Health Check result ${ container.service }: ${ container.status }` );
+			}
+
 			if ( notHealthyContainers.length ) {
 				for ( const container of notHealthyContainers ) {
 					console.log( `Waiting for service ${ container.service } ...` );


### PR DESCRIPTION
## Description

The DB container usually needs a few seconds to startup. However, dev-env seems to wait much longer (30s).

The reason is that although we check the state with an interval of 1s, docker-compose only checks every 30s (by default). This change changes the docker-compose interval to 2s. The default docker-compose retries are just 3 so I bumped that too with the much more frequent checks. 

## Steps to Test

1) Create (or update) dev-env
2) `npm run build && ./dist/bin/vip-dev-env-start.js --slug test --debug @automattic/vip:bin:dev-environment`
