### PR TITLE
Update engines to show support for npm > 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "license": "MIT",
   "engines": {
     "node": ">=14.14.0",
-    "npm": "^6 "
+    "npm": ">6"
   },
   "bugs": {
     "url": "https://github.com/Automattic/vip/issues"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "license": "MIT",
   "engines": {
     "node": ">=14.14.0",
-    "npm": ">6"
+    "npm": ">=6"
   },
   "bugs": {
     "url": "https://github.com/Automattic/vip/issues"


### PR DESCRIPTION
`vip` works fine with npm 6 + 8. This will prevent npm from throwing a warning on install / update.

See BB8-9424

Props @GaryJones