### PR TITLE
Handle comand interruptions during software update

### DIFF
--- a/src/lib/config/software.js
+++ b/src/lib/config/software.js
@@ -217,7 +217,9 @@ const _processComponent = async ( appTypeId: number, userProvidedComponent: stri
 		message: 'Component to update',
 		choices,
 	} );
-	return await select.run();
+	return await select.run().catch( () => {
+		throw new UserError( 'Command cancelled by user.' );
+	} );
 };
 
 const _processComponentVersion = async ( softwareSettings, component: string, userProvidedVersion: string | undefined ) => {
@@ -235,7 +237,9 @@ const _processComponentVersion = async ( softwareSettings, component: string, us
 		message: `Version for ${ COMPONENT_NAMES[ component ] } to upgrade to`,
 		choices: versionChoices,
 	} );
-	return await versionSelect.run();
+	return await versionSelect.run().catch( () => {
+		throw new UserError( 'Command cancelled by user.' );
+	} );
 };
 
 interface UpdateData {
@@ -255,7 +259,9 @@ export const promptForUpdate = async ( appTypeId: number, opts: UpdatePromptOpti
 
 	const confirm = opts.force || await new Confirm( {
 		message: `Are you sure you want to upgrade ${ COMPONENT_NAMES[ component ] } to ${ version }?`,
-	} ).run();
+	} ).run().catch( () => {
+		throw new UserError( 'Command cancelled by user.' );
+	} );
 
 	if ( confirm ) {
 		return {


### PR DESCRIPTION


## Description

When prompts are `ESC`ed or `Ctrl+C`ed during sw update we should handle it gracefully.

## Steps to Test

```
./dist/bin/vip-config-software-update.js @2891
✔ Component to update · wordpress
✖ Version for WordPress to upgrade to · 
Error:  Command cancelled by user.
Debug:  VIP-CLI v2.18.0, Node v14.18.0, linux 5.15.0-46-generic
```
