### PR TITLE
[dev-env] Update default software versions for PHP and Elasticsearch

### DIFF
--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -4,9 +4,9 @@ export const DEV_ENVIRONMENT_FULL_COMMAND = `vip ${ DEV_ENVIRONMENT_SUBCOMMAND }
 export const DEV_ENVIRONMENT_DEFAULTS = {
 	title: 'VIP Dev',
 	multisite: false,
-	elasticsearchVersion: '7.10.1',
+	elasticsearchVersion: '7.17.2',
 	mariadbVersion: '10.3',
-	phpImage: 'default',
+	phpVersion: '8.0',
 };
 
 export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up your local dev environment.\n\n' +
@@ -25,10 +25,9 @@ export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
 export const DEV_ENVIRONMENT_PHP_VERSIONS = {
-	default: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
-	// eslint-disable-next-line quote-props -- flow does nit support non-string keys
-	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:7.4',
-	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.0',
 	// eslint-disable-next-line quote-props
 	'8.1': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.1',
+	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.0',
+	// eslint-disable-next-line quote-props -- flow does nit support non-string keys
+	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:7.4',
 };


### PR DESCRIPTION
## Description

Switch Elasticsearch to 7.17.2 and make PHP 8.0 the default image.

Additionally, remove `default` version, instead use `DEV_ENVIRONMENT_DEFAULTS.phpVersion` when presenting the list to pick from.


## Steps to Test


1. Check out PR.
1. `npm run build`
1. `npm link`
1. Create a new env, note `8.0` should be preselected.
1. If enabled Enterprise Search hit the ES URL and verify the version is 7.17.2

