### PR TITLE
Increase the limit of sql file from 1GB to 5GB for SQL Imports

### DIFF
--- a/src/lib/site-import/db-file-import.js
+++ b/src/lib/site-import/db-file-import.js
@@ -9,7 +9,7 @@
 import { GB_IN_BYTES } from 'lib/constants/file-size';
 
 export const SQL_IMPORT_FILE_SIZE_LIMIT = 100 * GB_IN_BYTES;
-export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 1 * GB_IN_BYTES;
+export const SQL_IMPORT_FILE_SIZE_LIMIT_LAUNCHED = 5 * GB_IN_BYTES;
 
 export interface AppForImport {
 	id: number;


### PR DESCRIPTION
## Description

Increases the max file size for DB imports into launched sites from 1GB to 5GB.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
2. Targeting a **launched** test site, run the following command with an SQL file larger than 5GB: `./dist/bin/vip-import-sql.js @<app>.<env> <path_to_file.sql>`
1. Verify [an error](https://github.com/Automattic/vip/blob/c027a204b6b7d8a4e23ecd489e7b8b993a10afc0/src/bin/vip-import-sql.js#L144-L150) is thrown
2. Try the same command using a file less than 5GB in size and verify that the error is not thrown

