### PR TITLE
[dev-env] Update/lando compose version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10104,8 +10104,8 @@
       "dev": true
     },
     "lando": {
-      "version": "git+https://github.com/Automattic/lando-cli.git#3289bab60b4cd6011bb8f26397e4aa9ae99d8eb9",
-      "from": "git+https://github.com/Automattic/lando-cli.git#3289bab60b4cd6011bb8f26397e4aa9ae99d8eb9",
+      "version": "git+https://github.com/Automattic/lando-cli.git#3c74058161e51c9f482e6fa2727f616070853b98",
+      "from": "git+https://github.com/Automattic/lando-cli.git#v3.5.2-patch2022_06_20",
       "requires": {
         "@lando/platformsh": "^0.6.0",
         "axios": "0.21.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10104,8 +10104,8 @@
       "dev": true
     },
     "lando": {
-      "version": "git+https://github.com/Automattic/lando-cli.git#2a5c2a4c1b1a428be62d5907d62b4d8c6e659b50",
-      "from": "git+https://github.com/Automattic/lando-cli.git#v3.5.2-patch2022_06_13",
+      "version": "git+https://github.com/Automattic/lando-cli.git#3289bab60b4cd6011bb8f26397e4aa9ae99d8eb9",
+      "from": "git+https://github.com/Automattic/lando-cli.git#3289bab60b4cd6011bb8f26397e4aa9ae99d8eb9",
       "requires": {
         "@lando/platformsh": "^0.6.0",
         "axios": "0.21.4",
@@ -10865,9 +10865,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
-      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.3.tgz",
+      "integrity": "sha512-N0BOsdFAlNRfmwMhjAsLVWOk7Ljmeb39iqFlsV1At+jqRhSUP9yeof8FyJu4imaJiSUp8vQebWD/guZwGQC8iA==",
       "requires": {
         "yallist": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ini": "2.0.0",
     "json2csv": "5.0.6",
     "jwt-decode": "2.2.0",
-    "lando": "git+https://github.com/Automattic/lando-cli.git#3289bab60b4cd6011bb8f26397e4aa9ae99d8eb9",
+    "lando": "git+https://github.com/Automattic/lando-cli.git#v3.5.2-patch2022_06_20",
     "node-fetch": "^2.6.1",
     "opn": "5.5.0",
     "proxy-from-env": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "ini": "2.0.0",
     "json2csv": "5.0.6",
     "jwt-decode": "2.2.0",
-    "lando": "git+https://github.com/Automattic/lando-cli.git#v3.5.2-patch2022_06_13",
+    "lando": "git+https://github.com/Automattic/lando-cli.git#3289bab60b4cd6011bb8f26397e4aa9ae99d8eb9",
     "node-fetch": "^2.6.1",
     "opn": "5.5.0",
     "proxy-from-env": "^1.1.0",


### PR DESCRIPTION
## Description

The logic to get `docker-compose` version doesn't work on `darwin 21.x.x`. This change pulls workaround:
https://github.com/Automattic/lando-cli/pull/7

## Steps to Test

npm run build && ./dist/bin/vip-dev-env-info.js

