### PR TITLE
[dev-env] Remove app.env support from non-create command

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -68,8 +68,26 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				},
 				expected: 'foo',
 			},
+			{ // When app.env is not allowed use default value
+				options: {
+					allowAppEnv: false,
+					app: '123',
+					env: 'bar.car',
+					slug: 'foo',
+				},
+				expected: 'foo',
+			},
+			{ // When app.env is not allowed use default value
+				options: {
+					allowAppEnv: false,
+					app: '123',
+					env: 'bar.car',
+				},
+				expected: 'vip-local',
+			},
 			{ // construct name from app and env
 				options: {
+					allowAppEnv: true,
 					app: '123',
 					env: 'bar.car',
 				},
@@ -77,6 +95,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			},
 			{ // custom name takes precedence
 				options: {
+					allowAppEnv: true,
 					slug: 'foo',
 					app: '123',
 					env: 'bar.car',
@@ -92,32 +111,19 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 	describe( 'getEnvironmentStartCommand', () => {
 		it.each( [
 			{ // default value
-				options: {},
+				slug: undefined,
 				expected: 'vip dev-env start',
 			},
 			{ // use custom name
-				options: {
-					slug: 'foo',
-				},
+				slug: 'foo',
 				expected: 'vip dev-env start --slug foo',
-			},
-			{ // construct name from app and env
-				options: {
-					app: '123',
-					env: 'bar.car',
-				},
-				expected: 'vip @123.bar.car dev-env start',
 			},
 			{ // custom name takes precedence
-				options: {
-					slug: 'foo',
-					app: '123',
-					env: 'bar.car',
-				},
-				expected: 'vip dev-env start --slug foo',
+				slug: '',
+				expected: 'vip dev-env start',
 			},
 		] )( 'should get correct start command', async input => {
-			const result = getEnvironmentStartCommand( input.options );
+			const result = getEnvironmentStartCommand( input.slug );
 
 			expect( result ).toStrictEqual( input.expected );
 		} );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -106,7 +106,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				env: 'bar',
 			};
 
-			const expectedErrorMessage = "This command does not support @app.env notation. Use '--slug 123-bar' instead to target a specific local environment.";
+			const expectedErrorMessage = "This command does not support @app.env notation. Use '--slug=123-bar' to target the local environment.";
 			expect( () => {
 				getEnvironmentName( options );
 			} ).toThrow( expectedErrorMessage );

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -77,14 +77,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				},
 				expected: 'foo',
 			},
-			{ // When app.env is not allowed use default value
-				options: {
-					allowAppEnv: false,
-					app: '123',
-					env: 'bar.car',
-				},
-				expected: 'vip-local',
-			},
 			{ // construct name from app and env
 				options: {
 					allowAppEnv: true,
@@ -106,6 +98,18 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const result = getEnvironmentName( input.options );
 
 			expect( result ).toStrictEqual( input.expected );
+		} );
+		it( 'should throw an exception if used the app.env when not allowed', () => {
+			const options = {
+				allowAppEnv: false,
+				app: '123',
+				env: 'bar',
+			};
+
+			const expectedErrorMessage = "This command does not support @app.env notation. Use '--slug 123-bar' instead to target a specific local environment.";
+			expect( () => {
+				getEnvironmentName( options );
+			} ).toThrow( expectedErrorMessage );
 		} );
 	} );
 	describe( 'getEnvironmentStartCommand', () => {

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -64,13 +64,19 @@ cmd.examples( examples );
 cmd.argv( process.argv, async ( arg, opt ) => {
 	await validateDependencies();
 
-	const slug = getEnvironmentName( opt );
+	const environmentNameOptions = {
+		slug: opt.slug,
+		app: opt.app,
+		env: opt.env,
+		allowAppEnv: true,
+	};
+	const slug = getEnvironmentName( environmentNameOptions );
 	debug( 'Args: ', arg, 'Options: ', opt );
 
 	const trackingInfo = { slug };
 	await trackEvent( 'dev_env_create_command_execute', trackingInfo );
 
-	const startCommand = chalk.bold( getEnvironmentStartCommand( opt ) );
+	const startCommand = chalk.bold( getEnvironmentStartCommand( slug ) );
 
 	const environmentAlreadyExists = doesEnvironmentExist( slug );
 	if ( environmentAlreadyExists ) {

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -17,7 +17,7 @@ import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
 import { printEnvironmentInfo, printAllEnvironmentsInfo } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
-import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { getEnvTrackingInfo, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
@@ -26,10 +26,6 @@ const examples = [
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info --all`,
 		description: 'Return information about all local dev environments',
-	},
-	{
-		usage: `vip @123 ${ DEV_ENVIRONMENT_SUBCOMMAND } info`,
-		description: 'Return information about dev environment for site 123',
 	},
 	{
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } info --slug=my_site`,

--- a/src/lib/cli/command.js
+++ b/src/lib/cli/command.js
@@ -26,11 +26,15 @@ import { parseEnvAliasFromArgv } from './envAlias';
 import { rollbar } from '../rollbar';
 import * as exit from './exit';
 import debugLib from 'debug';
+import UserError from './userError';
 
 function uncaughtError( err ) {
 	// Error raised when trying to write to an already closed stream
 	if ( err.code === 'EPIPE' ) {
 		return;
+	}
+	if ( err instanceof UserError ) {
+		exit.withError( err.message );
 	}
 
 	console.log( chalk.red( '✕' ), 'Please contact VIP Support with the following information:' );

--- a/src/lib/cli/userError.js
+++ b/src/lib/cli/userError.js
@@ -1,0 +1,7 @@
+function UserError( message ) {
+	this.message = message;
+}
+
+UserError.prototype = new Error;
+
+export default UserError;

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -21,7 +21,6 @@ import * as exit from 'lib/cli/exit';
 import { trackEvent } from '../tracker';
 import {
 	DEV_ENVIRONMENT_FULL_COMMAND,
-	DEV_ENVIRONMENT_SUBCOMMAND,
 	DEV_ENVIRONMENT_DEFAULTS,
 	DEV_ENVIRONMENT_PROMPT_INTRO,
 	DEV_ENVIRONMENT_COMPONENTS,
@@ -85,27 +84,24 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 	if ( options.app ) {
 		const envSuffix = options.env ? `-${ options.env }` : '';
 
-		return options.app + envSuffix;
+		const appName = options.app + envSuffix;
+		if ( options.allowAppEnv ) {
+			return appName;
+		}
+
+		const message = `This command does not support @app.env notation. Use '--slug ${ appName }' instead. Falling back to the default '${ DEFAULT_SLUG }' development environment`;
+		console.log( chalk.yellow( 'Warning:' ), message );
 	}
 
 	return DEFAULT_SLUG;
 }
 
-export function getEnvironmentStartCommand( options: EnvironmentNameOptions ): string {
-	if ( options.slug ) {
-		return `${ DEV_ENVIRONMENT_FULL_COMMAND } start --slug ${ options.slug }`;
+export function getEnvironmentStartCommand( slug: string ): string {
+	if ( ! slug || slug === DEFAULT_SLUG ) {
+		return `${ DEV_ENVIRONMENT_FULL_COMMAND } start`;
 	}
 
-	if ( options.app ) {
-		let application = `@${ options.app }`;
-		if ( options.env ) {
-			application += `.${ options.env }`;
-		}
-
-		return `vip ${ application } ${ DEV_ENVIRONMENT_SUBCOMMAND } start`;
-	}
-
-	return `${ DEV_ENVIRONMENT_FULL_COMMAND } start`;
+	return `${ DEV_ENVIRONMENT_FULL_COMMAND } start --slug ${ slug }`;
 }
 
 export function printTable( data: Object ) {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -30,6 +30,7 @@ import {
 import { getVersionList, readEnvironmentData } from './dev-environment-core';
 import type { AppInfo, ComponentConfig, InstanceOptions, EnvironmentNameOptions, InstanceData } from './types';
 import { validateDockerInstalled } from './dev-environment-lando';
+import UserError from '../cli/userError';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -89,8 +90,8 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 			return appName;
 		}
 
-		const message = `This command does not support @app.env notation. Use '--slug ${ appName }' instead. Falling back to the default '${ DEFAULT_SLUG }' development environment`;
-		console.log( chalk.yellow( 'Warning:' ), message );
+		const message = `This command does not support @app.env notation. Use '--slug ${ appName }' instead to target a specific local environment.`;
+		throw new UserError( message );
 	}
 
 	return DEFAULT_SLUG;

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -90,7 +90,7 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 			return appName;
 		}
 
-		const message = `This command does not support @app.env notation. Use '--slug ${ appName }' instead to target a specific local environment.`;
+		const message = `This command does not support @app.env notation. Use '--slug=${ appName }' to target the local environment.`;
 		throw new UserError( message );
 	}
 

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -39,6 +39,7 @@ export type EnvironmentNameOptions = {
 	slug: string;
 	app: string;
 	env: string;
+	allowAppEnv?: boolean;
 }
 
 export interface InstanceData {


### PR DESCRIPTION
## Description

It turns out that havingt he support of `@app.env` is causing a bit of confusion and also a risk of running command meant for local dev-environment against real production site. This can lead to  negative outcomes (e.g. running `vip @123 import file.sql` instead of `vip @123 dev-env import file.sql`)

## Steps to Test

1) Test that only de-env subcommand that accepts @app.env is create, which fetches some data from prod instance
2) Other subcommand will issue a warning and NOT use `@app.env` in order to target env


![Peek 2022-08-15 12-54](https://user-images.githubusercontent.com/19240162/184623240-61b83c53-fb56-43aa-9c7c-ce83ee257c42.gif)

