### PR TITLE
Extract http helper into standalone function

### DIFF
--- a/src/lib/analytics/clients/pendo.js
+++ b/src/lib/analytics/clients/pendo.js
@@ -9,7 +9,7 @@ const debug = require( 'debug' )( '@automattic/vip:analytics:clients:pendo' );
  * Internal dependencies
  */
 import type { AnalyticsClient } from './client';
-import API from 'lib/api';
+import http from 'lib/api/http';
 
 /**
  * Pendo analytics client.
@@ -80,9 +80,7 @@ export default class Pendo implements AnalyticsClient {
 
 		debug( 'send()', body );
 
-		const { apiFetch } = await API();
-
-		const response = await apiFetch( Pendo.ENDPOINT, {
+		const response = await http( Pendo.ENDPOINT, {
 			method: 'POST',
 			body,
 		} );

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -78,7 +78,7 @@ export default async function API( { exitOnError = true } = {} ): Promise<Apollo
 
 	const proxyAgent = createProxyAgent( API_URL );
 
-	const http = require('./api/http').default;
+	const http = require( './api/http' ).default;
 
 	const httpLink = new HttpLink( {
 		uri: API_URL,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -78,10 +78,12 @@ export default async function API( { exitOnError = true } = {} ): Promise<Apollo
 
 	const proxyAgent = createProxyAgent( API_URL );
 
+	const http = require('./api/http').default;
+
 	const httpLink = new HttpLink( {
 		uri: API_URL,
 		headers,
-		fetch,
+		fetch: http,
 		fetchOptions: {
 			agent: proxyAgent,
 		},
@@ -91,31 +93,6 @@ export default async function API( { exitOnError = true } = {} ): Promise<Apollo
 		link: ApolloLink.from( [ withToken, errorLink, authLink, httpLink ] ),
 		cache: new InMemoryCache(),
 	} );
-
-	/**
-	 * Call the Public API with an arbitrary path (e.g. to connect to REST endpoints).
-	 * This will include the token in an Authorization header so requests are "logged-in."
-	 * @param {string} path API path to pass to `fetch` -- will be prefixed by the API_HOST
-	 * @param {object} options options to pass to `fetch`
-	 * @returns {Promise} Return value of the `fetch` call
-	 */
-	apiClient.apiFetch = ( path: string, options = {} ): Promise<any> =>
-		fetch( `${ API_HOST }${ path }`, {
-			...options,
-			...{
-				agent: proxyAgent,
-				headers: {
-					...headers,
-					...{
-						'Content-Type': 'application/json',
-					},
-					...options.headers,
-				},
-			},
-			...{
-				body: typeof options.body === 'object' ? JSON.stringify( options.body ) : options.body,
-			},
-		} );
 
 	return apiClient;
 }

--- a/src/lib/api/http.js
+++ b/src/lib/api/http.js
@@ -53,4 +53,4 @@ export default async ( path, options = {} ) => {
 			body: typeof options.body === 'object' ? JSON.stringify( options.body ) : options.body,
 		},
 	} );
-}
+};

--- a/src/lib/api/http.js
+++ b/src/lib/api/http.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import fetch from 'node-fetch';
 
+/**
+ * Internal dependencies
+ */
 import Token from 'lib/token';
 import env from 'lib/env';
 import { createProxyAgent } from 'lib/http/proxy-agent';

--- a/src/lib/api/http.js
+++ b/src/lib/api/http.js
@@ -1,0 +1,56 @@
+import fetch from 'node-fetch';
+
+import Token from 'lib/token';
+import env from 'lib/env';
+import { createProxyAgent } from 'lib/http/proxy-agent';
+import { API_HOST } from 'lib/api';
+
+const debug = require('debug')('@automattic/vip:http');
+
+/**
+ * Call the Public API with an arbitrary path (e.g. to connect to REST endpoints).
+ * This will include the token in an Authorization header so requests are "logged-in."
+ *
+ * This is simply a wrapper around node-fetch
+ *
+ * @param {string} path API path to pass to `fetch` -- will be prefixed by the API_HOST
+ * @param {object} options options to pass to `fetch`
+ * @returns {Promise} Return value of the `fetch` call
+ */
+export default async ( path, options = {} ) => {
+	let url = path;
+
+	// For convenience, we support just passing in the path to this function...
+	// but some things (Apollo) always pass the full url
+	if ( ! path.startsWith( API_HOST ) ) {
+		url = `${ API_HOST }${ path }`;
+	}
+
+	const authToken = await Token.get();
+
+	const headers = {
+		'User-Agent': env.userAgent,
+		Authorization: authToken ? `Bearer ${ authToken.raw }` : null,
+	};
+
+	const proxyAgent = createProxyAgent( url );
+
+	debug( 'running fetch', url );
+
+	return fetch( url, {
+		...options,
+		...{
+			agent: proxyAgent,
+			headers: {
+				...headers,
+				...{
+					'Content-Type': 'application/json',
+				},
+				...options.headers,
+			},
+		},
+		...{
+			body: typeof options.body === 'object' ? JSON.stringify( options.body ) : options.body,
+		},
+	} );
+}

--- a/src/lib/api/http.js
+++ b/src/lib/api/http.js
@@ -5,7 +5,7 @@ import env from 'lib/env';
 import { createProxyAgent } from 'lib/http/proxy-agent';
 import { API_HOST } from 'lib/api';
 
-const debug = require('debug')('@automattic/vip:http');
+const debug = require( 'debug' )( '@automattic/vip:http' );
 
 /**
  * Call the Public API with an arbitrary path (e.g. to connect to REST endpoints).


### PR DESCRIPTION
## Description

This extracts the HTTP transport code from the Apollo handler to a standalone utility. This decouples the HTTP request handling (with auto authorization, user agent, etc) from things like automatic 401 error handling (which calls `process.exit()` when it happens).

This means we can call the API from other parts of the code without the side effects of the 401 handling or any other Apollo functionality.

## Steps to Test

1. Check out PR.
1. Run `npm run build`
1. Run `./dist/bin/vip-app-list.js`
1. Should list all apps like normal
2. Run `./dist/bin/vip-wp.js @297.testing help`
3. Should see `wp help` output like normal

