### PR TITLE
[dev-env] Make xdebug config not break during wp update

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -577,6 +577,12 @@ async function updateWordPressImage( slug ) {
 		// Write new data and stage for rebuild
 		envData.wordpress.tag = version.tag;
 		envData.wordpress.ref = version.ref;
+
+		// Ensure xdebugConfig is not undefined (needed by .lando.yml template)
+		if ( ! envData.xdebugConfig ) {
+			envData.xdebugConfig = '';
+		}
+
 		await updateEnvironment( envData );
 
 		return true;

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -56,6 +56,7 @@ export interface InstanceData {
 	statsd: boolean;
 	phpmyadmin: boolean;
 	xdebug: boolean;
+	xdebugConfig?: string;
 	elasticsearch: string;
 	mariadb: string;
 	php: string;


### PR DESCRIPTION
## Description

When updating wp version we could show an error about xdebugConfig undefined. This change avoids the error.

## Steps to Test

1) Create environment:
```
vip dev-env create @1513.production --slug wpvip --title vip-wordpress-com \
    --multisite --php 7.4 --mu-plugins image --media-redirect-domain false --wordpress 5.9 \
    --app-code $(pwd) --elasticsearch 7.17.2 --phpmyadmin false --xdebug false
```
2) Start environment and **change** the wp version
3) No template error shown

