### PR TITLE
[dev-env] switch name to slug in info table

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -192,14 +192,14 @@ export async function landoInfo( instancePath: string ) {
 
 	const extraService = await getExtraServicesConnections( lando, app );
 	appInfo = {
+		slug: appInfo.name.replace( /^vipdev/, '' ),
 		...appInfo,
 		...extraService,
 	};
 
-	appInfo.status = isUp ? chalk.green( 'UP' ) : chalk.yellow( 'DOWN' );
+	delete appInfo.name;
 
-	// Drop vipdev prefix
-	appInfo.name = appInfo.name.replace( /^vipdev/, '' );
+	appInfo.status = isUp ? chalk.green( 'UP' ) : chalk.yellow( 'DOWN' );
 
 	// Add login information
 	if ( frontEndUrl ) {


### PR DESCRIPTION


## Description

We are using `--slug` to choose name for dev-env so we should show it as `SLUG` in the info table too.

## Steps to Test


```
npm run build && ./dist/bin/vip-dev-env-info.js 
```

