### PR TITLE
[dev-env] Validate dns lookup

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -63,8 +63,6 @@ addDevEnvConfigurationOptions( cmd );
 
 cmd.examples( examples );
 cmd.argv( process.argv, async ( arg, opt ) => {
-	await validateDependencies();
-
 	const environmentNameOptions = {
 		slug: opt.slug,
 		app: opt.app,
@@ -72,6 +70,9 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		allowAppEnv: true,
 	};
 	const slug = getEnvironmentName( environmentNameOptions );
+
+	await validateDependencies( slug );
+
 	debug( 'Args: ', arg, 'Options: ', opt );
 
 	const trackingInfo = { slug };

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -43,8 +43,8 @@ command()
 	.option( 'soft', 'Keep config files needed to start an environment intact' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		await validateDependencies();
 		const slug = getEnvironmentName( opt );
+		await validateDependencies( slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_destroy_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -39,8 +39,8 @@ command( { wildcardCommand: true } )
 	.option( 'force', 'Disabling validations before task execution', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
-		await validateDependencies();
 		const slug = getEnvironmentName( opt );
+		await validateDependencies( slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_exec_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -35,9 +35,9 @@ command( {
 	.examples( examples )
 	.option( 'slug', 'Custom name of the dev environment' )
 	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
-		await validateDependencies();
 		const [ filePath ] = unmatchedArgs;
 		const slug = getEnvironmentName( opt );
+		await validateDependencies( slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_import_media_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -48,10 +48,10 @@ command( {
 	.option( 'skip-validate', 'Do not perform file validation.' )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
-		await validateDependencies();
 		const [ fileName ] = unmatchedArgs;
 		const { searchReplace, inPlace } = opt;
 		const slug = getEnvironmentName( opt );
+		await validateDependencies( slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_import_sql_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -39,8 +39,8 @@ command()
 	.option( 'extended', 'Show extended information about the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		await validateDependencies();
 		const slug = getEnvironmentName( opt );
+		await validateDependencies( slug );
 
 		const trackingInfo = opt.all ? { all: true } : getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_info_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-list.js
+++ b/src/bin/vip-dev-env-list.js
@@ -34,7 +34,7 @@ command()
 		await trackEvent( 'dev_env_list_command_execute', trackingInfo );
 
 		try {
-			await printAllEnvironmentsInfo();
+			await printAllEnvironmentsInfo( {} );
 			await trackEvent( 'dev_env_list_command_success', trackingInfo );
 		} catch ( error ) {
 			handleCLIException( error, 'dev_env_list_command_error', trackingInfo );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -39,10 +39,10 @@ command()
 	.option( [ 'w', 'skip-wp-versions-check' ], 'Skip propting for wordpress update if non latest' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		await validateDependencies();
+		const slug = getEnvironmentName( opt );
+		await validateDependencies( slug );
 
 		const startProcessing = new Date();
-		const slug = getEnvironmentName( opt );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_start_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -34,8 +34,8 @@ command()
 	.option( 'slug', 'Custom name of the dev environment' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		await validateDependencies();
 		const slug = getEnvironmentName( opt );
+		await validateDependencies( slug );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -37,8 +37,8 @@ addDevEnvConfigurationOptions( cmd );
 
 cmd.examples( examples );
 cmd.argv( process.argv, async ( arg, opt ) => {
-	await validateDependencies();
 	const slug = getEnvironmentName( opt );
+	await validateDependencies( slug );
 
 	const trackingInfo = getEnvTrackingInfo( slug );
 	await trackEvent( 'dev_env_update_command_execute', trackingInfo );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -69,12 +69,37 @@ export async function handleCLIException( exception: Error, trackKey?: string, t
 	}
 }
 
-export const validateDependencies = async () => {
+const verifyDNSResolution = ( slug: string ) => {
+	const dns = require( 'dns' );
+	const expectedIP = '127.0.0.1';
+	const testDomain = `${ slug }.vipdev.lndo.site`;
+	const advice = `Please add following line to hosts file on your system:\n${ expectedIP } ${ testDomain }`;
+
+	debug( `Verifying DNS resolution for ${ testDomain }` );
+	return new Promise( ( resolve, reject ) => {
+		dns.lookup( testDomain, ( error, address ) => {
+			debug( `Got DNS response ${ address }` );
+
+			if ( error ) {
+				reject( new UserError( `DNS resolution for ${ testDomain } failed. ${ advice }` ) );
+			}
+
+			if ( address !== expectedIP ) {
+				reject( new UserError( `DNS resolution for ${ testDomain } returned unexpected IP ${ address }. Expected value is ${ expectedIP }. ${ advice }` ) );
+			}
+
+			resolve();
+		} );
+	} );
+};
+
+export const validateDependencies = async ( slug: string ) => {
 	try {
 		await validateDockerInstalled();
 	} catch ( exception ) {
-		exit.withError( exception.message );
+		throw new UserError( exception.message );
 	}
+	await verifyDNSResolution( slug );
 };
 
 export function getEnvironmentName( options: EnvironmentNameOptions ): string {


### PR DESCRIPTION
## Description

The biggest pain point in using `vip dev-env` can be networking. Especially DNS lookup of `smth.vipdev.lndo.site` as this can be suppressed by DNS used by users.

This change introduces DNS lookup which should detect the problem in advance and provide a workaround in form of changing `hosts` file to circumvent domain name lookup altogether. 

## Steps to Test

1) Change the dev-env domain to some wrong address. e.g. 
```
const testDomain = `${ slug }.vipdev.lndo.site`;
```
change to 
```
const testDomain = `${ slug }.totally.not.correct`;
```
2) Run `npm run build && ./dist/bin/vip-dev-env-create.js --slug test`
3) You should get an error with suggestion to update hosts file.
4) Follow the suggestion
5) try again and prosper (no more errors)

