### PR TITLE
[dev-env] Fix healthchecks No. 2

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -101,13 +101,40 @@ function addHooks( app: App, lando: Lando ) {
 	app.events.on( 'post-start', 1, () => healthcheckHook( app, lando ) );
 }
 
+const healthChecks = {
+	database: 'mysql -uroot --silent --execute "SHOW DATABASES;"',
+	'vip-search': "curl -s --noproxy '*' -XGET localhost:9200",
+	php: '[[ -f /wp/wp-includes/pomo/mo.php ]]',
+};
+
 async function healthcheckHook( app: App, lando: Lando ) {
 	try {
 		await lando.Promise.retry( async () => {
 			const list = await lando.engine.list( { project: app.project } );
 
-			const containersWithHealthCheck = list.filter( container => container.status.includes( 'health' ) );
-			const notHealthyContainers = containersWithHealthCheck.filter( container => ! container.status.includes( 'healthy' ) );
+			const notHealthyContainers = [];
+			for ( const container of list ) {
+				if ( healthChecks[ container.service ] ) {
+					try {
+						debug( `Testing ${ container.service }: ${ healthChecks[ container.service ] }` );
+						await app.engine.run( {
+							id: container.id,
+							cmd: healthChecks[ container.service ],
+							compose: app.compose,
+							project: app.project,
+							opts: {
+								silent: true,
+								noTTY: true,
+								cstdio: 'pipe',
+								services: [ container.service ],
+							},
+						} );
+					} catch ( e ) {
+						debug( `${ container.service } Health check failed` );
+						notHealthyContainers.push( container );
+					}
+				}
+			}
 
 			if ( notHealthyContainers.length ) {
 				for ( const container of notHealthyContainers ) {


### PR DESCRIPTION
## Description

The DB container usually needs a few seconds to startup. However, dev-env seems to wait much longer (30s).

The reason is that although we check the state with an interval of 1s, docker-compose only checks every 30s (by default). This change switches from using docker-compose checks to us calling it directly on the container.

## Steps to Test

1) Create (or update) dev-env
2) `npm run build && ./dist/bin/vip-dev-env-start.js --slug test --debug @automattic/vip:bin:dev-environment`
