### PR TITLE
Update php-fpm image names

### DIFF
--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -26,8 +26,8 @@ export const DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL = 86400; // once per day
 
 export const DEV_ENVIRONMENT_PHP_VERSIONS = {
 	// eslint-disable-next-line quote-props
-	'8.1': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.1',
-	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:8.0',
-	// eslint-disable-next-line quote-props -- flow does nit support non-string keys
-	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm-alt:7.4',
+	'8.1': 'ghcr.io/automattic/vip-container-images/php-fpm:8.1',
+	'8.0': 'ghcr.io/automattic/vip-container-images/php-fpm:8.0',
+	// eslint-disable-next-line quote-props -- flow does not support non-string keys
+	'7.4': 'ghcr.io/automattic/vip-container-images/php-fpm:7.4',
 };


### PR DESCRIPTION
## Description

This PR updates the name of the `php-fpm` image.

Ref: Automattic/vip-container-images#291

## Steps to Test

Check out this PR and create a new dev environment with PHP 8.1 (we didn't have php-fpm:8.1 image). If it works, everything is good :-)
