### PR TITLE
Add @app.env to commands help

### DIFF
--- a/__tests__/bin/vip-config-envvar-delete.js
+++ b/__tests__/bin/vip-config-envvar-delete.js
@@ -62,7 +62,7 @@ describe( 'vip config envvar delete', () => {
 
 describe( 'deleteEnvVarCommand', () => {
 	let args, opts;
-	const eventPayload = expect.objectContaining( { command: expect.stringContaining( 'vip config envvar delete' ) } );
+	const eventPayload = expect.objectContaining( { command: expect.stringContaining( 'vip @mysite.develop config envvar delete' ) } );
 	const executeEvent = [ 'envvar_delete_command_execute', eventPayload ];
 	const successEvent = [ 'envvar_delete_command_success', eventPayload ];
 

--- a/__tests__/bin/vip-config-envvar-get-all.js
+++ b/__tests__/bin/vip-config-envvar-get-all.js
@@ -67,7 +67,7 @@ describe( 'getAllEnvVarsCommand', () => {
 		},
 		format: 'csv',
 	};
-	const eventPayload = expect.objectContaining( { command: 'vip config envvar get-all' } );
+	const eventPayload = expect.objectContaining( { command: 'vip @mysite.develop config envvar get-all' } );
 	const executeEvent = [ 'envvar_get_all_command_execute', eventPayload ];
 	const successEvent = [ 'envvar_get_all_command_success', eventPayload ];
 

--- a/__tests__/bin/vip-config-envvar-get.js
+++ b/__tests__/bin/vip-config-envvar-get.js
@@ -61,7 +61,7 @@ describe( 'getEnvVarCommand', () => {
 			type: 'develop',
 		},
 	};
-	const eventPayload = expect.objectContaining( { command: 'vip config envvar get HELLO' } );
+	const eventPayload = expect.objectContaining( { command: 'vip @mysite.develop config envvar get HELLO' } );
 	const executeEvent = [ 'envvar_get_command_execute', eventPayload ];
 	const successEvent = [ 'envvar_get_command_success', eventPayload ];
 

--- a/__tests__/bin/vip-config-envvar-list.js
+++ b/__tests__/bin/vip-config-envvar-list.js
@@ -67,7 +67,7 @@ describe( 'listEnvVarsCommand', () => {
 		},
 		format: 'csv',
 	};
-	const eventPayload = expect.objectContaining( { command: 'vip config envvar list' } );
+	const eventPayload = expect.objectContaining( { command: 'vip @mysite.develop config envvar list' } );
 	const executeEvent = [ 'envvar_list_command_execute', eventPayload ];
 	const successEvent = [ 'envvar_list_command_success', eventPayload ];
 

--- a/__tests__/bin/vip-config-envvar-set.js
+++ b/__tests__/bin/vip-config-envvar-set.js
@@ -67,7 +67,7 @@ describe( 'vip config envvar set', () => {
 
 describe( 'setEnvVarCommand', () => {
 	let args, opts;
-	const eventPayload = expect.objectContaining( { command: expect.stringContaining( 'vip config envvar set' ) } );
+	const eventPayload = expect.objectContaining( { command: expect.stringContaining( 'vip @mysite.develop config envvar set' ) } );
 	const executeEvent = [ 'envvar_set_command_execute', eventPayload ];
 	const successEvent = [ 'envvar_set_command_success', eventPayload ];
 

--- a/src/bin/vip-config-envvar-delete.js
+++ b/src/bin/vip-config-envvar-delete.js
@@ -20,7 +20,7 @@ import { debug, getEnvContext } from 'lib/envvar/logging';
 import { rollbar } from 'lib/rollbar';
 import { trackEvent } from 'lib/tracker';
 
-const baseUsage = 'vip config envvar delete';
+const baseUsage = 'vip @mysite.develop config envvar delete';
 
 // Command examples
 const examples = [

--- a/src/bin/vip-config-envvar-get-all.js
+++ b/src/bin/vip-config-envvar-get-all.js
@@ -20,7 +20,7 @@ import { debug, getEnvContext } from 'lib/envvar/logging';
 import { rollbar } from 'lib/rollbar';
 import { trackEvent } from 'lib/tracker';
 
-const usage = 'vip config envvar get-all';
+const usage = 'vip @mysite.develop config envvar get-all';
 
 // Command examples
 const examples = [

--- a/src/bin/vip-config-envvar-get.js
+++ b/src/bin/vip-config-envvar-get.js
@@ -19,7 +19,7 @@ import { debug, getEnvContext } from 'lib/envvar/logging';
 import { rollbar } from 'lib/rollbar';
 import { trackEvent } from 'lib/tracker';
 
-const baseUsage = 'vip config envvar get';
+const baseUsage = 'vip @mysite.develop config envvar get';
 
 // Command examples
 const examples = [

--- a/src/bin/vip-config-envvar-list.js
+++ b/src/bin/vip-config-envvar-list.js
@@ -20,7 +20,7 @@ import { debug, getEnvContext } from 'lib/envvar/logging';
 import { rollbar } from 'lib/rollbar';
 import { trackEvent } from 'lib/tracker';
 
-const usage = 'vip config envvar list';
+const usage = 'vip @mysite.develop config envvar list';
 
 // Command examples
 const examples = [

--- a/src/bin/vip-config-envvar-set.js
+++ b/src/bin/vip-config-envvar-set.js
@@ -21,7 +21,7 @@ import { readVariableFromFile } from 'lib/envvar/read-file';
 import { rollbar } from 'lib/rollbar';
 import { trackEvent } from 'lib/tracker';
 
-const baseUsage = 'vip config envvar set';
+const baseUsage = 'vip @mysite.develop config envvar set';
 
 const NEW_RELIC_ENVVAR_KEY = 'NEW_RELIC_LICENSE_KEY';
 

--- a/src/bin/vip-config-software-get.js
+++ b/src/bin/vip-config-software-get.js
@@ -21,11 +21,11 @@ import UserError from 'lib/user-error';
 // Command examples
 const examples = [
 	{
-		usage: 'vip config software get wordpress --format json',
+		usage: 'vip @mysite.develop config software get wordpress --format json',
 		description: 'Read current software settings for WordPress in JSON format',
 	},
 	{
-		usage: 'vip config software get',
+		usage: 'vip @mysite.develop config software get',
 		description: 'Read current software settings for all components',
 	},
 ];
@@ -37,7 +37,7 @@ command( {
 	envContext: true,
 	wildcardCommand: true,
 	format: true,
-	usage: 'vip config software get <wordpress|php|nodejs|muplugins>',
+	usage: 'vip @mysite.develop config software get <wordpress|php|nodejs|muplugins>',
 } ).examples( examples ).argv( process.argv, async ( arg: string[], opt ) => {
 	const trackingInfo = {
 		environment_id: opt.env?.id,

--- a/src/bin/vip-config-software-update.js
+++ b/src/bin/vip-config-software-update.js
@@ -34,14 +34,14 @@ const cmd = command( {
 	appQueryFragments,
 	envContext: true,
 	wildcardCommand: true,
-	usage: 'vip config software update <wordpress|php|nodejs|muplugins> <version>',
+	usage: 'vip @mysite.develop config software update <wordpress|php|nodejs|muplugins> <version>',
 } ).examples( [
 	{
-		usage: 'vip config software update wordpress 6.0',
+		usage: 'vip @mysite.develop config software update wordpress 6.0',
 		description: 'Update WordPress to 6.0.x',
 	},
 	{
-		usage: 'vip config software update nodejs 16',
+		usage: 'vip @mysite.develop config software update nodejs 16',
 		description: 'Update Node.js to v16',
 	},
 ] );

--- a/src/bin/vip-config-software.js
+++ b/src/bin/vip-config-software.js
@@ -16,15 +16,8 @@ import command from 'lib/cli/command';
 
 command( {
 	requiredArgs: 1,
-	usage: 'vip config software <action>',
+	usage: 'vip @mysite.develop config software <action>',
 } )
 	.command( 'get', 'Read current software settings' )
-	.command( 'update', 'Update software settings' ).examples(
-		[
-			{
-				usage: 'vip config software update <wordpress|php|nodejs|muplugins> <version>',
-				description: 'Update <component> to <version>',
-			},
-		]
-	)
+	.command( 'update', 'Update software settings' )
 	.argv( process.argv );


### PR DESCRIPTION

## Description

All `vip config` subcommands need to target an `@app.env`. This change adds it to the examples/usage provided to user.

## Steps to Test

```
 npm run build && ./dist/bin/vip-config-envvar-list.js --help
```

