### PR TITLE
2.15.0 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ By default, we record information about the usage of this tool using an in-house
 
 ## Changelog
 
+### 2.15.0 (3 Aug 2022)
+
+- #1067 FORNO-1244: SQL Import: Increase max import size for launched sites to 1GB
+- #1064 FORNO-1254: SQL Import: Add multisite primary domain validation
+- #1062 [dev-env] Change wizard wording
+- #1065 [dev-env] Update default software versions for PHP and Elasticsearch
+- #1063 [dev-env] Remove redundant healthchecks
+- #1061 [dev-env] Fix duplicate shortcuts
+
 ### 2.14.0 (19 Jul 2022)
 
 - #1059 Update engines to show support for npm > 6

--- a/__fixtures__/validations/multiline-statements.sql
+++ b/__fixtures__/validations/multiline-statements.sql
@@ -1,0 +1,22 @@
+INSERT INTO `wp_site` (`id`, `domain`, `path`)
+VALUES
+	(1,'www.example.com','/');
+
+INSERT INTO wp_blogs VALUES (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
+
+INSERT INTO wp_blogs (blog_id, site_id, domain, path, registered, last_updated, public, archived, mature, spam, deleted, lang_id)
+    VALUES
+       (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
+
+INSERT INTO wp_blogs (blog_id, site_id, domain, path, registered, last_updated, public, archived, mature, spam, deleted, lang_id)
+    VALUES
+       (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0),
+       (2,1,'www.example.com','/2/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
+
+INSERT INTO wp_blogs (blog_id, site_id, domain, path, registered, last_updated, public, archived, mature, spam, deleted, lang_id)
+    VALUES
+        (1,1,'www.example.com','/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0),
+        (2,1,'www.example.com','/2/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0),
+        (3,1,'www.example.com','/3/','2022-07-25 00:00:00','2022-07-25 00:00:00',1,0,0,0,0,0);
+
+

--- a/__tests__/lib/validations/is-multisite-domain-mapped.js
+++ b/__tests__/lib/validations/is-multisite-domain-mapped.js
@@ -1,0 +1,102 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import nock from 'nock';
+import url from 'url';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getPrimaryDomainFromSQL,
+	maybeSearchReplacePrimaryDomain,
+	getPrimaryDomain,
+	isMultisitePrimaryDomainMapped,
+} from 'lib/validations/is-multisite-domain-mapped';
+
+import { API_URL } from 'lib/api';
+
+describe( 'is-multisite-domain-mapped', () => {
+	const capturedStatement = [
+		[
+			'INSERT INTO `wp_site` (`id`, `domain`, `path`)',
+			'VALUES',
+			"\t(1,'www.example.com','/');",
+		],
+	];
+
+	describe( 'getPrimaryDomainFromSQL', () => {
+		it( 'should extract the domain from a wp_site INSERT statement', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			expect( domain ).toEqual( 'www.example.com' );
+		} );
+	} );
+
+	describe( 'maybeSearchReplacePrimaryDomain', () => {
+		it( 'should replace the domain if there are matching replacements', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			const replacedDomain = maybeSearchReplacePrimaryDomain( domain, 'www.example.com,www.newdomain.com' );
+			expect( replacedDomain ).toEqual( 'www.newdomain.com' );
+		} );
+
+		it( 'should handle multiple replacements', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			const replacedDomain = maybeSearchReplacePrimaryDomain( domain, [ 'example.com,newdomain.com', 'www.example.com,www.newdomain.com' ] );
+			expect( replacedDomain ).toEqual( 'www.newdomain.com' );
+		} );
+
+		it( 'should return return the original domain if no matching replacements', () => {
+			const domain = getPrimaryDomainFromSQL( capturedStatement );
+			const replacedDomain = maybeSearchReplacePrimaryDomain( domain, 'example.com,www.newdomain.com' );
+			expect( replacedDomain ).toEqual( domain );
+		} );
+	} );
+
+	describe( 'getPrimaryDomain', () => {
+		it( 'should return the domain from wp_site INSERT statement', () => {
+			const domain = getPrimaryDomain( capturedStatement );
+			expect( domain ).toEqual( 'www.example.com' );
+		} );
+
+		it( 'should apply relevant search-replacements to the domain found in the wp_site INSERT statement', () => {
+			const domain = getPrimaryDomain( capturedStatement, 'www.example.com,www.newdomain.com' );
+			expect( domain ).toEqual( 'www.newdomain.com' );
+		} );
+	} );
+
+	describe( 'isMultisitePrimaryDomainMapped', () => {
+		it( 'return true if the domain is mapped to the environment', async () => {
+			const {
+				protocol,
+				host,
+				path,
+			} = url.parse( API_URL );
+
+			nock( `${ protocol }//${ host }` ).post( path ).reply( 200, {
+				data: {
+					app: {
+						environments: [
+							{
+								domains: {
+									nodes: [
+										{
+											name: 'www.example.com',
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+			} );
+
+			const isMapped = await isMultisitePrimaryDomainMapped( 1, 1, 'www.example.com' );
+			expect( isMapped ).toEqual( true );
+			nock.cleanAll();
+		} );
+	} );
+} );

--- a/__tests__/lib/validations/utils.js
+++ b/__tests__/lib/validations/utils.js
@@ -1,0 +1,55 @@
+/**
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import path from 'path';
+
+/**
+ * Internal dependencies
+ */
+import { getMultilineStatement } from 'lib/validations/utils';
+import { getReadInterface } from 'lib/validations/line-by-line';
+
+describe( 'utils', () => {
+	describe( 'getMultilineStatement', () => {
+		it( 'should return each occurance of a statement as an array of its lines', async () => {
+			const sqlDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'multiline-statements.sql' );
+			const readInterface = await getReadInterface( sqlDumpPath );
+
+			const getStatementsByLine = getMultilineStatement( /INSERT INTO wp_blogs/s );
+
+			let statements;
+			readInterface.on( 'line', line => {
+				statements = getStatementsByLine( line );
+			} );
+
+			await new Promise( resolveBlock => readInterface.on( 'close', resolveBlock ) );
+
+			// expecting the correct number of matching statements
+			expect( statements ).toHaveLength( 4 );
+			// expecting the statement to have the right number of lines
+			expect( statements[ 0 ] ).toHaveLength( 1 );
+			expect( statements[ 1 ] ).toHaveLength( 3 );
+			expect( statements[ 2 ] ).toHaveLength( 4 );
+			expect( statements[ 3 ] ).toHaveLength( 5 );
+		} );
+
+		it( 'should accurately capture the statement', async () => {
+			const sqlDumpPath = path.join( process.cwd(), '__fixtures__', 'validations', 'multiline-statements.sql' );
+			const readInterface = await getReadInterface( sqlDumpPath );
+
+			const getStatementsByLine = getMultilineStatement( /INSERT INTO `wp_site`/s );
+
+			let statements;
+			readInterface.on( 'line', line => {
+				statements = getStatementsByLine( line );
+			} );
+
+			await new Promise( resolveBlock => readInterface.on( 'close', resolveBlock ) );
+			expect( statements[ 0 ].join( '' ).replace( /\s/g, '' ) ).toBe( "INSERTINTO`wp_site`(`id`,`domain`,`path`)VALUES(1,'www.example.com','/');" );
+		} );
+	} );
+} );

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -68,8 +68,6 @@ services:
       command: docker-entrypoint.sh mysqld
       ports:
         - ":3306"
-      healthcheck:
-        test: 'mysql -uroot --silent --execute "SHOW DATABASES;"'
       environment:
         MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
       volumes:
@@ -106,8 +104,6 @@ services:
         discovery.type: 'single-node'
       ports:
         - ":9200"
-      healthcheck:
-        test: "curl --noproxy '*' -XGET localhost:9200"
       volumes:
         - search_data:/usr/share/elasticsearch/data
     volumes:

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -43,7 +43,7 @@ command( {
 	requiredArgs: 1,
 } )
 	.option( 'slug', 'Custom name of the dev environment' )
-	.option( 'search-replace', 'Perform Search and Replace on the specified SQL file' )
+	.option( [ 'r', 'search-replace' ], 'Perform Search and Replace on the specified SQL file' )
 	.option( 'in-place', 'Search and Replace explicitly on the given input file' )
 	.option( 'skip-validate', 'Do not perform file validation.' )
 	.examples( examples )

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -238,6 +238,7 @@ export type validateAndGetTableNamesInputType = {
 	appId: number,
 	envId: number,
 	fileNameToUpload: string,
+	searchReplace?: string | array,
 };
 
 export async function validateAndGetTableNames( {
@@ -245,6 +246,7 @@ export async function validateAndGetTableNames( {
 	appId,
 	envId,
 	fileNameToUpload,
+	searchReplace,
 }: validateAndGetTableNamesInputType ): Promise<Array<string>> {
 	const validations = [ staticSqlValidations, siteTypeValidations ];
 	if ( skipValidate ) {
@@ -252,10 +254,10 @@ export async function validateAndGetTableNames( {
 		return [];
 	}
 	try {
-		await fileLineValidations( appId, envId, fileNameToUpload, validations );
+		await fileLineValidations( appId, envId, fileNameToUpload, validations, searchReplace );
 	} catch ( validateErr ) {
 		console.log( '' );
-		exit.withError( `${ validateErr.message }
+		exit.withError( `${ validateErr.message }\n
 If you are confident the file does not contain unsupported statements, you can retry the command with the ${ chalk.yellow( '--skip-validate' ) } option.
 ` );
 	}
@@ -415,6 +417,7 @@ command( {
 			appId,
 			envId,
 			fileNameToUpload,
+			searchReplace,
 		} );
 
 		// display playbook of what will happen during execution

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -4,9 +4,9 @@ export const DEV_ENVIRONMENT_FULL_COMMAND = `vip ${ DEV_ENVIRONMENT_SUBCOMMAND }
 export const DEV_ENVIRONMENT_DEFAULTS = {
 	title: 'VIP Dev',
 	multisite: false,
-	elasticsearchVersion: '7.10.1',
+	elasticsearchVersion: '7.17.2',
 	mariadbVersion: '10.3',
-	phpImage: 'default',
+	phpVersion: '8.0',
 };
 
 export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up your local dev environment.\n\n' +
@@ -25,10 +25,9 @@ export const DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY = 'wordpress-versions.json';
 export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
 export const DEV_ENVIRONMENT_PHP_VERSIONS = {
-	default: 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
-	// eslint-disable-next-line quote-props -- flow does nit support non-string keys
-	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:7.4',
-	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.0',
 	// eslint-disable-next-line quote-props
 	'8.1': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.1',
+	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.0',
+	// eslint-disable-next-line quote-props -- flow does nit support non-string keys
+	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:7.4',
 };

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -205,7 +205,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		instanceData[ component ] = result;
 	}
 
-	instanceData.enterpriseSearchEnabled = await promptForBoolean( 'Enable Enterprise Search?', defaultOptions.enterpriseSearchEnabled );
+	instanceData.enterpriseSearchEnabled = await promptForBoolean( 'Enable Elasticsearch (needed by Enterprise Search)?', defaultOptions.enterpriseSearchEnabled );
 	if ( instanceData.enterpriseSearchEnabled ) {
 		instanceData.statsd = preselectedOptions.statsd || defaultOptions.statsd || false;
 	} else {

--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -6,10 +6,10 @@
 /**
  * Internal dependencies
  */
-import { GB_IN_BYTES, MB_IN_BYTES } from 'lib/constants/file-size';
+import { GB_IN_BYTES } from 'lib/constants/file-size';
 
 export const SQL_IMPORT_FILE_SIZE_LIMIT = 100 * GB_IN_BYTES;
-export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 350 * MB_IN_BYTES;
+export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 1 * GB_IN_BYTES;
 
 export interface AppForImport {
 	id: number;

--- a/src/lib/validations/is-multisite-domain-mapped.js
+++ b/src/lib/validations/is-multisite-domain-mapped.js
@@ -1,0 +1,127 @@
+/**
+ * @flow
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import gql from 'graphql-tag';
+
+/**
+ * Internal dependencies
+ */
+import API from 'lib/api';
+import { trackEventWithEnv } from 'lib/tracker';
+import * as exit from 'lib/cli/exit';
+
+/**
+ * Extracts the domain for site with ID 1 from an INSERT INTO `wp_site` SQL statement
+ *
+ * @param {array} statements An array of SQL statements
+ * @returns {string} The domain
+ */
+export const getPrimaryDomainFromSQL = ( statements: array ) => {
+	if ( ! statements.length ) {
+		return '';
+	}
+
+	const SQL_WP_SITE_DOMAINS_REGEX = /\(1,'(.*?)'/s;
+	const matches = statements[ 0 ]?.join( '' ).replace( /\s/g, '' ).match( SQL_WP_SITE_DOMAINS_REGEX );
+	return matches ? matches[ 1 ] : '';
+};
+
+/**
+ * Apply search-replacements to a domain
+ *
+ * @param {string} domain The domain to apply replacements to
+ * @param {(string|array)} searchReplace The search-replace pairs
+ * @returns {string} The processed domain
+ */
+export const maybeSearchReplacePrimaryDomain = function( domain: string, searchReplace?: string | array ) {
+	if ( searchReplace ) {
+		let pairs = searchReplace;
+		if ( ! Array.isArray( pairs ) ) {
+			pairs = [ searchReplace ];
+		}
+		const domainReplacements = pairs.map( pair => pair.split( ',' ) );
+		const primaryDomainReplacement = domainReplacements.find( pair => pair[ 0 ] === domain );
+		return primaryDomainReplacement?.[ 1 ] ?? domain;
+	}
+	return domain;
+};
+
+/**
+ * Get the primary domain as it will be imported
+ *
+ * @param {array} statements An array of SQL statements
+ * @param {(string|array)} searchReplace The search-replace pairs
+ * @returns {string} The replaced domain, or the domain as found in the SQL dump
+ */
+export const getPrimaryDomain = function( statements: array, searchReplace?: string | array ) {
+	const domainFromSQL = getPrimaryDomainFromSQL( statements );
+	return maybeSearchReplacePrimaryDomain( domainFromSQL, searchReplace );
+};
+
+/**
+ * Gets the mapped domains and checks if the primary domain from the provided SQL dump is one of them
+ *
+ * @param {number} appId The ID of the app in GOOP
+ * @param {number} envId The ID of the enviroment in GOOP
+ * @param {string} primaryDomain The primary domain found in the provided SQL file
+ * @returns {boolean} Whether the primary domain is mapped
+ */
+export async function isMultisitePrimaryDomainMapped(
+	appId: number,
+	envId: number,
+	primaryDomain: string,
+): Promise<boolean> {
+	const track = trackEventWithEnv.bind( null, appId, envId );
+
+	const api = await API();
+	let res;
+	try {
+		res = await api.query( {
+			query: gql`
+				query AppMappedDomains($appId: Int, $envId: Int) {
+					app(id: $appId) {
+						id
+						name
+						environments(id: $envId) {
+							uniqueLabel
+							isMultisite
+							domains {
+								nodes {
+									name
+									isPrimary
+								}
+							}
+						}
+					}
+				}
+			`,
+			variables: {
+				appId,
+				envId,
+			},
+		} );
+	} catch ( GraphQlError ) {
+		await track( 'import_sql_command_error', {
+			error_type: 'GraphQL-MappedDomain-Check-failed',
+			gql_err: GraphQlError,
+		} );
+		exit.withError( `StartImport call failed: ${ GraphQlError }` );
+	}
+	if ( ! Array.isArray( res?.data?.app?.environments ) ) {
+		return false;
+	}
+
+	const environments = res.data.app.environments;
+	if ( ! environments.length ) {
+		return false;
+	}
+
+	const mappedDomains = environments[ 0 ]?.domains?.nodes?.map( domain => domain.name );
+
+	return mappedDomains.includes( primaryDomain );
+}

--- a/src/lib/validations/line-by-line.js
+++ b/src/lib/validations/line-by-line.js
@@ -27,6 +27,7 @@ export type PostLineExecutionProcessingParams = {
 	fileName?: string,
 	isImport?: boolean,
 	skipChecks?: string[],
+	searchReplace?: string | array,
 }
 
 function openFile( filename, flags = 'r', mode = 666 ) {
@@ -55,7 +56,7 @@ export async function getReadInterface( filename: string ) {
 	} );
 }
 
-export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject> ) {
+export async function fileLineValidations( appId: number, envId: number, fileName: string, validations: Array<PerLineValidationObject>, searchReplace: string | array ) {
 	const isImport = true;
 	const readInterface = await getReadInterface( fileName );
 
@@ -77,7 +78,7 @@ export async function fileLineValidations( appId: number, envId: number, fileNam
 
 	return Promise.all( validations.map( async validation => {
 		if ( validation.hasOwnProperty( 'postLineExecutionProcessing' ) && typeof validation.postLineExecutionProcessing === 'function' ) {
-			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId } );
+			return validation.postLineExecutionProcessing( { fileName, isImport, appId, envId, searchReplace } );
 		}
 	} ) );
 }

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -14,21 +14,34 @@ import debugLib from 'debug';
 import { trackEventWithEnv } from 'lib/tracker';
 import { sqlDumpLineIsMultiSite } from 'lib/validations/is-multi-site-sql-dump';
 import { isMultiSiteInSiteMeta } from 'lib/validations/is-multi-site';
+import {
+	isMultisitePrimaryDomainMapped,
+	getPrimaryDomain,
+} from 'lib/validations/is-multisite-domain-mapped';
+import { getMultilineStatement } from 'lib/validations/utils';
 import type { PostLineExecutionProcessingParams } from 'lib/validations/line-by-line';
 
 const debug = debugLib( 'vip:vip-import-sql' );
 
 let isMultiSiteSqlDump = false;
+let wpSiteInsertStatement;
+const getWpSiteInsertStatement = getMultilineStatement( /INSERT INTO `wp_site`/s );
 
 export const siteTypeValidations = {
 	execute: ( line: string ) => {
 		const lineIsMultiSite = sqlDumpLineIsMultiSite( line );
+		wpSiteInsertStatement = getWpSiteInsertStatement( line );
+
 		if ( lineIsMultiSite ) {
 			isMultiSiteSqlDump = true;
 		}
 	},
-	postLineExecutionProcessing: async ( { appId, envId }: PostLineExecutionProcessingParams ) => {
+	postLineExecutionProcessing: async ( { appId, envId, searchReplace }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
+		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
+		const isPrimaryDomainMapped =
+			primaryDomainFromSQL &&
+			( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
@@ -53,6 +66,17 @@ export const siteTypeValidations = {
 			} );
 			throw new Error(
 				'You have requested a subsite SQL import but have not provided a subsite compatiable SQL dump.'
+			);
+		}
+
+		if ( isMultiSite && ! isPrimaryDomainMapped ) {
+			await track( 'import_sql_command_error', {
+				error_type: 'multisite-import-where-primary-domain-unmapped',
+			} );
+			throw new Error(
+				'This import would set the network\'s main site domain to ' + primaryDomainFromSQL +
+				', however this domain is not mapped to the target environment. Please replace this domain in your ' +
+				'import file, or map it to the environment.'
 			);
 		}
 	},

--- a/src/lib/validations/utils.js
+++ b/src/lib/validations/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Get SQL statements matching a supplied pattern from a file stream
+ *
+ * @param {RegExp} statementRegex A RegExp pattern representing the start of the statement to capture
+ * @returns {function} A function which processes individual lines to capture the matching statements
+ */
+export function getMultilineStatement( statementRegex ) {
+	const matchingStatements = [];
+	let isCapturing = false;
+	let index = 0;
+
+	/**
+	 * Processes each line of the file stream and builds an array of statements which start with the supplied pattern
+	 *
+	 * @param {string} line A line from the file stream
+	 * @returns {array} An array of matching statements where each statement is presented as an array of lines
+	 */
+	return line => {
+		const shouldStartCapture = statementRegex.test( line );
+		const shouldEndCapture = ( shouldStartCapture || isCapturing ) && /;$/.test( line );
+		if ( shouldStartCapture ) {
+			isCapturing = true;
+			matchingStatements[ index ] = [];
+		}
+
+		if ( isCapturing ) {
+			matchingStatements[ index ].push( line );
+		}
+
+		if ( shouldEndCapture ) {
+			isCapturing = false;
+			index++;
+		}
+
+		return matchingStatements;
+	};
+}


### PR DESCRIPTION
### 2.15.0 (3 Aug 2022)

- #1067 FORNO-1244: SQL Import: Increase max import size for launched sites to 1GB
- #1064 FORNO-1254: SQL Import: Add multisite primary domain validation
- #1062 [dev-env] Change wizard wording
- #1065 [dev-env] Update default software versions for PHP and Elasticsearch
- #1063 [dev-env] Remove redundant healthchecks
- #1061 [dev-env] Fix duplicate shortcuts