### PR TITLE
Using http module instead of already decommissioned API.apiFetch function

### DIFF
--- a/src/lib/client-file-uploader.js
+++ b/src/lib/client-file-uploader.js
@@ -20,7 +20,7 @@ import debugLib from 'debug';
 /**
  * Internal dependencies
  */
-import API from 'lib/api';
+import http from 'lib/api/http';
 import { MB_IN_BYTES } from 'lib/constants/file-size';
 
 const debug = debugLib( 'vip:lib/client-file-uploader' );
@@ -326,8 +326,7 @@ export async function getSignedUploadRequestData( {
 	uploadId = undefined,
 	partNumber = undefined,
 }: GetSignedUploadRequestDataArgs ): Promise<Object> {
-	const { apiFetch } = await API();
-	const response = await apiFetch( '/upload/site-import-presigned-url', {
+	const response = await http( '/upload/site-import-presigned-url', {
 		method: 'POST',
 		body: { action, appId, basename, envId, etagResults, partNumber, uploadId },
 	} );


### PR DESCRIPTION
## Description

The apiFetch method of the API module was removed earlier but all references were not updated: https://github.com/Automattic/vip/pull/1091

This PR uses the `http` internal module over here which is was intended with the earlier PR 

## Steps to Test

TBD

