### PR TITLE
[dev-env] Include stack trace to error tracking

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -52,7 +52,7 @@ export async function handleCLIException( exception: Error, trackKey?: string, t
 
 		if ( trackKey ) {
 			try {
-				const errorTrackingInfo = { ...trackBaseInfo, failure: message };
+				const errorTrackingInfo = { ...trackBaseInfo, failure: message, stack: exception.stack };
 				await trackEvent( trackKey, errorTrackingInfo );
 			} catch ( trackException ) {
 				console.log( errorPrefix, `Failed to record track event ${ trackKey }`, trackException.message );


### PR DESCRIPTION
## Description

The most common exception that we got is without a message. That is why we are adding stack trace as well in order to gather more information.

## Steps to Test

1) Introduce some exception in dev-env command
2) Run command with `--debug` `npm run build && ./dist/bin/vip-dev-env-start.js --slug test --debug`
3) See that stack trace is included in the pendo and tracks event. 

