### PR TITLE
FORNO-1254: SQL Import: Add multisite primary domain validation

### DIFF
--- a/__fixtures__/validations/multiline-statements.sql
+++ b/__fixtures__/validations/multiline-statements.sql
@@ -2,18 +2,21 @@ INSERT INTO `wp_site` (`id`, `domain`, `path`)
 VALUES
 	(1,'www.example.com','/');
 
-INSERT INTO wp_options (option_name, option_value, autoload)
-    VALUES
-        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
-        ('home', 'https://super-empoyees.com', 'yes');
+INSERT INTO wp_blogs VALUES (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
 
-INSERT INTO wp_options (option_name, option_value, autoload)
+INSERT INTO wp_blogs (blog_id, site_id, domain, path, registered, last_updated, public, archived, mature, spam, deleted, lang_id)
     VALUES
-        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
-        ('home', 'https://super-empoyees.com', 'yes');
+       (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
 
-INSERT INTO wp_options (option_name, option_value, autoload)
+INSERT INTO wp_blogs (blog_id, site_id, domain, path, registered, last_updated, public, archived, mature, spam, deleted, lang_id)
     VALUES
-        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
-        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
-        ('blogname','super-employees-go.vip.net','yes');
+       (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0),
+       (2,1,'www.example.com','/2/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
+
+INSERT INTO wp_blogs (blog_id, site_id, domain, path, registered, last_updated, public, archived, mature, spam, deleted, lang_id)
+    VALUES
+        (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0),
+        (2,1,'www.example.com','/2/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0),
+        (3,1,'www.example.com','/3/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
+
+

--- a/__fixtures__/validations/multiline-statements.sql
+++ b/__fixtures__/validations/multiline-statements.sql
@@ -1,0 +1,19 @@
+INSERT INTO `wp_site` (`id`, `domain`, `path`)
+VALUES
+	(1,'www.example.com','/');
+
+INSERT INTO wp_options (option_name, option_value, autoload)
+    VALUES
+        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
+        ('home', 'https://super-empoyees.com', 'yes');
+
+INSERT INTO wp_options (option_name, option_value, autoload)
+    VALUES
+        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
+        ('home', 'https://super-empoyees.com', 'yes');
+
+INSERT INTO wp_options (option_name, option_value, autoload)
+    VALUES
+        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
+        ('siteurl', 'https://super-employees-go.vip.net', 'yes'),
+        ('blogname','super-employees-go.vip.net','yes');

--- a/__tests__/lib/validations/is-multisite-domain-mapped.js
+++ b/__tests__/lib/validations/is-multisite-domain-mapped.js
@@ -1,0 +1,102 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import nock from 'nock';
+import url from 'url';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getPrimaryDomainFromSQL,
+	maybeSearchReplacePrimaryDomain,
+	getPrimaryDomain,
+	isMultisitePrimaryDomainMapped,
+} from 'lib/validations/is-multisite-domain-mapped';
+
+import { API_URL } from 'lib/api';
+
+describe( 'is-multisite-domain-mapped', () => {
+	const capturedStatement = [
+		[
+			'INSERT INTO `wp_site` (`id`, `domain`, `path`)',
+			'VALUES',
+			"\t(1,'www.example.com','/');",
+		],
+	];
+
+	describe( 'getPrimaryDomainFromSQL', () => {
+		it( 'should extract the domain from a wp_site INSERT statement', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			expect( domain ).toEqual( 'www.example.com' );
+		} );
+	} );
+
+	describe( 'maybeSearchReplacePrimaryDomain', () => {
+		it( 'should replace the domain if there are matching replacements', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			const replacedDomain = maybeSearchReplacePrimaryDomain( domain, 'www.example.com,www.newdomain.com' );
+			expect( replacedDomain ).toEqual( 'www.newdomain.com' );
+		} );
+
+		it( 'should handle multiple replacements', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			const replacedDomain = maybeSearchReplacePrimaryDomain( domain, [ 'example.com,newdomain.com', 'www.example.com,www.newdomain.com' ] );
+			expect( replacedDomain ).toEqual( 'www.newdomain.com' );
+		} );
+
+		it( 'should return return the original domain if no matching replacements', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			const replacedDomain = maybeSearchReplacePrimaryDomain( domain, 'example.com,www.newdomain.com' );
+			expect( replacedDomain ).toEqual( domain );
+		} );
+	} );
+
+	describe( 'getPrimaryDomain', () => {
+		it( 'should return the domain from wp_site INSERT statement', () => {
+			const domain = getPrimaryDomain( capturedStatement );
+			expect( domain ).toEqual( 'www.example.com' );
+		} );
+
+		it( 'should apply relevant search-replacements to the domain found in the wp_site INSERT statement', () => {
+			const domain = getPrimaryDomain( capturedStatement, 'www.example.com,www.newdomain.com' );
+			expect( domain ).toEqual( 'www.newdomain.com' );
+		} );
+	} );
+
+	describe( 'isMultisitePrimaryDomainMapped', () => {
+		it( 'return true if the domain is mapped to the environment', async () => {
+			const {
+				protocol,
+				host,
+				path,
+			} = url.parse( API_URL );
+
+			nock( `${ protocol }//${ host }` ).post( path ).reply( 200, {
+				data: {
+					app: {
+						environments: [
+							{
+								domains: {
+									nodes: [
+										{
+											name: 'www.example.com',
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+			} );
+
+			const isMapped = await isMultisitePrimaryDomainMapped( 1, 1, 'www.example.com' );
+			expect( isMapped ).toEqual( true );
+			nock.cleanAll();
+		} );
+	} );
+} );

--- a/__tests__/lib/validations/utils.js
+++ b/__tests__/lib/validations/utils.js
@@ -19,7 +19,7 @@ describe( 'utils', () => {
 			const sqlDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'multiline-statements.sql' );
 			const readInterface = await getReadInterface( sqlDumpPath );
 
-			const getStatementsByLine = getMultilineStatement( /INSERT INTO wp_options/s );
+			const getStatementsByLine = getMultilineStatement( /INSERT INTO wp_blogs/s );
 
 			let statements;
 			readInterface.on( 'line', line => {
@@ -29,10 +29,12 @@ describe( 'utils', () => {
 			await new Promise( resolveBlock => readInterface.on( 'close', resolveBlock ) );
 
 			// expecting the correct number of matching statements
-			expect( statements ).toHaveLength( 3 );
+			expect( statements ).toHaveLength( 4 );
 			// expecting the statement to have the right number of lines
-			expect( statements[ 0 ] ).toHaveLength( 4 );
-			expect( statements[ 2 ] ).toHaveLength( 5 );
+			expect( statements[ 0 ] ).toHaveLength( 1 );
+			expect( statements[ 1 ] ).toHaveLength( 3 );
+			expect( statements[ 2 ] ).toHaveLength( 4 );
+			expect( statements[ 3 ] ).toHaveLength( 5 );
 		} );
 
 		it( 'should accurately capture the statement', async () => {
@@ -47,8 +49,7 @@ describe( 'utils', () => {
 			} );
 
 			await new Promise( resolveBlock => readInterface.on( 'close', resolveBlock ) );
-
-			expect( statements[ 0 ].join( ',' ).replace( /\s/g, '' ) ).toBe( "INSERTINTO`wp_site`(`id`,`domain`,`path`),VALUES,(1,'www.example.com','/');" );
+			expect( statements[ 0 ].join( '' ).replace( /\s/g, '' ) ).toBe( "INSERTINTO`wp_site`(`id`,`domain`,`path`)VALUES(1,'www.example.com','/');" );
 		} );
 	} );
 } );

--- a/__tests__/lib/validations/utils.js
+++ b/__tests__/lib/validations/utils.js
@@ -1,0 +1,54 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { getMultilineStatement } from 'lib/validations/utils';
+import { getReadInterface } from 'lib/validations/line-by-line';
+
+describe( 'utils', () => {
+	describe( 'getMultilineStatement', () => {
+		it( 'should return each occurance of a statement as an array of its lines', async () => {
+			const sqlDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'multiline-statements.sql' );
+			const readInterface = await getReadInterface( sqlDumpPath );
+
+			const getStatementsByLine = getMultilineStatement( /INSERT INTO wp_options/s );
+
+			let statements;
+			readInterface.on( 'line', line => {
+				statements = getStatementsByLine( line );
+			} );
+
+			await new Promise( resolveBlock => readInterface.on( 'close', resolveBlock ) );
+
+			// expecting the correct number of matching statements
+			expect( statements ).toHaveLength( 3 );
+			// expecting the statement to have the right number of lines
+			expect( statements[ 0 ] ).toHaveLength( 4 );
+			expect( statements[ 2 ] ).toHaveLength( 5 );
+		} );
+
+		it( 'should accurately capture the statement', async () => {
+			const sqlDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'multiline-statements.sql' );
+			const readInterface = await getReadInterface( sqlDumpPath );
+
+			const getStatementsByLine = getMultilineStatement( /INSERT INTO `wp_site`/s );
+
+			let statements;
+			readInterface.on( 'line', line => {
+				statements = getStatementsByLine( line );
+			} );
+
+			await new Promise( resolveBlock => readInterface.on( 'close', resolveBlock ) );
+
+			expect( statements[ 0 ].join( ',' ).replace( /\s/g, '' ) ).toBe( "INSERTINTO`wp_site`(`id`,`domain`,`path`),VALUES,(1,'www.example.com','/');" );
+		} );
+	} );
+} );

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -238,6 +238,7 @@ export type validateAndGetTableNamesInputType = {
 	appId: number,
 	envId: number,
 	fileNameToUpload: string,
+	searchReplace?: string | array,
 };
 
 export async function validateAndGetTableNames( {
@@ -245,6 +246,7 @@ export async function validateAndGetTableNames( {
 	appId,
 	envId,
 	fileNameToUpload,
+	searchReplace,
 }: validateAndGetTableNamesInputType ): Promise<Array<string>> {
 	const validations = [ staticSqlValidations, siteTypeValidations ];
 	if ( skipValidate ) {
@@ -252,7 +254,7 @@ export async function validateAndGetTableNames( {
 		return [];
 	}
 	try {
-		await fileLineValidations( appId, envId, fileNameToUpload, validations );
+		await fileLineValidations( appId, envId, fileNameToUpload, validations, searchReplace );
 	} catch ( validateErr ) {
 		console.log( '' );
 		exit.withError( `${ validateErr.message }
@@ -415,6 +417,7 @@ command( {
 			appId,
 			envId,
 			fileNameToUpload,
+			searchReplace,
 		} );
 
 		// display playbook of what will happen during execution

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -257,7 +257,7 @@ export async function validateAndGetTableNames( {
 		await fileLineValidations( appId, envId, fileNameToUpload, validations, searchReplace );
 	} catch ( validateErr ) {
 		console.log( '' );
-		exit.withError( `${ validateErr.message }
+		exit.withError( `${ validateErr.message }\n
 If you are confident the file does not contain unsupported statements, you can retry the command with the ${ chalk.yellow( '--skip-validate' ) } option.
 ` );
 	}

--- a/src/lib/validations/is-multisite-domain-mapped.js
+++ b/src/lib/validations/is-multisite-domain-mapped.js
@@ -56,7 +56,7 @@ export async function isMultisitePrimaryDomainMapped(
 	appId: number,
 	envId: number,
 	primaryDomainFromSQL: array
-): Promise< boolean > {
+): Promise<boolean> {
 	const track = trackEventWithEnv.bind( null, appId, envId );
 
 	const api = await API();

--- a/src/lib/validations/is-multisite-domain-mapped.js
+++ b/src/lib/validations/is-multisite-domain-mapped.js
@@ -1,0 +1,108 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+import { trackEventWithEnv } from 'lib/tracker';
+import * as exit from 'lib/cli/exit';
+
+/**
+ * Extracts the domain for site with ID 1 from an INSERT INTO `wp_site` SQL statement
+ *
+ * @param {array} statements An array of SQL statements
+ * @returns {string} The domain
+ */
+export const getPrimaryDomainFromSQL = statements => {
+	if ( ! statements.length ) {
+		return '';
+	}
+
+	const SQL_WP_SITE_DOMAINS_REGEX = /\(1\s*,\s*'(.*?)'/s;
+	const matches = statements[ 0 ]?.join( '' ).match( SQL_WP_SITE_DOMAINS_REGEX );
+	return matches ? matches[ 1 ] : '';
+};
+
+/**
+ * Checks whether a domain is in a list of domains
+ *
+ * @param {string} domainToFind The domain to look for in the list
+ * @param {array} domains An array of domains mapped to the environment
+ * @returns {boolean} Whether the primary domain is in the list of mapped domains
+ */
+const isPrimaryDomainMapped = ( domainToFind, domains ) => {
+	// TODO: Should also check if the domain is found in any search-replace `to` values
+	// If so, we should consider the domain mapped
+	return domains.some( domain => domain === domainToFind );
+};
+
+/**
+ * Gets the mapped domains and checks if the primary domain from the provided SQL dump is one of them
+ *
+ * @param {number} appId The ID of the app in GOOP
+ * @param {number} envId The ID of the enviroment in GOOP
+ * @param {array} primaryDomainFromSQL The primary domain found in the provided SQL file
+ * @returns {boolean} Whether the primary domain is mapped
+ */
+export async function isMultisitePrimaryDomainMapped(
+	appId: number,
+	envId: number,
+	primaryDomainFromSQL: array
+): Promise< boolean > {
+	const track = trackEventWithEnv.bind( null, appId, envId );
+
+	const api = await API();
+	let res;
+	try {
+		res = await api.query( {
+			query: gql`
+				query AppMappedDomains($appId: Int, $envId: Int) {
+					app(id: $appId) {
+						id
+						name
+						environments(id: $envId) {
+							uniqueLabel
+							isMultisite
+							domains {
+								nodes {
+									name
+									isPrimary
+								}
+							}
+						}
+					}
+				}
+			`,
+			variables: {
+				appId,
+				envId,
+			},
+		} );
+	} catch ( GraphQlError ) {
+		await track( 'import_sql_command_error', {
+			error_type: 'GraphQL-MappedDomain-Check-failed',
+			gql_err: GraphQlError,
+		} );
+		exit.withError( `StartImport call failed: ${ GraphQlError }` );
+	}
+
+	if ( ! Array.isArray( res?.data?.app?.environments ) ) {
+		return false;
+	}
+
+	const environments = res.data.app.environments;
+	if ( ! environments.length ) {
+		return false;
+	}
+
+	const mappedDomains = environments[ 0 ]?.domains?.nodes?.map( domain => domain.name );
+	return isPrimaryDomainMapped( primaryDomainFromSQL, mappedDomains );
+}

--- a/src/lib/validations/is-multisite-domain-mapped.js
+++ b/src/lib/validations/is-multisite-domain-mapped.js
@@ -38,7 +38,7 @@ export const getPrimaryDomainFromSQL = ( statements: array ) => {
  * @param {(string|array)} searchReplace The search-replace pairs
  * @returns {string} The processed domain
  */
-const maybeSearchReplacePrimaryDomain = function( domain: string, searchReplace?: string | array ) {
+export const maybeSearchReplacePrimaryDomain = function( domain: string, searchReplace?: string | array ) {
 	if ( searchReplace ) {
 		let pairs = searchReplace;
 		if ( ! Array.isArray( pairs ) ) {
@@ -112,7 +112,6 @@ export async function isMultisitePrimaryDomainMapped(
 		} );
 		exit.withError( `StartImport call failed: ${ GraphQlError }` );
 	}
-
 	if ( ! Array.isArray( res?.data?.app?.environments ) ) {
 		return false;
 	}
@@ -123,5 +122,6 @@ export async function isMultisitePrimaryDomainMapped(
 	}
 
 	const mappedDomains = environments[ 0 ]?.domains?.nodes?.map( domain => domain.name );
+
 	return mappedDomains.includes( primaryDomain );
 }

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -27,6 +27,7 @@ export type PostLineExecutionProcessingParams = {
 	fileName?: string,
 	isImport?: boolean,
 	skipChecks?: string[],
+	searchReplace?: string | array,
 }
 
 function openFile( filename, flags = 'r', mode = 666 ) {
@@ -55,7 +56,7 @@ export async function getReadInterface( filename: string ) {
 	} );
 }
 
-export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject> ) {
+export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject>, searchReplace: string | array ) {
 	const isImport = true;
 	const readInterface = await getReadInterface( fileName );
 
@@ -77,7 +78,7 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 
 	return Promise.all( validations.map( async validation => {
 		if ( validation.hasOwnProperty( 'postLineExecutionProcessing' ) && typeof validation.postLineExecutionProcessing === 'function' ) {
-			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
+			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId, searchReplace } );
 		}
 	} ) );
 }

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -74,7 +74,9 @@ export const siteTypeValidations = {
 				error_type: 'multisite-import-where-primary-domain-unmapped',
 			} );
 			throw new Error(
-				`This import would set the network's main site domain to ${ primaryDomainFromSQL }, however this domain is not mapped to the target environment.`
+				'This import would set the network\'s main site domain to ' + primaryDomainFromSQL +
+				', however this domain is not mapped to the target environment. Please replace this domain in your ' +
+				'import file, or map it to the environment.'
 			);
 		}
 	},

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -16,7 +16,7 @@ import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
 import {
 	isMultisitePrimaryDomainMapped,
-	getPrimaryDomainFromSQL,
+	getPrimaryDomain,
 } from 'lib/validations/is-multisite-domain-mapped';
 import { getMultilineStatement } from 'lib/validations/utils';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
@@ -36,9 +36,9 @@ export const siteTypeValidations = {
 			isMultiSiteSqlDump = true;
 		}
 	},
-	postLineExecutionProcessing: async ( { appId, envId }: PostLineExecutionProcessingParams ) => {
+	postLineExecutionProcessing: async ( { appId, envId, searchReplace }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
-		const primaryDomainFromSQL = getPrimaryDomainFromSQL( wpSiteInsertStatement );
+		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
 		const isPrimaryDomainMapped =
 			primaryDomainFromSQL &&
 			( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
@@ -74,7 +74,7 @@ export const siteTypeValidations = {
 				error_type: 'multisite-import-where-primary-domain-unmapped',
 			} );
 			throw new Error(
-				`The SQL dump provided would set the network's main site domain to ${ primaryDomainFromSQL }, however this domain is not mapped to the target environment.`
+				`This import would set the network's main site domain to ${ primaryDomainFromSQL }, however this domain is not mapped to the target environment.`
 			);
 		}
 	},

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -14,21 +14,34 @@ import debugLib from 'debug';
 import { trackEventWithEnv } from 'lib/tracker';
 import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
+import {
+	isMultisitePrimaryDomainMapped,
+	getPrimaryDomainFromSQL,
+} from 'lib/validations/is-multisite-domain-mapped';
+import { getMultilineStatement } from 'lib/validations/utils';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
 
 const debug = debugLib( 'vip:vip-import-sql' );
 
 let isMultiSiteSqlDump = false;
+let wpSiteInsertStatement;
+const getWpSiteInsertStatement = getMultilineStatement( /INSERT INTO `wp_site`/s );
 
 export const siteTypeValidations = {
 	execute: ( line: string ) => {
 		const lineIsMultiSite = sqlDumpLineIsMultiSite( line );
+		wpSiteInsertStatement = getWpSiteInsertStatement( line );
+
 		if ( lineIsMultiSite ) {
 			isMultiSiteSqlDump = true;
 		}
 	},
 	postLineExecutionProcessing: async ( { appId, envId }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
+		const primaryDomainFromSQL = getPrimaryDomainFromSQL( wpSiteInsertStatement );
+		const isPrimaryDomainMapped =
+			primaryDomainFromSQL &&
+			( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
@@ -53,6 +66,15 @@ export const siteTypeValidations = {
 			} );
 			throw new Error(
 				'You have requested a subsite SQL import but have not provided a subsite compatiable SQL dump.'
+			);
+		}
+
+		if ( isMultiSite && ! isPrimaryDomainMapped ) {
+			await track( 'import_sql_command_error', {
+				error_type: 'multisite-import-where-primary-domain-unmapped',
+			} );
+			throw new Error(
+				`The SQL dump provided would set the network's main site domain to ${ primaryDomainFromSQL }, however this domain is not mapped to the target environment.`
 			);
 		}
 	},

--- a/src/lib/validations/utils.js
+++ b/src/lib/validations/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Get SQL statements matching a supplied pattern from a file stream
+ *
+ * @param {RegExp} statementRegex A RegExp pattern representing the start of the statement to capture
+ * @returns {function} A function which processes individual lines to capture the matching statements
+ */
+export function getMultilineStatement( statementRegex ) {
+	const matchingStatements = [];
+	let isCapturing = false;
+	let index = 0;
+
+	/**
+	 * Processes each line of the file stream and builds an array of statements which start with the supplied pattern
+	 *
+	 * @param {string} line A line from the file stream
+	 * @returns {array} An array of matching statements where each statement is presented as an array of lines
+	 */
+	return line => {
+		const shouldStartCapture = statementRegex.test( line );
+		const shouldEndCapture = isCapturing && /;$/.test( line );
+		if ( shouldStartCapture ) {
+			isCapturing = true;
+			matchingStatements[ index ] = [];
+		}
+
+		if ( isCapturing ) {
+			matchingStatements[ index ].push( line );
+		}
+
+		if ( shouldEndCapture ) {
+			isCapturing = false;
+			index++;
+		}
+
+		return matchingStatements;
+	};
+}

--- a/src/lib/validations/utils.js
+++ b/src/lib/validations/utils.js
@@ -17,7 +17,7 @@ export function getMultilineStatement( statementRegex ) {
 	 */
 	return line => {
 		const shouldStartCapture = statementRegex.test( line );
-		const shouldEndCapture = isCapturing && /;$/.test( line );
+		const shouldEndCapture = ( shouldStartCapture || isCapturing ) && /;$/.test( line );
 		if ( shouldStartCapture ) {
 			isCapturing = true;
 			matchingStatements[ index ] = [];


### PR DESCRIPTION
## Description

Adds a validation for multisite imports to check that the primary domain specified in the SQL dump is mapped to the  environment targeted for import. (Currently this is only validated after the file has been imported into the target DB which can cause the site to be locked for further imports.)

SQL dumps are currently validated line-by-line. However this particular validation needs to read the value that will be inserted into the DB from a potentially multiline statement like this:

```
INSERT INTO `wp_site` (`id`, `domain`, `path`)
VALUES
	(1,'www.example.com','/');
```

This PR adds a [helper function](https://github.com/Automattic/vip/pull/1064/files#diff-394caca4a5c6624bc99a610da97c9966a5686b23ae4bdb98e4cd53d565a4e484) to make validating multiline statements possible using the line-by-line approach.

## Steps to Test

1. Check out PR
1. Run `npm run build`
2. Select a test multisite application and export its DB
3. Edit the SQL dump, changing the  value of the `INSERT INTO wp_site` statement to a domain which is not mapped to the environment 
1. Run `node ./dist/bin/vip-import-sql.js @<id>.<environment> path_to_sql_file.sql`
1. Verify [an error is thrown](https://github.com/Automattic/vip/pull/1064/files#diff-62922613b6c15d1b6618432ef6421a2b9c2a0a467d9dd57a5883f5ad080ec4beR76-R77) and the command exits

