### PR TITLE
[dev-env] prompt for es index after db import

### DIFF
--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -82,7 +82,7 @@ command( {
 
 			try {
 				await exec( slug, [ 'wp', 'cli', 'has-command', 'vip-search' ] );
-				const doIndex = await promptForBoolean( 'Do you wnat to index data in ElasticSearch (used by enterprise search)?', true );
+				const doIndex = await promptForBoolean( 'Do you want to index data in ElasticSearch (used by enterprise search)?', true );
 				if ( doIndex ) {
 					await exec( slug, [ 'wp', 'vip-search', 'index', '--setup', '--network-wide', '--skip-confirm' ] );
 				}

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -86,7 +86,7 @@ command( {
 				if ( doIndex ) {
 					await exec( slug, [ 'wp', 'vip-search', 'index', '--setup', '--network-wide', '--skip-confirm' ] );
 				}
-			} catch( e ) {
+			} catch ( e ) {
 				// Exception means they don't have vip-search enabled.
 			}
 

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -15,10 +15,12 @@ import fs from 'fs';
  */
 import { trackEvent } from 'lib/tracker';
 import command from '../lib/cli/command';
-import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, promptForBoolean, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import { validate } from '../lib/validations/sql';
+import { confirm } from '../lib/cli/prompt';
+import { prompt } from 'enquirer';
 
 const examples = [
 	{
@@ -77,6 +79,16 @@ command( {
 
 			const cacheArg = [ 'wp', 'cache', 'flush' ];
 			await exec( slug, cacheArg );
+
+			try {
+				await exec( slug, [ 'wp', 'cli', 'has-command', 'vip-search' ] );
+				const doIndex = await promptForBoolean( 'Do you wnat to index data in ElasticSearch (used by enterprise search)?', true );
+				if ( doIndex ) {
+					await exec( slug, [ 'wp', 'vip-search', 'index', '--setup', '--network-wide', '--skip-confirm' ] );
+				}
+			} catch( e ) {
+				// Exception means they don't have vip-search enabled.
+			}
 
 			const addUserArg = [ 'wp', 'dev-env-add-admin', '--username=vipgo', '--password=password' ];
 			await exec( slug, addUserArg );


### PR DESCRIPTION
## Description

After users does sql import and if they are using enterprise search we can ask if they want to reindex elastic search so that data is up to date as well.

```
/dist/bin/vip-dev-env-import-sql.js ~/Downloads/test.sql 
Success: Imported from '/user/Downloads/test.sql'.
Success: The cache was flushed.
✔ Do you wnat to index data in ElasticSearch (used by enterprise search)? (Y/n) · true
Adding post mapping...
Success: Mapping sent
Indexing posts...
Processed 2/2. Last Object ID: 1
Number of posts indexed: 2
Total time elapsed: 0.964
Success: Done!
User "vipgo" already exits. Skipping creating it.
```

## Steps to Test


```
/dist/bin/vip-dev-env-import-sql.js ~/Downloads/test.sql 
```

