### PR TITLE
[dev-env] adds default for wordpress version prompt

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -499,6 +499,7 @@ export async function promptForComponent( component: string, allowLocal: boolean
 		const selectTag = new Select( {
 			message,
 			choices: tagChoices,
+			initial: defaultObject?.tag || '',
 		} );
 		const option = await selectTag.run();
 


### PR DESCRIPTION
## Description

Dev-env setup wizard would ignore current version of WP on update. This change makes it so the current version is used as default. 

## Steps to Test

```
$ npm run build && ./dist/bin/vip-dev-env-update.js 
Running validation steps...
✓ Check for docker installation 
✓ Check for docker-compose installation 
✓ Check access to docker for current user 
✓ Check DNS resolution 
This is a wizard to help you set up your local dev environment.

Sensible default values were pre-selected for convenience. You may also choose to create multiple environments with different settings using the --slug option.


✔ PHP version to use · 8.1
? WordPress - Which version would you like … 
  6.0   →  6.0.3
  5.9   →  5.9.5
  5.8   →  5.8.6
▸ 5.7   →  5.7.8
  trunk → (Pre-Release) HEAD
```

