### PR TITLE
SQL validation: Change formatting to make it more readable

### DIFF
--- a/src/lib/validations/sql.js
+++ b/src/lib/validations/sql.js
@@ -403,10 +403,7 @@ const postValidation = async ( options: ValidationOptions ) => {
 			error: errorSummary,
 		} );
 
-		const errorOutput = [
-			`SQL validation failed due to ${ chalk.red( problemsFound ) } error(s)`,
-			'',
-		];
+		const errorOutput = [];
 
 		formattedErrors.forEach( error => {
 			errorOutput.push( error.error );
@@ -417,6 +414,8 @@ const postValidation = async ( options: ValidationOptions ) => {
 
 			errorOutput.push( '' );
 		} );
+
+		errorOutput.push( chalk.bold.red( `SQL validation failed due to ${ problemsFound } error(s)` ) );
 
 		if ( options.isImport ) {
 			throw new Error( errorOutput.join( '\n' ) );


### PR DESCRIPTION
## Description

I personally found it confusing that the errors were listed after the error message displaying that the validation failed.

All this change does is:
- moves the ordering of the list of errors to be in line with the grouping of the list of warnings (above the message displaying validation error)
- bolds and reds the entire validation error message

Before:
<img width="908" alt="Screen Shot 2022-10-18 at 12 03 07 PM" src="https://user-images.githubusercontent.com/16962021/196509450-7c2710c9-f6cc-4ac5-85e7-21eb42b8d81b.png">

After:
<img width="878" alt="Screen Shot 2022-10-18 at 12 00 43 PM" src="https://user-images.githubusercontent.com/16962021/196508892-abd270fd-5cbe-4247-af8e-38115a432512.png">


## Steps to Test

1) Use a SQL file with both warnings and errors
2) `npm run build`
3) `./dist/bin/vip-dev-env-import-sql.js file.sql`