### PR TITLE
[dev-env] support multiple falsy values

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -24,6 +24,7 @@ import {
 	addDevEnvConfigurationOptions,
 	getOptionsFromAppInfo,
 	handleCLIException,
+	processBooleanOption,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
@@ -56,7 +57,7 @@ const examples = [
 const cmd = command()
 	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'title', 'Title for the WordPress site' )
-	.option( 'multisite', 'Enable multisite install', undefined, value => 'false' !== value?.toLowerCase?.() );
+	.option( 'multisite', 'Enable multisite install', undefined, processBooleanOption );
 
 addDevEnvConfigurationOptions( cmd );
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -444,15 +444,28 @@ export async function promptForComponent( component: string, allowLocal: boolean
 	};
 }
 
+const FALSE_OPTIONS = [ 'false', 'no', 'n', '0' ];
+export function processBooleanOption( value: string ): boolean {
+	if ( ! value ) {
+		return false;
+	}
+
+	if ( FALSE_OPTIONS.includes( value.toLowerCase?.() ) ) {
+		return false;
+	}
+
+	return true;
+}
+
 export function addDevEnvConfigurationOptions( command ) {
 	return command
 		.option( 'wordpress', 'Use a specific WordPress version' )
 		.option( [ 'u', 'mu-plugins' ], 'Use a specific mu-plugins changeset or local directory' )
 		.option( 'client-code', 'Use the client code from a local directory or VIP skeleton' )
-		.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
-		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
-		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, value => 'false' !== value?.toLowerCase?.() )
-		.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use or false to disable it', undefined, value => 'false' === value?.toLowerCase?.() ? false : value )
+		.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, processBooleanOption )
+		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, processBooleanOption )
+		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, processBooleanOption )
+		.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use or false to disable it', undefined, value => FALSE_OPTIONS.includes( value?.toLowerCase?.() ) ? false : value )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
 		.option( 'php', 'Explicitly choose PHP version to use' );


### PR DESCRIPTION
## Description

For boolean options, we would only accept `false` as an actual false value. This change also adds `no`, `n` and `0` as valid falsy values. Everything else is considered true. evaluation is case insensitive.

## Steps to Test

Outline the steps to test and verify the PR here.


```
npm run build && ./dist/bin/vip-dev-env-create.js --slug test --multisite no --statsd n --phpmyadmin false
```

