### PR TITLE
FORNO-1296: SQL Import - Add ALTER TABLE statement validation

### DIFF
--- a/__fixtures__/validations/bad-sql-dump.sql
+++ b/__fixtures__/validations/bad-sql-dump.sql
@@ -32,3 +32,8 @@ INSERT INTO wp_options (option_name, option_value, autoload)
         ('home', 'https://super-empoyees.com', 'yes');
 
 SET @@SESSION.SQL_LOG_BIN= 0;
+
+ALTER TABLE wp_options
+	ADD PRIMARY KEY (`option_id`),
+	ADD UNIQUE KEY `option_name` (`option_name`),
+	ADD KEY `autoload` (`autoload`);

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -70,6 +70,9 @@ describe( 'lib/validations/sql', () => {
 		it( 'use statement should be ok', () => {
 			expect( output ).not.toContain( '\'USE <DATABASE_NAME>\' should not be present (case-insensitive)' );
 		} );
+		it( 'instances of ALTER TABLE statements', () => {
+			expect( output ).toContain( 'ALTER TABLE statement on line(s) 36' );
+		} );
 	} );
 	describe( 'it fails when the SQL has (using bad-sql-duplicate-tables.sql)', () => {
 		beforeAll( async () => {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -267,7 +267,7 @@ const checks: Checks = {
 		results: [],
 		message: 'ALTER TABLE statement',
 		excerpt: "'ALTER TABLE' should not be present (case-insensitive)",
-		recommendation: 'Define table structure in the CREATE TABLE statement',
+		recommendation: 'Remove these lines and define table structure in the CREATE TABLE statement instead',
 	},
 	siteHomeUrl: {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -260,6 +260,15 @@ const checks: Checks = {
 		excerpt: "'CREATE TABLE' should be present (case-insensitive)",
 		recommendation: 'Check import settings to include CREATE TABLE statements',
 	},
+	alterTable: {
+		matcher: /^ALTER TABLE `?([a-z0-9_]*)/i,
+		matchHandler: lineNumber => ( { lineNumber } ),
+		outputFormatter: lineNumberCheckFormatter,
+		results: [],
+		message: 'ALTER TABLE statement',
+		excerpt: "'ALTER TABLE' should not be present (case-insensitive)",
+		recommendation: 'Define table structure in the CREATE TABLE statement',
+	},
 	siteHomeUrl: {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",
 		matchHandler: ( lineNumber, results ) => ( { text: results[ 1 ] } ),


### PR DESCRIPTION
## Description

DB exports from tools like phpMyAdmin sometimes define constraints like primary keys in `ALTER TABLE` statements at the end of the file. When customers import these files, it can lead to a scenario where another process inserts data into a table before its constraints are set. Since we require the SQL file being imported to contain `DROP TABLE` and `CREATE TABLE` statements, this PR encourages defining the table structure in the `CREATE TABLE` statements by disallowing `ALTER TABLE`.

## Documentation

https://veetoop2.wordpress.com/2022/10/06/disallowing-alter-table-statements-in-sql-imports/

## Steps to Test

1. Produce an SQL file containing an `ALTER TABLE` statement:

```
DROP TABLE IF EXISTS `wp_a8c_cron_control_jobs`;

CREATE TABLE `wp_a8c_cron_control_jobs` (
  `ID` bigint(20) UNSIGNED NOT NULL,
  `timestamp` bigint(20) UNSIGNED NOT NULL,
  `action` varchar(255) NOT NULL,
  `action_hashed` varchar(32) NOT NULL,
  `instance` varchar(32) NOT NULL,
  `args` longtext NOT NULL,
  `schedule` varchar(255) DEFAULT NULL,
  `interval` int(10) UNSIGNED DEFAULT 0,
  `status` varchar(32) NOT NULL DEFAULT 'pending',
  `created` datetime NOT NULL,
  `last_modified` datetime NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8;

ALTER TABLE `wp_a8c_cron_control_jobs`
  ADD PRIMARY KEY (`ID`),
  ADD UNIQUE KEY `ts_action_instance_status` (`timestamp`,`action`(191),`instance`,`status`),
  ADD KEY `status` (`status`);
```

3. Check out PR.
4. Run `npm run build`
5. Run `./dist/bin/vip-import-validate-sql.js path/to/file.sql`
6. Verify that validation fails

