### PR TITLE
[dev-env] skip validate skips env up check too

### DIFF
--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -68,18 +68,21 @@ command( {
 				} );
 			}
 
+			const execOptions = {
+				force: !! opt.skipValidate,
+			};
 			const importArg = [ 'wp', 'db', 'import', inContainerPath ];
-			await exec( slug, importArg );
+			await exec( slug, importArg, execOptions );
 
 			if ( searchReplace && searchReplace.length && ! inPlace ) {
 				fs.unlinkSync( resolvedPath );
 			}
 
 			const cacheArg = [ 'wp', 'cache', 'flush' ];
-			await exec( slug, cacheArg );
+			await exec( slug, cacheArg, execOptions );
 
 			const addUserArg = [ 'wp', 'dev-env-add-admin', '--username=vipgo', '--password=password' ];
-			await exec( slug, addUserArg );
+			await exec( slug, addUserArg, execOptions );
 			await trackEvent( 'dev_env_import_sql_command_success', trackingInfo );
 		} catch ( error ) {
 			handleCLIException( error, 'dev_env_import_sql_command_error', trackingInfo );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -235,7 +235,11 @@ export async function printEnvironmentInfo( slug: string, options: PrintOptions 
 	printTable( appInfo );
 }
 
-export async function exec( slug: string, args: Array<string>, options: any = {} ) {
+interface ExecOptions {
+	force?: boolean
+}
+
+export async function exec( slug: string, args: Array<string>, options: ExecOptions = {} ) {
 	debug( 'Will run a wp command on env', slug, 'with args', args, ' and options', options );
 
 	const instancePath = getEnvironmentPath( slug );

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -269,7 +269,11 @@ async function isEnvUp( app ) {
 	return scanResult?.length && scanResult.filter( result => result.status ).length === scanResult.length;
 }
 
-export async function landoExec( instancePath: string, toolName: string, args: Array<string>, options: any ) {
+interface LandoExecOptions {
+	force?: boolean
+}
+
+export async function landoExec( instancePath: string, toolName: string, args: Array<string>, options: LandoExecOptions ) {
 	const lando = new Lando( getLandoConfig() );
 	await lando.bootstrap();
 


### PR DESCRIPTION
## Description

When users try to import SQL to dev-env we check for validity of SQL file. We also check that `dev-env` is UP. The user has an option to skip file validations with `--skip-validate`. This change makes it that `--skip-validate` will also skip environment status.

This is useful for cases when the environment is reported to be DOWN as false negative due to an issue with communication between terminal and public endpoints but still works fine in browser.


## Steps to Test
1) Have dev-env down
2) Run
```
npm run build && ./dist/bin/vip-dev-env-import-sql.js ~/Downloads/test.sql -S
```
