### PR TITLE
[dev-env] Makes exec attempt to run the task even if env seems to be down

### DIFF
--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -36,6 +36,7 @@ const examples = [
 
 command( { wildcardCommand: true } )
 	.option( 'slug', 'Custom name of the dev environment' )
+	.option( 'force', 'Disabling validations before task execution', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		await validateDependencies();
@@ -57,7 +58,8 @@ command( { wildcardCommand: true } )
 				arg = process.argv.slice( argSplitterIx + 1 );
 			}
 
-			await exec( slug, arg );
+			const options = { force: opt.force };
+			await exec( slug, arg, options );
 			await trackEvent( 'dev_env_exec_command_success', trackingInfo );
 		} catch ( error ) {
 			handleCLIException( error, 'dev_env_exec_command_error', trackingInfo );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -206,8 +206,8 @@ export async function printEnvironmentInfo( slug: string ) {
 	printTable( appInfo );
 }
 
-export async function exec( slug: string, args: Array<string> ) {
-	debug( 'Will run a wp command on env', slug, 'with args', args );
+export async function exec( slug: string, args: Array<string>, options: any = {}) {
+	debug( 'Will run a wp command on env', slug, 'with args', args, ' and options', options );
 
 	const instancePath = getEnvironmentPath( slug );
 
@@ -226,7 +226,7 @@ export async function exec( slug: string, args: Array<string> ) {
 		commandArgs = [ ...args.map( argument => argument.replace( '--new-site-', '--' ) ) ];
 	}
 
-	await landoExec( instancePath, command, commandArgs );
+	await landoExec( instancePath, command, commandArgs, options );
 }
 
 export function doesEnvironmentExist( slug: string ): boolean {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -206,7 +206,7 @@ export async function printEnvironmentInfo( slug: string ) {
 	printTable( appInfo );
 }
 
-export async function exec( slug: string, args: Array<string>, options: any = {}) {
+export async function exec( slug: string, args: Array<string>, options: any = {} ) {
 	debug( 'Will run a wp command on env', slug, 'with args', args, ' and options', options );
 
 	const instancePath = getEnvironmentPath( slug );

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -269,17 +269,19 @@ async function isEnvUp( app ) {
 	return scanResult?.length && scanResult.filter( result => result.status ).length === scanResult.length;
 }
 
-export async function landoExec( instancePath: string, toolName: string, args: Array<string> ) {
+export async function landoExec( instancePath: string, toolName: string, args: Array<string>, options: any ) {
 	const lando = new Lando( getLandoConfig() );
 	await lando.bootstrap();
 
 	const app = lando.getApp( instancePath );
 	await app.init();
 
-	const isUp = await isEnvUp( app );
+	if ( ! options.force ) {
+		const isUp = await isEnvUp( app );
 
-	if ( ! isUp ) {
-		throw new Error( 'environment needs to be started before running wp command' );
+		if ( ! isUp ) {
+			throw new Error( 'environment needs to be started before running wp command' );
+		}
 	}
 
 	const tool = app.config.tooling[ toolName ];

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -129,7 +129,7 @@ async function healthcheckHook( app: App, lando: Lando ) {
 								services: [ container.service ],
 							},
 						} );
-					} catch ( e ) {
+					} catch ( exception ) {
 						debug( `${ container.service } Health check failed` );
 						notHealthyContainers.push( container );
 					}


### PR DESCRIPTION
## Description

The environment is considered up if all its public URLs are accessible from the terminal. In most cases, this is what we want. However, there might be some network issue making the site "look" down while it is actually running. This issue should be discovered and solved.

However, as a workaround, we can provide users the ability to skip the check for the env status so that they can still use cli commands. 

## Steps to Test

Run `npm run build && ./dist/bin/vip-dev-env-exec.js --force  -- wp post list` (it will still fail later if the env isn't started, but it is possibly to run it)

