### PR TITLE
[dev-env] Support custom location

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -298,7 +298,7 @@ export function getEnvironmentPath( name: string ): string {
 		throw new Error( 'Name was not provided' );
 	}
 
-	const mainEnvironmentPath = xdgBasedir.data || os.tmpdir();
+	const mainEnvironmentPath = process.env.VIP_DEV_ENV_LOCATION || xdgBasedir.data || os.tmpdir();
 
 	return path.join( mainEnvironmentPath, 'vip', 'dev-environment', name + '' );
 }


### PR DESCRIPTION
## Description

Adds support for `VIP_DEV_ENV_LOCATION` environment variable that lets users set custom location for dev-env.

**Note:** It does not play well with already existing dev-env you need to remove all containers and volumes including proxy container.

## Steps-to-test


1) export VIP_DEV_ENV_LOCATION=~/dev-env
2) npm run build && ./dist/bin/vip-dev-env-create.js

