### PR TITLE
Update/exec help

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -181,12 +181,6 @@ tooling:
     cmd:
       - wp
 
-  add-site:
-    service: php
-    description: "Add site to a multisite installation"
-    cmd:
-      - bash /dev-tools/add-site.sh
-
   db:
     service: php
     description: "Connect to the DB using mysql client (e.g. allow to run imports)"

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -32,10 +32,6 @@ const examples = [
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec --slug my_site -- wp shell`,
 		description: 'Use dev-environment "my_site" to run interactive wp shell',
 	},
-	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec -- db`,
-		description: 'Use dev-environment to run interactive mysql shell connected to the environment\'s database',
-	},
 ];
 
 command( { wildcardCommand: true } )

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -32,6 +32,10 @@ const examples = [
 		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec --slug my_site -- wp shell`,
 		description: 'Use dev-environment "my_site" to run interactive wp shell',
 	},
+	{
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec -- db`,
+		description: 'Use dev-environment to run interactive mysql shell connected to the environment\'s database',
+	},
 ];
 
 command( { wildcardCommand: true } )

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -25,12 +25,12 @@ const examples = [
 		description: 'Use dev-environment to run `wp post list`',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec --slug my_site -- wp shell`,
-		description: 'Use dev-environment "my_site" to run interactive wp shell',
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec --slug my_site -- wp post list --posts_per_page=500`,
+		description: 'Use dev-environment "my-site" to run `wp post list --posts_per_page=500`',
 	},
 	{
-		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec -- add-site --new-site-slug subsite --new-site-title "New Subsite"`,
-		description: 'Execute script to add a subsite to multisite dev environment',
+		usage: `${ DEV_ENVIRONMENT_FULL_COMMAND } exec --slug my_site -- wp shell`,
+		description: 'Use dev-environment "my_site" to run interactive wp shell',
 	},
 ];
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -111,7 +111,7 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 	}
 
 	if ( options.app ) {
-	const envSuffix = options.env ? `-${ options.env }` : '';
+		const envSuffix = options.env ? `-${ options.env }` : '';
 
 		const appName = options.app + envSuffix;
 		if ( options.allowAppEnv ) {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -111,7 +111,7 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 	}
 
 	if ( options.app ) {
-		const envSuffix = options.env ? `-${ options.env }` : '';
+	const envSuffix = options.env ? `-${ options.env }` : '';
 
 		const appName = options.app + envSuffix;
 		if ( options.allowAppEnv ) {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -250,10 +250,7 @@ export async function exec( slug: string, args: Array<string>, options: any = {}
 
 	const command = args.shift();
 
-	let commandArgs = [ ...args ];
-	if ( 'add-site' === command ) {
-		commandArgs = [ ...args.map( argument => argument.replace( '--new-site-', '--' ) ) ];
-	}
+	const commandArgs = [ ...args ];
 
 	await landoExec( instancePath, command, commandArgs, options );
 }


### PR DESCRIPTION
## Description

Removes `add-site` command. As users can do `wp site create`.

Also, added an example for running `vip dev-env exec -- db`

## Steps to Test

```
vip dev-env exec --help
```
