### PR TITLE
[dev-env] Fix wording in wizard

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -371,20 +371,25 @@ const componentDisplayNames = {
 	muPlugins: 'vip-go-mu-plugins',
 	appCode: 'application code',
 };
+const componentDemoyNames = {
+	muPlugins: 'vip-go-mu-plugins',
+	appCode: 'vip-go-skeleton',
+};
 
 export async function promptForComponent( component: string, allowLocal: boolean, defaultObject: ComponentConfig | null ): Promise<ComponentConfig> {
 	debug( `Prompting for ${ component } with default:`, defaultObject );
 	const componentDisplayName = componentDisplayNames[ component ] || component;
+	const componentDemoName = componentDemoyNames[ component ] || component;
 	const modChoices = [];
 
 	if ( allowLocal ) {
 		modChoices.push( {
-			message: `local folder - where you already have ${ componentDisplayName }`,
+			message: `Custom - Path to a locally cloned ${ componentDisplayName } directory`,
 			value: 'local',
 		} );
 	}
 	modChoices.push( {
-		message: 'demo image - that gets automatically fetched',
+		message: `Demo - Automatically fetched ${ componentDemoName }`,
 		value: 'image',
 	} );
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -379,7 +379,7 @@ export async function promptForComponent( component: string, allowLocal: boolean
 
 	if ( allowLocal ) {
 		modChoices.push( {
-			message: `local folder - where you already have ${ componentDisplayName } code`,
+			message: `local folder - where you already have ${ componentDisplayName }`,
 			value: 'local',
 		} );
 	}


### PR DESCRIPTION


## Description

Fix wording in wizard by dropping `code` word.

So instead of:
>  local folder - where you already have application code code

We are going to get
>  local folder - where you already have application code

## Steps to Test

```
$npm run build && ./dist/bin/vip-dev-env-update.js 
...
✔ PHP version to use · 8.1
✔ WordPress - Which version would you like · 6.0
? How would you like to source vip-go-mu-plugins … 
▸ local folder - where you already have vip-go-mu-plugins
? How would you like to source application code … 
▸ local folder - where you already have application code
```


