### PR TITLE
Remove unused confirmation prompt during sql import

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -359,8 +359,6 @@ command( {
 	envContext: true,
 	requiredArgs: 1,
 	module: 'import-sql',
-	requireConfirm: 'Are you sure you want to import the contents of the provided SQL file?',
-	skipConfirmPrompt: true,
 } )
 	.command( 'status', 'Check the status of the current running import' )
 	.option(


### PR DESCRIPTION

## Description

What’s happening is that the there is [supposed to be another confirmation right at the beginning](https://github.com/Automattic/vip-cli/blob/48408e8df48536e5aad6eeac3799aa98ef5290ba/src/bin/vip-import-sql.js#L362), which is not working for this command because of the `skipConfirmPrompt: true`

This results in having `--force` parameter in help that doesn't do anything.

This change removes the prompt and its autoskipping.

## Steps to Test


```
$ npm run build && ./dist/bin/vip-import-sql.js --help
```
