### PR TITLE
[dev-env] Validate import file and add debug lines

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -278,12 +278,13 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			expect( searchAndReplace ).not.toHaveBeenCalled();
 
 			await expect( promise ).rejects.toEqual(
-				new Error( 'The provided file does not exist or it is not valid (see "--help" for examples)' )
+				new Error( 'The provided file undefined does not exist or it is not valid (see "--help" for examples)' )
 			);
 		} );
 
 		it( 'should resolve the path and replace it with /user', async () => {
 			fs.existsSync.mockReturnValue( true );
+			fs.lstatSync.mockReturnValue( { isDirectory: () => false } );
 			const resolvedPath = `${ os.homedir() }/testfile.sql`;
 			resolvePath.mockReturnValue( resolvedPath );
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -38,7 +38,10 @@ const DEFAULT_SLUG = 'vip-local';
 
 export async function handleCLIException( exception: Error, trackKey?: string, trackBaseInfo?: any = {} ) {
 	const errorPrefix = chalk.red( 'Error:' );
-	if ( DEV_ENVIRONMENT_NOT_FOUND === exception.message ) {
+	if ( exception instanceof UserError ) {
+		// User errors are handled in global error handler
+		throw exception;
+	} else if ( DEV_ENVIRONMENT_NOT_FOUND === exception.message ) {
 		const createCommand = chalk.bold( DEV_ENVIRONMENT_FULL_COMMAND + ' create' );
 
 		const message = `Environment doesn't exist.\n\n\nTo create a new environment run:\n\n${ createCommand }\n`;

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -34,6 +34,7 @@ import {
 } from '../constants/dev-environment';
 import type { AppInfo, ComponentConfig, InstanceData } from './types';
 import { appQueryFragments as softwareQueryFragment } from '../config/software';
+import UserError from '../user-error';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -422,10 +423,16 @@ export async function getApplicationInformation( appId: number, envType: string 
 }
 
 export async function resolveImportPath( slug: string, fileName: string, searchReplace: string | string[], inPlace: boolean ): Promise<SQLImportPaths> {
+	debug( `Will try to resolve path - ${ fileName }` );
 	let resolvedPath = resolvePath( fileName );
 
+	debug( `Filename ${ fileName } resolved to ${ resolvedPath }` );
+
 	if ( ! fs.existsSync( resolvedPath ) ) {
-		throw new Error( 'The provided file does not exist or it is not valid (see "--help" for examples)' );
+		throw new UserError( `The provided file ${ resolvedPath } does not exist or it is not valid (see "--help" for examples)` );
+	}
+	if ( fs.lstatSync( resolvedPath ).isDirectory() ) {
+		throw new UserError( `The provided file ${ resolvedPath } is a directory. Please point to a sql file.` );
 	}
 
 	// Run Search and Replace if the --search-replace flag was provided


### PR DESCRIPTION
## Description

This change detects if the import file is a directory to avoid:
```
 EISDIR: illegal operation on a directory, read
```

Also adds a bit more debug lines to make it easier to debug import path issues.

## Steps to Test

1) `npm run build && ./dist/bin/vip-dev-env-import-sql.js test --debug`

