### PR TITLE
[dev-env] validate client code - look for specific subdirectories

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -238,19 +238,50 @@ async function processComponent( component: string, preselectedValue: string, de
 		const resolvedPath = resolvePath( result.dir || '' );
 		result.dir = resolvedPath;
 
-		const isDirectory = resolvedPath && fs.existsSync( resolvedPath ) && fs.lstatSync( resolvedPath ).isDirectory();
-		const isEmpty = isDirectory ? fs.readdirSync( resolvedPath ).length === 0 : true;
+		const { result: isPathValid, message } = validateLocalPath( component, resolvedPath );
 
-		if ( isDirectory && ! isEmpty ) {
+		if ( isPathValid ) {
 			break;
 		} else {
-			const message = `Provided path "${ resolvedPath }" does not point to a valid or existing directory.`;
 			console.log( chalk.yellow( 'Warning:' ), message );
 			result = await promptForComponent( component, allowLocal, defaultObject );
 		}
 	}
 
 	return result;
+}
+
+function validateLocalPath( component: string, providedPath: string ) {
+	if ( ! isNonEmptyDirectory( providedPath ) ) {
+		const message = `Provided path "${ providedPath }" does not point to a valid or existing directory.`;
+		return {
+			result: false,
+			message,
+		};
+	}
+
+	if ( component === 'clientCode' ) {
+		const themesPath = path.resolve( providedPath, 'themes' );
+		if ( ! isNonEmptyDirectory( themesPath ) ) {
+			const message = `Provided path "${ providedPath }" does not have a non-empty themes subdirectory.`;
+			return {
+				result: false,
+				message,
+			};
+		}
+	}
+
+	return {
+		result: true,
+		message: '',
+	};
+}
+
+function isNonEmptyDirectory( directoryPath: string ) {
+	const isDirectory = directoryPath && fs.existsSync( directoryPath ) && fs.lstatSync( directoryPath ).isDirectory();
+	const isEmpty = isDirectory ? fs.readdirSync( directoryPath ).length === 0 : true;
+
+	return ! isEmpty && isDirectory;
 }
 
 export function resolvePath( input: string ): string {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -271,7 +271,7 @@ function validateLocalPath( component: string, providedPath: string ) {
 			}
 		}
 		if ( missingFiles.length > 0 ) {
-			const message = `Provided path "${ providedPath }" is missing following files/folders: ${ missingFiles.join( ', ' ) }`;
+			const message = `Provided path "${ providedPath }" is missing following files/folders: ${ missingFiles.join( ', ' ) }. Learn more: https://docs.wpvip.com/technical-references/vip-codebase/#1-wordpress`;
 			return {
 				result: false,
 				message,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -261,9 +261,25 @@ function validateLocalPath( component: string, providedPath: string ) {
 	}
 
 	if ( component === 'clientCode' ) {
-		const themesPath = path.resolve( providedPath, 'themes' );
-		if ( ! isNonEmptyDirectory( themesPath ) ) {
-			const message = `Provided path "${ providedPath }" does not have a non-empty themes subdirectory.`;
+		const files = {
+			languages: false,
+			plugins: false,
+			themes: false,
+			private: false,
+			images: false,
+			'client-mu-plugins': false,
+			'vip-config': false,
+		};
+
+		const missingFiles = [];
+		for ( const file of Object.keys( files ) ) {
+			const filePath = path.resolve( providedPath, file );
+			if ( ! fs.existsSync( filePath ) ) {
+				missingFiles.push( file );
+			}
+		}
+		if ( missingFiles.length > 0 ) {
+			const message = `Provided path "${ providedPath }" is missing following files/folders: ${ missingFiles.join( ', ' ) }`;
 			return {
 				result: false,
 				message,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -261,18 +261,10 @@ function validateLocalPath( component: string, providedPath: string ) {
 	}
 
 	if ( component === 'clientCode' ) {
-		const files = {
-			languages: false,
-			plugins: false,
-			themes: false,
-			private: false,
-			images: false,
-			'client-mu-plugins': false,
-			'vip-config': false,
-		};
+		const files = [ 'languages', 'plugins', 'themes', 'private', 'images', 'client-mu-plugins', 'vip-config' ];
 
 		const missingFiles = [];
-		for ( const file of Object.keys( files ) ) {
+		for ( const file of files ) {
 			const filePath = path.resolve( providedPath, file );
 			if ( ! fs.existsSync( filePath ) ) {
 				missingFiles.push( file );


### PR DESCRIPTION
## Description

To prevent folks from linking to an incorrect site-code folder we added basic validation that there is `themes` subdirectory at least.

## Steps to Test

```
npm run build && ./dist/bin/vip-dev-env-create.js --slug test --client-code="/tmp"
```

Or type something like that during wizard. 
