### PR TITLE
FORNO-1328: SQL Import: Add validation for unique_checks being disabled

### DIFF
--- a/__fixtures__/validations/bad-sql-dump.sql
+++ b/__fixtures__/validations/bad-sql-dump.sql
@@ -37,3 +37,5 @@ ALTER TABLE wp_options
 	ADD PRIMARY KEY (`option_id`),
 	ADD UNIQUE KEY `option_name` (`option_name`),
 	ADD KEY `autoload` (`autoload`);
+
+SET UNIQUE_CHECKS = 0;

--- a/__tests__/lib/validations/sql.js
+++ b/__tests__/lib/validations/sql.js
@@ -73,6 +73,9 @@ describe( 'lib/validations/sql', () => {
 		it( 'instances of ALTER TABLE statements', () => {
 			expect( output ).toContain( 'ALTER TABLE statement on line(s) 36' );
 		} );
+		it( 'instances SET UNIQUE_CHECKS = 0', () => {
+			expect( output ).toContain( 'SET UNIQUE_CHECKS = 0 on line(s) 41' );
+		} );
 	} );
 	describe( 'it fails when the SQL has (using bad-sql-duplicate-tables.sql)', () => {
 		beforeAll( async () => {

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -269,6 +269,15 @@ const checks: Checks = {
 		excerpt: "'ALTER TABLE' should not be present (case-insensitive)",
 		recommendation: 'Remove these lines and define table structure in the CREATE TABLE statement instead',
 	},
+	uniqueChecks: {
+		matcher: /^SET UNIQUE_CHECKS\s*=\s*0/i,
+		matchHandler: lineNumber => ( { lineNumber } ),
+		outputFormatter: lineNumberCheckFormatter,
+		results: [],
+		message: 'SET UNIQUE_CHECKS = 0',
+		excerpt: "'UNIQUE_CHECKS' must not be disabled",
+		recommendation: 'Remove these lines',
+	},
 	siteHomeUrl: {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",
 		matchHandler: ( lineNumber, results ) => ( { text: results[ 1 ] } ),

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -275,8 +275,8 @@ const checks: Checks = {
 		outputFormatter: lineNumberCheckFormatter,
 		results: [],
 		message: 'SET UNIQUE_CHECKS = 0',
-		excerpt: "'UNIQUE_CHECKS' must not be disabled",
-		recommendation: 'Remove these lines',
+		excerpt: "'SET UNIQUE_CHECKS = 0' should not be present",
+		recommendation: "'UNIQUE_CHECKS' must not be disabled. These lines should be removed",
 	},
 	siteHomeUrl: {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -276,7 +276,7 @@ const checks: Checks = {
 		results: [],
 		message: 'SET UNIQUE_CHECKS = 0',
 		excerpt: "'SET UNIQUE_CHECKS = 0' should not be present",
-		recommendation: "'UNIQUE_CHECKS' cannot not be disabled. These lines should be removed",
+		recommendation: "Disabling 'UNIQUE_CHECKS' is not allowed. These lines should be removed",
 	},
 	siteHomeUrl: {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",

--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -276,7 +276,7 @@ const checks: Checks = {
 		results: [],
 		message: 'SET UNIQUE_CHECKS = 0',
 		excerpt: "'SET UNIQUE_CHECKS = 0' should not be present",
-		recommendation: "'UNIQUE_CHECKS' must not be disabled. These lines should be removed",
+		recommendation: "'UNIQUE_CHECKS' cannot not be disabled. These lines should be removed",
 	},
 	siteHomeUrl: {
 		matcher: "'(siteurl|home)',\\s?'(.*?)'",


### PR DESCRIPTION
## Description

`SET UNIQUE_CHECKS = 0` disables unique constraint validation. Since in some circumstances other processes may modify the DB during the import, we should not allow disabling `unique_checks`. This PR adds a validation for same.

<img width="613" alt="Screen Shot 2022-10-14 at 10 44 13" src="https://user-images.githubusercontent.com/4177859/195731937-7b4900cd-b3e6-4707-89df-ff8259e3448e.png">


## Steps to Test

1. Produce an SQL file containing a `SET UNIQUE_CHECKS = 0` statement:


```
DROP TABLE IF EXISTS `wp_a8c_cron_control_jobs`;

CREATE TABLE `wp_a8c_cron_control_jobs` (
  `ID` bigint(20) UNSIGNED NOT NULL,
  `timestamp` bigint(20) UNSIGNED NOT NULL,
  `action` varchar(255) NOT NULL,
  `action_hashed` varchar(32) NOT NULL,
  `instance` varchar(32) NOT NULL,
  `args` longtext NOT NULL,
  `schedule` varchar(255) DEFAULT NULL,
  `interval` int(10) UNSIGNED DEFAULT 0,
  `status` varchar(32) NOT NULL DEFAULT 'pending',
  `created` datetime NOT NULL,
  `last_modified` datetime NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8;

SET UNIQUE_CHECKS = 0;
```


2. Check out PR.
1. Run` npm run build`
1. Run `./dist/bin/vip-import-validate-sql.js path/to/file.sql`
1. Verify that validation fails

