### PR TITLE
[dev-env] Update debug instruction example

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -60,9 +60,9 @@ export async function handleCLIException( exception: Error, trackKey?: string, t
 		}
 
 		if ( ! process.env.DEBUG ) {
-			console.log( `Please re-run the command with "--debug ${ chalk.bold( '@automattic/vip:bin:dev-environment' ) }" appended to it and provide the stack trace on the support ticket.` );
+			console.log( `\nPlease re-run the command with "--debug ${ chalk.bold( '@automattic/vip:bin:dev-environment' ) }" appended to it and provide the stack trace on the support ticket.` );
 			console.log( chalk.bold( '\nExample:\n' ) );
-			console.log( 'vip dev-env create --debug @automattic/vip:bin:dev-environment \n' );
+			console.log( 'vip dev-env <command> <arguments> --debug @automattic/vip:bin:dev-environment \n' );
 		}
 
 		debug( exception );


### PR DESCRIPTION
## Description

Having `create` in example on how to use `--debug` can be confusing if you run other subcommand.

So it might be better to put placeholders to highlight that the `--debug @automattic/vip:bin:dev-environment` 

## Steps to Test

```
$ npm run build && ./dist/bin/vip-dev-env-import-sql.js /test.sql
...
Error: The provided file does not exist or it is not valid (see "--help" for examples)

Please re-run the command with "--debug @automattic/vip:bin:dev-environment" appended to it and provide the stack trace on the support ticket.

Example:

vip dev-env <command> <arguments> --debug @automattic/vip:bin:dev-environment 

```

