### PR TITLE
[dev-env] reclasify most common error

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -14,6 +14,7 @@ import landoUtils from 'lando/plugins/lando-core/lib/utils';
 import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import chalk from 'chalk';
 import App from 'lando/lib/app';
+import UserError from '../user-error';
 
 /**
  * Internal dependencies
@@ -280,7 +281,7 @@ export async function landoExec( instancePath: string, toolName: string, args: A
 		const isUp = await isEnvUp( app );
 
 		if ( ! isUp ) {
-			throw new Error( 'environment needs to be started before running wp command' );
+			throw new UserError( 'Environment needs to be started before running wp command' );
 		}
 	}
 


### PR DESCRIPTION
## Description

The most common error we see in our error report is: `Environment needs to be started before running wp command`

This change reclassifies the error to `UserError` which makes it not reported as `<command>_error`.

## Steps to Test
Without starting dev-env do:


```
npm run build && ./dist/bin/vip-dev-env-exec.js --debug @automattic/vip:analytics:clients:tracks -- wp test
```

