### PR TITLE
FORNO-1244: SQL Import: Increase max import size for launched sites to 1GB

### DIFF
--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -9,7 +9,7 @@
 import { GB_IN_BYTES, MB_IN_BYTES } from 'lib/constants/file-size';
 
 export const SQL_IMPORT_FILE_SIZE_LIMIT = 100 * GB_IN_BYTES;
-export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 350 * MB_IN_BYTES;
+export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 1 * GB_IN_BYTES;
 
 export interface AppForImport {
 	id: number;

--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -6,7 +6,7 @@
 /**
  * Internal dependencies
  */
-import { GB_IN_BYTES, MB_IN_BYTES } from 'lib/constants/file-size';
+import { GB_IN_BYTES } from 'lib/constants/file-size';
 
 export const SQL_IMPORT_FILE_SIZE_LIMIT = 100 * GB_IN_BYTES;
 export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 1 * GB_IN_BYTES;


### PR DESCRIPTION
## Description

Increases the max file size for DB imports into launched sites from 350MB to 1GB. 

## Steps to Test

1. Check out PR.
1. Run `npm run build`
2. Targeting a **launched** test site, run the following command with an SQL file larger than 1GB: `./dist/bin/vip-import-sql.js @<app>.<env> <path_to_file.sql>`
1. Verify [an error ](https://github.com/Automattic/vip/blob/c027a204b6b7d8a4e23ecd489e7b8b993a10afc0/src/bin/vip-import-sql.js#L144-L150) is thrown
2. Try the same command using a file less than 1GB in size and verify that the error is not thrown

