### PR TITLE
[dev-env] simplify and rename elasticsearch service config

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -371,7 +371,6 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 					title: 'a',
 					wordpress: testReleaseWP,
 					mariadb: 'maria_a',
-					elasticsearch: 'elastic_a',
 				},
 				default: {
 				},
@@ -383,17 +382,14 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 				},
 				default: {
 					mariadb: 'maria_b',
-					elasticsearch: 'elastic_b',
 				},
 			},
-		] )( 'should handle elasticsearch/mariadb', async input => {
+		] )( 'should handle mariadb', async input => {
 			const result = await promptForArguments( input.preselected, input.default );
 
 			const expectedMaria = input.preselected.mariadb ? input.preselected.mariadb : input.default.mariadb;
-			const expectedElastic = input.preselected.elasticsearch ? input.preselected.elasticsearch : input.default.elasticsearch;
 
 			expect( result.mariadb ).toStrictEqual( expectedMaria );
-			expect( result.elasticsearch ).toStrictEqual( expectedElastic );
 		} );
 	} );
 } );

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -14,7 +14,7 @@ services:
   devtools:
     type: compose
     services:
-      image: ghcr.io/automattic/vip-container-images/dev-tools:0.8
+      image: ghcr.io/automattic/vip-container-images/dev-tools:0.9
       command: sleep infinity
       volumes:
         - devtools:/dev-tools
@@ -92,11 +92,11 @@ services:
       environment:
         UPLOAD_LIMIT: 4G
 <% } %>
-<% if ( elasticsearchEnabled ) { %>
-  vip-search:
+<% if ( elasticsearch ) { %>
+  elasticsearch:
     type: compose
     services:
-      image: elasticsearch:<%= elasticsearch %>
+      image: elasticsearch:7.17.2
       command: /usr/local/bin/docker-entrypoint.sh
       environment:
         ELASTICSEARCH_IS_DEDICATED_NODE: 'no'

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -64,7 +64,6 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			appCode: currentInstanceData.appCode.dir || currentInstanceData.appCode.tag || 'latest',
 			muPlugins: currentInstanceData.muPlugins.dir || currentInstanceData.muPlugins.tag || 'latest',
 			wordpress: currentInstanceData.wordpress.tag,
-			elasticsearchEnabled: currentInstanceData.elasticsearchEnabled,
 			elasticsearch: currentInstanceData.elasticsearch,
 			php: currentInstanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default,
 			mariadb: currentInstanceData.mariadb,

--- a/src/lib/constants/dev-environment.js
+++ b/src/lib/constants/dev-environment.js
@@ -4,7 +4,6 @@ export const DEV_ENVIRONMENT_FULL_COMMAND = `vip ${ DEV_ENVIRONMENT_SUBCOMMAND }
 export const DEV_ENVIRONMENT_DEFAULTS = {
 	title: 'VIP Dev',
 	multisite: false,
-	elasticsearchVersion: '7.17.2',
 	mariadbVersion: '10.3',
 	phpVersion: '8.0',
 };

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -219,8 +219,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 	const instanceData: InstanceData = {
 		wpTitle: preselectedOptions.title || await promptForText( 'WordPress site title', defaultOptions.title || DEV_ENVIRONMENT_DEFAULTS.title ),
 		multisite: 'multisite' in preselectedOptions ? preselectedOptions.multisite : await promptForBoolean( multisiteText, !! multisiteDefault ),
-		elasticsearchEnabled: false,
-		elasticsearch: preselectedOptions.elasticsearch || defaultOptions.elasticsearch || DEV_ENVIRONMENT_DEFAULTS.elasticsearchVersion,
+		elasticsearch: false,
 		php: preselectedOptions.php ? resolvePhpVersion( preselectedOptions.php ) : await promptForPhpVersion( resolvePhpVersion( defaultOptions.php || DEV_ENVIRONMENT_DEFAULTS.phpVersion ) ),
 		mariadb: preselectedOptions.mariadb || defaultOptions.mariadb || DEV_ENVIRONMENT_DEFAULTS.mariadbVersion,
 		mediaRedirectDomain: preselectedOptions.mediaRedirectDomain || '',
@@ -267,12 +266,12 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 
 	debug( `Processing elasticsearch with preselected "${ preselectedOptions.elasticsearch }"` );
 	if ( 'elasticsearch' in preselectedOptions ) {
-		instanceData.elasticsearchEnabled = !! preselectedOptions.elasticsearch;
+		instanceData.elasticsearch = !! preselectedOptions.elasticsearch;
 	} else {
-		instanceData.elasticsearchEnabled = await promptForBoolean( 'Enable Elasticsearch (needed by Enterprise Search)?', defaultOptions.elasticsearchEnabled );
+		instanceData.elasticsearch = await promptForBoolean( 'Enable Elasticsearch (needed by Enterprise Search)?', defaultOptions.elasticsearch );
 	}
 
-	if ( instanceData.elasticsearchEnabled ) {
+	if ( instanceData.elasticsearch ) {
 		instanceData.statsd = preselectedOptions.statsd || defaultOptions.statsd || false;
 	} else {
 		instanceData.statsd = false;
@@ -536,7 +535,7 @@ export function addDevEnvConfigurationOptions( command ) {
 		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, processBooleanOption )
 		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, processBooleanOption )
 		.option( 'xdebug_config', 'Extra configuration to pass to xdebug via XDEBUG_CONFIG environment variable' )
-		.option( 'elasticsearch', 'Explicitly choose Elasticsearch version to use or false to disable it', undefined, value => FALSE_OPTIONS.includes( value?.toLowerCase?.() ) ? false : value )
+		.option( 'elasticsearch', 'Enable Elasticsearch (needed by Enterprise Search)', undefined, processBooleanOption )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
 		.option( 'php', 'Explicitly choose PHP version to use' );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -150,7 +150,7 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.mediaRedirectDomain = `https://${ instanceData.mediaRedirectDomain }`;
 	}
 
-	newInstanceData.elasticsearchEnabled = instanceData.elasticsearchEnabled || false;
+	newInstanceData.elasticsearch = instanceData.elasticsearch || false;
 
 	newInstanceData.php = instanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default;
 	if ( newInstanceData.php.startsWith( 'image:' ) ) {
@@ -286,9 +286,9 @@ export function readEnvironmentData( slug: string ): InstanceData {
 	 ***********************************/
 
 	// REMOVEME after the wheel of time spins around few times
-	if ( instanceData.enterpriseSearchEnabled ) {
-		// enterpriseSearchEnabled was renamed to elasticsearchEnabled
-		instanceData.elasticsearchEnabled = instanceData.enterpriseSearchEnabled;
+	if ( instanceData.enterpriseSearchEnabled || instanceData.elasticsearchEnabled ) {
+		// enterpriseSearchEnabled and elasticsearchEnabled was renamed to elasticsearch
+		instanceData.elasticsearch = instanceData.enterpriseSearchEnabled || instanceData.elasticsearchEnabled;
 	}
 
 	// REMOVEME after the wheel of time spins around few times

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -5,8 +5,7 @@ export interface InstanceOptions {
 	wordpress?: string;
 	muPlugins?: string;
 	appCode?: string;
-	elasticsearchEnabled?: boolean;
-	elasticsearch?: string;
+	elasticsearch?: boolean;
 	mariadb?: string;
 	php?: string;
 	mediaRedirectDomain?: string;
@@ -57,7 +56,6 @@ export interface InstanceData {
 	phpmyadmin: boolean;
 	xdebug: boolean;
 	xdebugConfig?: string;
-	elasticsearch: string;
 	mariadb: string;
 	php: string;
 }


### PR DESCRIPTION
## Description

This change simplifies setting up elasticsearch inside dev-env.

Before this change one would have to provide a version to create/update command `--elasticsearch=17.2.2`, `--elaticsearch=true` would NOT work.

Also the resulting service would list as `vip-search` which is confusing.

NOTE: This change is blocked by [container change](https://github.com/Automattic/vip-container-images/pull/334) 

## Steps to Test


```
npm run build && ./dist/bin/vip-dev-env-update.js --elasticsearch true
```

