### PR TITLE
fix(dev-env): Fall back to copy when rename fails due to EXDEV

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -481,7 +481,20 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 		const baseName = path.basename( outputFileName );
 
 		resolvedPath = path.join( instancePath, baseName );
-		fs.renameSync( outputFileName, resolvedPath );
+
+		try {
+			fs.renameSync( outputFileName, resolvedPath );
+			debug( `Renamed ${ outputFileName } to ${ resolvedPath }` );
+		} catch ( err ) {
+			if ( err.code !== 'EXDEV' ) {
+				throw err;
+			}
+			debug( 'Could not rename across filesystems. Copying the file instead.' );
+			fs.copyFileSync( outputFileName, resolvedPath, fs.constants.COPYFILE_FICLONE );
+			debug( `Copied ${ outputFileName } to ${ resolvedPath }` );
+			fs.unlinkSync( outputFileName );
+			debug( `Removed ${ outputFileName }` );
+		}
 	}
 
 	/**

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -490,7 +490,7 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 				throw err;
 			}
 			debug( 'Could not rename across filesystems. Copying the file instead.' );
-			fs.copyFileSync( outputFileName, resolvedPath, fs.constants.COPYFILE_FICLONE );
+			fs.copyFileSync( outputFileName, resolvedPath );
 			debug( `Copied ${ outputFileName } to ${ resolvedPath }` );
 			fs.unlinkSync( outputFileName );
 			debug( `Removed ${ outputFileName }` );


### PR DESCRIPTION
## Description

While following the instructions to [import a sql file to a local dev-env](https://docs.wpvip.com/how-tos/dev-env-add-content/#h-3-import-the-sql-file) on my Linux machine, I encountered an error:

`Error: EXDEV: cross-device link not permitted, rename '/tmp/vip-search-replace-....sql' -> '.../.local/share/vip/dev-environment/....sql'`

The POSIX [rename(2)](http://man7.org/linux/man-pages/man2/rename.2.html) documentation says that the `EXDEV` error is thrown when:
> `oldpath` and `newpath` are not on the same mounted filesystem.  (Linux permits a filesystem to be mounted at multiple points, but rename() does not work across different mount points, even if the same filesystem is mounted on both.)

I'm not sure if it's something with the dev-env ensemble composition or my actual local file system, but this change works around the issue by copying the intermediate file to the appropriate destination and then removing the intermediate file (instead of "renaming" it) when this specific error is encountered. 

## Steps to Test

1. Start a dev-env
1. Check out PR.
1. Run `npm run build`
1. Run node `./dist/bin/vip-dev-env-import-sql ./path/to/dump.sql --search-replace="fromstring,tostring" --skip-validate`
1. Verify import works as expected.

