### PR TITLE
Run wp-cli as www-data

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -177,9 +177,9 @@ tooling:
   wp:
     service: php
     description: "Run WP-CLI command"
-    user: root
+    user: www-data
     cmd:
-      - wp --allow-root
+      - wp
 
   add-site:
     service: php


### PR DESCRIPTION
## Description

This PR updates the Lando template to run WP CLI as `www-data` user for the reasons specified in Automattic/vip-container-images#293

## Steps to Test

Check out this PR, create a dev env with ElasticSearch turned on, enable ES, run

```sh
vip dev-env exec -- wp vip-search index --setup --skip-confirm
```

Ensure that there are no permission errors out there.

Without this PR, the output will look like this:
```
Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]

Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]

Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]

Warning: error_log(/tmp/logstash.log): Failed to open stream: Permission denied in /wp/wp-content/mu-plugins/logstash/class-logger.php on line 541 [$ /usr/local/bin/wp --allow-root vip-search index --setup --skip-confirm] [wp-content/mu-plugins/logstash/class-logger.php:541 error_log(), wp-includes/class-wp-hook.php:307 Automattic\VIP\Logstash\Logger::process_entries_on_shutdown(), wp-includes/class-wp-hook.php:331 WP_Hook-&gt;apply_filters(), wp-includes/plugin.php:476 WP_Hook-&gt;do_action(), wp-includes/load.php:1102 do_action('shutdown'), shutdown_action_hook()]
```

