### PR TITLE
Use --yes instead of --force

### DIFF
--- a/src/bin/vip-config-software-update.js
+++ b/src/bin/vip-config-software-update.js
@@ -45,7 +45,7 @@ const cmd = command( {
 		description: 'Update Node.js to v16',
 	},
 ] );
-cmd.option( 'force', 'Auto-confirm update' );
+cmd.option( 'yes', 'Auto-confirm update' );
 cmd.argv( process.argv, async ( arg: string[], opt ) => {
 	const { app, env } = opt;
 	const { softwareSettings } = env;
@@ -63,7 +63,7 @@ cmd.argv( process.argv, async ( arg: string[], opt ) => {
 		}
 
 		const updateOptions: UpdatePromptOptions = {
-			force: !! opt.force,
+			force: !! opt.yes,
 		};
 
 		if ( arg.length > 0 ) {


### PR DESCRIPTION
## Description

In an effort to unify prompt skipping option we are renaming `--force` to `--yes`

## Steps to Test

```
npm run build && ./dist/bin/vip-config-software-update.js @2891 php --yes
```
