### PR TITLE
[dev-env] Change wizard wording

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -205,7 +205,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		instanceData[ component ] = result;
 	}
 
-	instanceData.enterpriseSearchEnabled = await promptForBoolean( 'Enable Enterprise Search?', defaultOptions.enterpriseSearchEnabled );
+	instanceData.enterpriseSearchEnabled = await promptForBoolean( 'Enable Elasticsearch (needed by Enterprise Search)?', defaultOptions.enterpriseSearchEnabled );
 	if ( instanceData.enterpriseSearchEnabled ) {
 		instanceData.statsd = preselectedOptions.statsd || defaultOptions.statsd || false;
 	} else {


### PR DESCRIPTION
## Description

Dev-env wizzard would ask if:
`Enable Enterprise Search?`
This can be a bit confusing as this option would decide if elasticsearch container would be spinned up or not. If the Enterprise search would be enabled is only controlled by the constants as in regular site.

## Steps to Test


```
$ npm run build && ./dist/bin/vip-dev-env-create.js --slug test
...
This is a wizard to help you set up your local dev environment.

Sensible default values were pre-selected for convenience. You may also choose to create multiple environments with different settings using the --slug option.


✔ WordPress site title · VIP Dev
✔ Multisite (y/N) · false
✔ PHP version to use · default
✔ WordPress - Which version would you like · 6.0
✔ How would you like to source vip-go-mu-plugins · image
✔ How would you like to source site-code · image
? Enable Elasticsearch (needed by Enterprise Search)? (y/N) ‣ false
```

