### PR TITLE
[dev-env] fetch php and wordpress versions for creation wizard

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -148,6 +148,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 						branch: 'dev',
 						isMultisite: true,
 						primaryDomain: '',
+						php: '',
+						wordpress: '',
 					},
 				},
 			},
@@ -193,6 +195,18 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 							primaryDomain: {
 								name: 'test.develop.com',
 							},
+							softwareSettings: {
+								php: {
+									current: {
+										version: '8.1',
+									},
+								},
+								wordpress: {
+									current: {
+										version: '6.2',
+									},
+								},
+							},
 						},
 						{
 							name: 'prodName',
@@ -212,6 +226,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 						branch: 'dev',
 						isMultisite: true,
 						primaryDomain: 'test.develop.com',
+						php: '8.1',
+						wordpress: '6.2',
 					},
 				},
 			},

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -132,6 +132,8 @@ export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
 		title: appInfo.environment?.name || appInfo.name || '',
 		multisite: !! appInfo?.environment?.isMultisite,
 		mediaRedirectDomain: appInfo.environment?.primaryDomain,
+		php: appInfo.environment?.php || '',
+		wordpress: appInfo.environment?.wordpress || '',
 	};
 }
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -33,6 +33,7 @@ import {
 	DEV_ENVIRONMENT_PHP_VERSIONS,
 } from '../constants/dev-environment';
 import type { AppInfo, ComponentConfig, InstanceData } from './types';
+import { appQueryFragments as softwareQueryFragment } from '../config/software';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -366,10 +367,18 @@ export async function getApplicationInformation( appId: number, envType: string 
 			isMultisite,
 			primaryDomain {
 				name
+			},
+			softwareSettings {
+				php {
+				  ...Software
+				}
+				wordpress {
+				  ...Software
+				}
 			}
 		}`;
 
-	const queryResult = await app( appId, fieldsQuery );
+	const queryResult = await app( appId, fieldsQuery, softwareQueryFragment );
 
 	const appData = {};
 
@@ -403,6 +412,8 @@ export async function getApplicationInformation( appId: number, envType: string 
 				type: envData.type,
 				isMultisite: envData.isMultisite,
 				primaryDomain: envData.primaryDomain?.name || '',
+				php: envData.softwareSettings?.php?.current?.version || '',
+				wordpress: envData.softwareSettings?.wordpress?.current?.version || '',
 			};
 		}
 	}

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -25,6 +25,8 @@ export type AppInfo = {
 		branch: string;
 		isMultisite: boolean;
 		primaryDomain: string;
+		php: string;
+		wordpress: string;
 	};
 }
 


### PR DESCRIPTION
## Description

Fetch `php` and `wordpress` versions from real site and inform the default values during the setup wizard

## Steps to Test

```
npm run build && ./dist/bin/vip-dev-env-create.js @2891
```

