### PR TITLE
[dev-env] support xdebug_config environment variable

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -40,9 +40,11 @@ services:
       command: run.sh
       working_dir: /wp
       environment:
-        XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
         STATSD: <%= statsd ? 'enable' : 'disable' %>
-
+        XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
+<% if ( xdebugConfig ) { %>
+        XDEBUG_CONFIG: "<%= xdebugConfig %>"
+<% } %>
         LANDO_NO_USER_PERMS: 'enable'
 
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -204,6 +204,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		statsd: false,
 		phpmyadmin: false,
 		xdebug: false,
+		xdebugConfig: preselectedOptions.xdebugConfig,
 		siteSlug: '',
 	};
 
@@ -250,7 +251,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 			if ( service in preselectedOptions ) {
 				instanceData[ service ] = preselectedOptions[ service ];
 			} else {
-				instanceData[ service ] = await promptForBoolean( `Enable ${ promptLabels[ service ] || service }`, instanceData[ service ] );
+				instanceData[ service ] = await promptForBoolean( `Enable ${ promptLabels[ service ] || service }`, defaultOptions[ service ] );
 			}
 		}
 	}
@@ -497,6 +498,7 @@ export function addDevEnvConfigurationOptions( command ) {
 		.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, processBooleanOption )
 		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, processBooleanOption )
 		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, processBooleanOption )
+		.option( 'xdebug_config', 'Extra configuration to pass to xdebug via XDEBUG_CONFIG environment variable' )
 		.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use or false to disable it', undefined, value => FALSE_OPTIONS.includes( value?.toLowerCase?.() ) ? false : value )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -13,6 +13,7 @@ export interface InstanceOptions {
 	statsd?: boolean;
 	phpmyadmin?: boolean;
 	xdebug?: boolean;
+	xdebugConfig?: string;
 }
 
 export type AppInfo = {


### PR DESCRIPTION
## Description

This change enables users to pass `--xdebug_config` parameter to `vip dev-env create/update` the value of this parameter is then used to set-up `XDEBUG_CONFIG` environment variable on `php` container.

[This variable ](https://xdebug.org/docs/all_settings) can be used to overwrite certain configuration of xdebug. Notable it can be used to configure client information. On Linux machines xdebug won't be able to connect from within container to IDE running on host out of the box. 

One way to make this happen is to use `ngrok` which exposes local application (xdebug client listening on connection in this case) on the internet.

```
$ ngrok tcp 9003 
ngrok                                                                                                                                                                                         (Ctrl+C to quit)
                                                                                                                                                                                                              
Visit http://localhost:4040/ to inspect, replay, and modify your requests                                                                                                                                     
                                                                                                                                                                                                              
Session Status                online                                                                                                                                                                          
Account                       Pavel Schoffer (Plan: Free)                                                                                                                                                     
Version                       3.1.0                                                                                                                                                                           
Region                        United States (us)                                                                                                                                                              
Latency                       -                                                                                                                                                                               
Web Interface                 http://127.0.0.1:4040                                                                                                                                                           
Forwarding                    tcp://6.tcp.ngrok.io:11728 -> localhost:9003                                                                                                                                    
                                                                                                                                                                                                              
Connections                   ttl     opn     rt1     rt5     p50     p90                                                                                                                                     
                              0       0       0.00    0.00    0.00    0.00         
```

Note that now we can use `6.tcp.ngrok.io:11728` to connect to client. to configure dev-env we would:

```
./dist/bin/vip-dev-env-update.js --xdebug_config "client_host=6.tcp.ngrok.io client_port=11728"
```


## Steps to Test

See description above

