### PR TITLE
SQL Import: Fix multisite primary domain validation

### DIFF
--- a/__tests__/lib/validations/is-multisite-domain-mapped.js
+++ b/__tests__/lib/validations/is-multisite-domain-mapped.js
@@ -37,7 +37,7 @@ describe( 'is-multisite-domain-mapped', () => {
 			expect( domain ).toEqual( 'www.example.com' );
 		} );
 
-		it( 'should return an empty string when statement not found', () => {
+		it( 'should return an empty string if no wp_site INSERT statement is found', () => {
 			const domain = getPrimaryDomainFromSQL( statementNotFound );
 			expect( domain ).toEqual( '' );
 		} );
@@ -64,9 +64,14 @@ describe( 'is-multisite-domain-mapped', () => {
 	} );
 
 	describe( 'getPrimaryDomain', () => {
-		it( 'should return the domain from wp_site INSERT statement', () => {
+		it( 'should return the domain from a wp_site INSERT statement', () => {
 			const domain = getPrimaryDomain( capturedStatement );
 			expect( domain ).toEqual( 'www.example.com' );
+		} );
+
+		it( 'should return an empty string if no wp_site INSERT statement is found', () => {
+			const domain = getPrimaryDomain( statementNotFound );
+			expect( domain ).toEqual( '' );
 		} );
 
 		it( 'should apply relevant search-replacements to the domain found in the wp_site INSERT statement', () => {
@@ -109,13 +114,7 @@ describe( 'is-multisite-domain-mapped', () => {
 			expect( isMapped ).toEqual( true );
 		} );
 
-		it( 'should return true if the SQL does not contain a wp_site INSERT statement', async () => {
-			const domain = getPrimaryDomainFromSQL( statementNotFound );
-			const isMapped = await isMultisitePrimaryDomainMapped( 1, 1, domain );
-			expect( isMapped ).toEqual( true );
-		} );
-
-		it( 'should return false if the domain is mapped to the environment', async () => {
+		it( 'should return false if the domain is not mapped to the environment', async () => {
 			const isMapped = await isMultisitePrimaryDomainMapped( 1, 1, 'test.com' );
 			expect( isMapped ).toEqual( false );
 		} );

--- a/__tests__/lib/validations/is-multisite-domain-mapped.js
+++ b/__tests__/lib/validations/is-multisite-domain-mapped.js
@@ -29,10 +29,17 @@ describe( 'is-multisite-domain-mapped', () => {
 		],
 	];
 
+	const statementNotFound = [];
+
 	describe( 'getPrimaryDomainFromSQL', () => {
 		it( 'should extract the domain from a wp_site INSERT statement', () => {
 			const domain = getPrimaryDomainFromSQL( capturedStatement );
 			expect( domain ).toEqual( 'www.example.com' );
+		} );
+
+		it( 'should return an empty string when statement not found', () => {
+			const domain = getPrimaryDomainFromSQL( statementNotFound );
+			expect( domain ).toEqual( '' );
 		} );
 	} );
 
@@ -69,7 +76,7 @@ describe( 'is-multisite-domain-mapped', () => {
 	} );
 
 	describe( 'isMultisitePrimaryDomainMapped', () => {
-		it( 'return true if the domain is mapped to the environment', async () => {
+		beforeEach( () => {
 			const {
 				protocol,
 				host,
@@ -93,10 +100,24 @@ describe( 'is-multisite-domain-mapped', () => {
 					},
 				},
 			} );
+		} );
 
+		afterEach( nock.cleanAll );
+
+		it( 'should return true if the domain is mapped to the environment', async () => {
 			const isMapped = await isMultisitePrimaryDomainMapped( 1, 1, 'www.example.com' );
 			expect( isMapped ).toEqual( true );
-			nock.cleanAll();
+		} );
+
+		it( 'should return true if the SQL does not contain a wp_site INSERT statement', async () => {
+			const domain = getPrimaryDomainFromSQL( statementNotFound );
+			const isMapped = await isMultisitePrimaryDomainMapped( 1, 1, domain );
+			expect( isMapped ).toEqual( true );
+		} );
+
+		it( 'should return false if the domain is mapped to the environment', async () => {
+			const isMapped = await isMultisitePrimaryDomainMapped( 1, 1, 'test.com' );
+			expect( isMapped ).toEqual( false );
 		} );
 	} );
 } );

--- a/src/lib/validations/is-multisite-domain-mapped.js
+++ b/src/lib/validations/is-multisite-domain-mapped.js
@@ -76,10 +76,6 @@ export async function isMultisitePrimaryDomainMapped(
 	envId: number,
 	primaryDomain: string,
 ): Promise<boolean> {
-	if ( ! primaryDomain ) {
-		return true;
-	}
-
 	const track = trackEventWithEnv.bind( null, appId, envId );
 	const api = await API();
 	let res;

--- a/src/lib/validations/is-multisite-domain-mapped.js
+++ b/src/lib/validations/is-multisite-domain-mapped.js
@@ -76,8 +76,11 @@ export async function isMultisitePrimaryDomainMapped(
 	envId: number,
 	primaryDomain: string,
 ): Promise<boolean> {
-	const track = trackEventWithEnv.bind( null, appId, envId );
+	if ( ! primaryDomain ) {
+		return true;
+	}
 
+	const track = trackEventWithEnv.bind( null, appId, envId );
 	const api = await API();
 	let res;
 	try {

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -40,7 +40,7 @@ export const siteTypeValidations = {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
 		const isPrimaryDomainMapped = primaryDomainFromSQL && ( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
-		const doesPrimaryDomainExist = () => '' !== primaryDomainFromSQL;
+		const doesPrimaryDomainExist = '' !== primaryDomainFromSQL;
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
@@ -68,7 +68,7 @@ export const siteTypeValidations = {
 			);
 		}
 
-		if ( isMultiSite && doesPrimaryDomainExist() && ! isPrimaryDomainMapped ) {
+		if ( isMultiSite && doesPrimaryDomainExist && ! isPrimaryDomainMapped ) {
 			await track( 'import_sql_command_error', {
 				error_type: 'multisite-import-where-primary-domain-unmapped',
 			} );

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -39,8 +39,8 @@ export const siteTypeValidations = {
 	postLineExecutionProcessing: async ( { appId, envId, searchReplace }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
-		const primaryDomainExists = primaryDomainFromSQL && '' !== primaryDomainFromSQL;
-		const isPrimaryDomainMapped = primaryDomainExists && ( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
+		const isPrimaryDomainMapped = primaryDomainFromSQL && ( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
+		const isPrimaryDomainValid = isPrimaryDomainMapped || '' === primaryDomainFromSQL;
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
@@ -68,7 +68,7 @@ export const siteTypeValidations = {
 			);
 		}
 
-		if ( isMultiSite && ! isPrimaryDomainMapped ) {
+		if ( isMultiSite && ! isPrimaryDomainValid ) {
 			await track( 'import_sql_command_error', {
 				error_type: 'multisite-import-where-primary-domain-unmapped',
 			} );

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -39,9 +39,7 @@ export const siteTypeValidations = {
 	postLineExecutionProcessing: async ( { appId, envId, searchReplace }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
-		const isPrimaryDomainMapped =
-			primaryDomainFromSQL &&
-			( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
+		const isPrimaryDomainMapped = await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL );
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -39,8 +39,8 @@ export const siteTypeValidations = {
 	postLineExecutionProcessing: async ( { appId, envId, searchReplace }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
-		const isPrimaryDomainMapped = primaryDomainFromSQL && ( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
-		const doesPrimaryDomainExist = '' !== primaryDomainFromSQL;
+		const primaryDomainExists = primaryDomainFromSQL && '' !== primaryDomainFromSQL;
+		const isPrimaryDomainMapped = primaryDomainExists && ( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
@@ -68,7 +68,7 @@ export const siteTypeValidations = {
 			);
 		}
 
-		if ( isMultiSite && doesPrimaryDomainExist && ! isPrimaryDomainMapped ) {
+		if ( isMultiSite && ! isPrimaryDomainMapped ) {
 			await track( 'import_sql_command_error', {
 				error_type: 'multisite-import-where-primary-domain-unmapped',
 			} );

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -67,13 +67,18 @@ export const siteTypeValidations = {
 
 		// Get Primary Domain
 		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
+
 		// Check if Primary Domain exists (empty string does not qualify)
 		const primaryDomainExists = primaryDomainFromSQL || '' !== primaryDomainFromSQL;
+
 		// Check if primary domain is mapped only if it exists
+		// Also saves on a call to Parker by checking ahead
 		if ( primaryDomainExists ) {
-			// Also saves on a call to Parker by checking ahead
 			const isPrimaryDomainMapped = ( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
-			if ( isMultiSite && isPrimaryDomainMapped ) {
+
+			// If site is multisite AND the primary domain is exists AND the primary is unmapped
+			// then throw an error
+			if ( isMultiSite && ! isPrimaryDomainMapped ) {
 				await track( 'import_sql_command_error', {
 					error_type: 'multisite-import-where-primary-domain-unmapped',
 				} );

--- a/src/lib/validations/site-type.js
+++ b/src/lib/validations/site-type.js
@@ -39,7 +39,8 @@ export const siteTypeValidations = {
 	postLineExecutionProcessing: async ( { appId, envId, searchReplace }: PostLineExecutionProcessingParams ) => {
 		const isMultiSite = await isMultiSiteInSiteMeta( appId, envId );
 		const primaryDomainFromSQL = getPrimaryDomain( wpSiteInsertStatement, searchReplace );
-		const isPrimaryDomainMapped = await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL );
+		const isPrimaryDomainMapped = primaryDomainFromSQL && ( await isMultisitePrimaryDomainMapped( appId, envId, primaryDomainFromSQL ) );
+		const doesPrimaryDomainExist = () => '' !== primaryDomainFromSQL;
 		const track = trackEventWithEnv.bind( null, appId, envId );
 
 		debug( `\nAppId: ${ appId } is ${ isMultiSite ? 'a multisite.' : 'not a multisite' }` );
@@ -67,7 +68,7 @@ export const siteTypeValidations = {
 			);
 		}
 
-		if ( isMultiSite && ! isPrimaryDomainMapped ) {
+		if ( isMultiSite && doesPrimaryDomainExist() && ! isPrimaryDomainMapped ) {
 			await track( 'import_sql_command_error', {
 				error_type: 'multisite-import-where-primary-domain-unmapped',
 			} );


### PR DESCRIPTION
## Description

The primary domain validation for multisite imports fails when the provided SQL file does not contain the `wp_site` table. 

Customers will often import just these tables. E.g. if they are adding content to a new site on the network in preparation for launch and they don’t want to touch any other sites on the network.

This PR corrects the behaviour and adds relevant tests.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `node ./dist/bin/vip-import-sql.js @<id>.<environment> path_to_sql_file.sql` referencing a file that only contains subsite tables
1. Verify that [this error is not thrown](https://github.com/Automattic/vip/blob/214a5eccc971bc4296d5d4b0e2400079def7aa6f/src/lib/validations/site-type.js#L74-L77)

