### PR TITLE
[dev-env] Remove redundant healthchecks

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -68,8 +68,6 @@ services:
       command: docker-entrypoint.sh mysqld
       ports:
         - ":3306"
-      healthcheck:
-        test: 'mysql -uroot --silent --execute "SHOW DATABASES;"'
       environment:
         MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
       volumes:
@@ -106,8 +104,6 @@ services:
         discovery.type: 'single-node'
       ports:
         - ":9200"
-      healthcheck:
-        test: "curl --noproxy '*' -XGET localhost:9200"
       volumes:
         - search_data:/usr/share/elasticsearch/data
     volumes:


### PR DESCRIPTION
## Description

We have now moved healthchecks [here](https://github.com/Automattic/vip/blob/6b463c87a29c89e8fc6e9369fa31cdeffd241f7e/src/lib/dev-environment/dev-environment-lando.js#L104) and we run them after env start before bootstrap and then we stop running them.

There is no need to also run them by docker all the time.
 
## Steps to Test

```
npm run build && ./dist/bin/vip-dev-env-create.js --slug test
npm run build && ./dist/bin/vip-dev-env-start.js --slug test
```

