### PR TITLE
Add support for custom PHP images

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -366,6 +366,11 @@ export async function promptForBoolean( message: string, initial: boolean ): Pro
 
 function resolvePhpVersion( version: string ): string {
 	debug( `Resolving PHP version '${ version }'` );
+
+	if ( version.startsWith( 'image:' ) ) {
+		return version;
+	}
+
 	const versions = Object.keys( DEV_ENVIRONMENT_PHP_VERSIONS );
 	const images = ( ( Object.values( DEV_ENVIRONMENT_PHP_VERSIONS ): any[] ): string[] );
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -367,7 +367,7 @@ export async function promptForBoolean( message: string, initial: boolean ): Pro
 function resolvePhpVersion( version: string ): string {
 	debug( `Resolving PHP version '${ version }'` );
 
-	if ( version.startsWith( 'image:' ) ) {
+	if ( typeof version === 'string' && version.startsWith( 'image:' ) ) {
 		return version;
 	}
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -153,6 +153,10 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 	newInstanceData.elasticsearchEnabled = instanceData.elasticsearchEnabled || false;
 
 	newInstanceData.php = instanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default;
+	if ( newInstanceData.php.startsWith( 'image:' ) ) {
+		newInstanceData.php = newInstanceData.php.slice( 'image:'.length );
+	}
+
 	return newInstanceData;
 }
 


### PR DESCRIPTION
## Description

This PR adds experimental support for custom PHP images.

Currently, it is possible to specify the name of the image only with the help of the command line, like this:

```sh
./dist/bin/vip-dev-env-create.js -a demo -e false -P image:php:8.2-rc-fpm-alpine -s xxx -w 6.0 -t title
```

The name of the image needs to be prefixed with the `image:` string.

## Steps to Test

`vip dev-env create` and `vip dev-env update` should work as they used to.