### PR TITLE
[dev-env] Add switch to skip wp version check

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -36,6 +36,7 @@ const examples = [
 command()
 	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'skip-rebuild', 'Only start stopped services' )
+	.option( [ 'w', 'skip-wp-versions-check' ], 'Skip propting for wordpress update if non latest' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		await validateDependencies();
@@ -50,6 +51,7 @@ command()
 
 		const options = {
 			skipRebuild: !! opt.skipRebuild,
+			skipWpVersionsCheck: !! opt.skipWpVersionsCheck,
 		};
 		try {
 			if ( process.platform === 'win32' ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -48,7 +48,8 @@ const uploadPathString = 'uploads';
 const nginxPathString = 'nginx';
 
 type StartEnvironmentOptions = {
-	skipRebuild: boolean
+	skipRebuild: boolean,
+	skipWpVersionsCheck: boolean
 };
 
 type SQLImportPaths = {
@@ -69,7 +70,10 @@ export async function startEnvironment( slug: string, options: StartEnvironmentO
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 
-	const updated = await updateWordPressImage( slug );
+	let updated = false;
+	if ( ! options.skipWpVersionsCheck ) {
+		updated = await updateWordPressImage( slug );
+	}
 
 	if ( options.skipRebuild && ! updated ) {
 		await landoStart( instancePath );


### PR DESCRIPTION
For the CI/CD pipelines we don't want any prompts, so we want to suppress WP version checks.

```
vip dev-env create --wordpress 5.9
npm run build && ./dist/bin/vip-dev-env-start.js -w --slug test --debug
```