### PR TITLE
[dev-env] rename clientCode to appCode 

### DIFF
--- a/__tests__/e2e_test.bat
+++ b/__tests__/e2e_test.bat
@@ -14,7 +14,7 @@ rem dev-env tests
 
 echo "== Creating dev-env"
 
-call vip dev-env create --client-code image --title Test --multisite false --php 8.0 --wordpress 6.0 --mu-plugins image -e false -p false -x false
+call vip dev-env create --app-code image --title Test --multisite false --php 8.0 --wordpress 6.0 --mu-plugins image -e false -p false -x false
 
 if NOT %errorlevel% == 0 (
     echo "== Failed to create dev-env"

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -197,8 +197,8 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 					mode: 'image',
 				},
 			},
-			{ // clientCode have just one tag
-				component: 'clientCode',
+			{ // appCode have just one tag
+				component: 'appCode',
 				mode: 'image',
 				expected: {
 					mode: 'image',
@@ -238,7 +238,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				preselected: {
 					title: 'a',
 					muPlugins: 'mu',
-					clientCode: 'code',
+					appCode: 'code',
 					wordpress: 'wp',
 				},
 				default: {
@@ -247,7 +247,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			{
 				preselected: {
 					muPlugins: 'mu',
-					clientCode: 'code',
+					appCode: 'code',
 					wordpress: 'wp',
 				},
 				default: {

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -147,7 +147,7 @@ services:
       mu-plugins: {}
 <% } %>
 
-<% if ( clientCode.mode == 'image' ) { %>
+<% if ( appCode.mode == 'image' ) { %>
   client-code:
     type: compose
     services:
@@ -205,7 +205,7 @@ tooling:
 <% } else { %>
         - <%= muPlugins.dir %>:/wp/wp-content/mu-plugins
 <% } %>
-<% if ( clientCode.mode == 'image' ) { %>
+<% if ( appCode.mode == 'image' ) { %>
         - type: volume
           source: clientcode_clientmuPlugins
           target: /wp/wp-content/client-mu-plugins
@@ -243,12 +243,12 @@ tooling:
           volume:
             nocopy: true
 <% } else { %>
-        - <%= clientCode.dir %>/client-mu-plugins:/wp/wp-content/client-mu-plugins
-        - <%= clientCode.dir %>/images:/wp/wp-content/images
-        - <%= clientCode.dir %>/languages:/wp/wp-content/languages
-        - <%= clientCode.dir %>/plugins:/wp/wp-content/plugins
-        - <%= clientCode.dir %>/private:/wp/wp-content/private
-        - <%= clientCode.dir %>/themes:/wp/wp-content/themes
-        - <%= clientCode.dir %>/vip-config:/wp/wp-content/vip-config
+        - <%= appCode.dir %>/client-mu-plugins:/wp/wp-content/client-mu-plugins
+        - <%= appCode.dir %>/images:/wp/wp-content/images
+        - <%= appCode.dir %>/languages:/wp/wp-content/languages
+        - <%= appCode.dir %>/plugins:/wp/wp-content/plugins
+        - <%= appCode.dir %>/private:/wp/wp-content/private
+        - <%= appCode.dir %>/themes:/wp/wp-content/themes
+        - <%= appCode.dir %>/vip-config:/wp/wp-content/vip-config
 <% } %>
 <% } %>

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -49,8 +49,8 @@ const examples = [
 		description: 'Assigning unique slugs to environments allows multiple environments to be created.',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress="5.8" --client-code="~/git/my_code"`,
-		description: 'Creates a local multisite dev environment using WP 5.8 and client code is expected to be in "~/git/my_code"',
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } create --multisite --wordpress="5.8" --app-code="~/git/my_code"`,
+		description: 'Creates a local multisite dev environment using WP 5.8 and application code is expected to be in "~/git/my_code"',
 	},
 ];
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -61,7 +61,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		};
 
 		const defaultOptions: InstanceOptions = {
-			clientCode: currentInstanceData.clientCode.dir || currentInstanceData.clientCode.tag || 'latest',
+			appCode: currentInstanceData.appCode.dir || currentInstanceData.appCode.tag || 'latest',
 			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
 			wordpress: currentInstanceData.wordpress.tag,
 			elasticsearchEnabled: currentInstanceData.elasticsearchEnabled,

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -14,7 +14,7 @@ export const DEV_ENVIRONMENT_PROMPT_INTRO = 'This is a wizard to help you set up
 	'You may also choose to create multiple environments with different settings using the --slug option.\n\n';
 export const DEV_ENVIRONMENT_NOT_FOUND = 'Environment not found.';
 
-export const DEV_ENVIRONMENT_COMPONENTS = [ 'wordpress', 'muPlugins', 'clientCode' ];
+export const DEV_ENVIRONMENT_COMPONENTS = [ 'wordpress', 'muPlugins', 'appCode' ];
 
 export const DEV_ENVIRONMENT_RAW_GITHUB_HOST = 'raw.githubusercontent.com';
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -168,7 +168,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		muPlugins: {
 			mode: 'image',
 		},
-		clientCode: {
+		appCode: {
 			mode: 'image',
 		},
 		statsd: false,
@@ -267,7 +267,7 @@ function validateLocalPath( component: string, providedPath: string ) {
 		};
 	}
 
-	if ( component === 'clientCode' ) {
+	if ( component === 'appCode' ) {
 		const files = [ 'languages', 'plugins', 'themes', 'private', 'images', 'client-mu-plugins', 'vip-config' ];
 
 		const missingFiles = [];
@@ -369,7 +369,7 @@ export async function promptForPhpVersion( initialValue: string ): Promise<strin
 const componentDisplayNames = {
 	wordpress: 'WordPress',
 	muPlugins: 'vip-go-mu-plugins',
-	clientCode: 'site-code',
+	appCode: 'application code',
 };
 
 export async function promptForComponent( component: string, allowLocal: boolean, defaultObject: ComponentConfig | null ): Promise<ComponentConfig> {
@@ -384,12 +384,12 @@ export async function promptForComponent( component: string, allowLocal: boolean
 		} );
 	}
 	modChoices.push( {
-		message: 'image - that gets automatically fetched',
+		message: 'demo image - that gets automatically fetched',
 		value: 'image',
 	} );
 
 	let initialMode = 'image';
-	if ( 'clientCode' === component ) {
+	if ( 'appCode' === component ) {
 		initialMode = 'local';
 	}
 
@@ -458,7 +458,7 @@ export function addDevEnvConfigurationOptions( command ) {
 	return command
 		.option( 'wordpress', 'Use a specific WordPress version' )
 		.option( [ 'u', 'mu-plugins' ], 'Use a specific mu-plugins changeset or local directory' )
-		.option( 'client-code', 'Use the client code from a local directory or VIP skeleton' )
+		.option( 'app-code', 'Use the application code from a local directory or use "demo" for VIP skeleton code' )
 		.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, processBooleanOption )
 		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, processBooleanOption )
 		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, processBooleanOption )

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -254,10 +254,21 @@ export function readEnvironmentData( slug: string ): InstanceData {
 
 	const instanceData = JSON.parse( instanceDataString );
 
+	/**
+	 ***********************************
+	 * BACKWARDS COMPATIBILITY SECTION
+	 ***********************************/
+
 	// REMOVEME after the wheel of time spins around few times
 	if ( instanceData.enterpriseSearchEnabled ) {
 		// enterpriseSearchEnabled was renamed to elasticsearchEnabled
 		instanceData.elasticsearchEnabled = instanceData.enterpriseSearchEnabled;
+	}
+
+	// REMOVEME after the wheel of time spins around few times
+	if ( instanceData.clientCode ) {
+		// clientCode was renamed to appCode
+		instanceData.appCode = instanceData.clientCode;
 	}
 
 	return instanceData;

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -4,7 +4,7 @@ export interface InstanceOptions {
 	multisite: boolean;
 	wordpress?: string;
 	muPlugins?: string;
-	clientCode?: string;
+	appCode?: string;
 	elasticsearchEnabled?: boolean;
 	elasticsearch?: string;
 	mariadb?: string;
@@ -48,7 +48,7 @@ export interface InstanceData {
 	multisite: boolean;
 	wordpress: ComponentConfig;
 	muPlugins: ComponentConfig;
-	clientCode: ComponentConfig;
+	appCode: ComponentConfig;
 	mediaRedirectDomain: string;
 	statsd: boolean;
 	phpmyadmin: boolean;


### PR DESCRIPTION
## Description

To make naming easier (and consistent) we renamed clientCode/siteCode to appCode.

## Steps to Test

` npm run build && ./dist/bin/vip-dev-env-create.js --slug test --app-code demo`

