### PR TITLE
[dev-env] Supress Setup wizard during update

### DIFF
--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -76,7 +76,12 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			title: '',
 		};
 
-		const instanceData = await promptForArguments( preselectedOptions, defaultOptions );
+		const providedOptions = Object.keys( opt )
+			.filter( option => option.length > 1 ) // Filter out single letter aliases
+			.filter( option => ! [ 'debug', 'help', 'slug' ].includes( option ) ); // Filter out options that are not related to instance configuration
+
+		const supressPrompts = providedOptions.length > 0;
+		const instanceData = await promptForArguments( preselectedOptions, defaultOptions, supressPrompts );
 		instanceData.siteSlug = slug;
 
 		await updateEnvironment( instanceData );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -169,12 +169,17 @@ export function getOptionsFromAppInfo( appInfo: AppInfo ): InstanceOptions {
  * Prompt for arguments
  * @param {InstanceOptions} preselectedOptions - options to be used without prompt
  * @param {InstanceOptions} defaultOptions - options to be used as default values for prompt
+ * @param {boolean} supressPrompts - supress prompts and use default values where needed
  * @returns {any} instance data
  */
-export async function promptForArguments( preselectedOptions: InstanceOptions, defaultOptions: $Shape<InstanceOptions> ): Promise<InstanceData> {
+export async function promptForArguments( preselectedOptions: InstanceOptions, defaultOptions: $Shape<InstanceOptions>, supressPrompts: boolean = false ): Promise<InstanceData> {
 	debug( 'Provided preselected', preselectedOptions, 'and default', defaultOptions );
 
-	console.log( DEV_ENVIRONMENT_PROMPT_INTRO );
+	if ( supressPrompts ) {
+		preselectedOptions = { ...defaultOptions, ...preselectedOptions };
+	} else {
+		console.log( DEV_ENVIRONMENT_PROMPT_INTRO );
+	}
 
 	let multisiteText = 'Multisite';
 	let multisiteDefault = DEV_ENVIRONMENT_DEFAULTS.multisite;


### PR DESCRIPTION

## Description

This change makes is so that when any option that changes dev-env config is provided to `vip dev-env update` the setup wizard is not triggered. The values that are not provided are kept the same as they were.

If no option is provided the wizard still starts like it did.

## Steps to Test

```
 npm run build && ./dist/bin/vip-dev-env-update.js --phpmyadmin false
```

