### PR TITLE
Update memcached to 1.6-alpine3.16

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -80,7 +80,7 @@ services:
   memcached:
     type: memcached:custom
     overrides:
-      image: memcached:1.6-alpine3.14
+      image: memcached:1.6-alpine3.16
       command: docker-entrypoint.sh memcached
 
 <% if ( phpmyadmin ) { %>


### PR DESCRIPTION
## Description

This PR updates Memcached from 1.6-alpine3.14 to 1.6-alpine3.16 because security support for Alpine 3.14 ends soon.

## Steps to Test

Check out this PR, create a dev env, and make sure that it works.
