### PR TITLE
[dev-env] Fix search popup during wizard

### DIFF
--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -70,6 +70,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			statsd: currentInstanceData.statsd,
 			phpmyadmin: currentInstanceData.phpmyadmin,
 			xdebug: currentInstanceData.xdebug,
+			enterpriseSearchEnabled: currentInstanceData.enterpriseSearchEnabled,
 			mediaRedirectDomain: currentInstanceData.mediaRedirectDomain,
 			multisite: false,
 			title: '',

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -12,6 +12,7 @@ export interface InstanceOptions {
 	statsd?: boolean;
 	phpmyadmin?: boolean;
 	xdebug?: boolean;
+	enterpriseSearchEnabled?: boolean;
 }
 
 export type AppInfo = {


### PR DESCRIPTION

## Description

We were not parsing if the current config has Search enabled or not. This resulted in default being always false even if the current environment has search enabled during update.

```
$ vip dev-env  update
This is a wizard to help you set up your local dev environment.

Sensible default values were pre-selected for convenience. You may also choose to create multiple environments with different settings using the --slug option.


✔ PHP version to use · default
✔ WordPress - Which version would you like · 6.0-RC2
✔ How would you like to source vip-go-mu-plugins · local
✔       What is a path to your local vip-go-mu-plugins · /home/pavel/git/automattic/vip-go-mu-plugins
✔ How would you like to source site-code · local
✔       What is a path to your local site-code · /home/pavel/git/automattic/vip-go-skeleton
? Enable Enterprise Search? (y/N) ‣ false
```

After this change the data is reflected and true is preselected if the dev env already has search running.

` npm run build && ./dist/bin/vip-dev-env-update.js`

