### PR TITLE
[dev-env] add app and env to tracks when creating env

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -75,7 +75,11 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 	debug( 'Args: ', arg, 'Options: ', opt );
 
-	const trackingInfo = { slug };
+	const trackingInfo = {
+		slug,
+		app: opt.app,
+		env: opt.env,
+	};
 	await trackEvent( 'dev_env_create_command_execute', trackingInfo );
 
 	const startCommand = chalk.bold( getEnvironmentStartCommand( slug ) );


### PR DESCRIPTION
## Description

When creating dev-env we can pass app and env from user to know if they used `@target` or not.

## Steps to Test

```
npm run build && ./dist/bin/vip-dev-env-create.js @2891  --debug @automattic/vip:analytics:clients:tracks
```
