### PR TITLE
fix: Suppress ES security-related warnings

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -104,6 +104,7 @@ services:
         ELASTICSEARCH_NODE_NAME: 'lando'
         ELASTICSEARCH_PORT_NUMBER: 9200
         discovery.type: 'single-node'
+        xpack.security.enabled: 'false'
       ports:
         - ":9200"
       volumes:


### PR DESCRIPTION
## Description

This PR suppresses the annoying warning:

> Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html to enable security

Ref: https://github.com/Automattic/vip-go-mu-plugins/actions/runs/3288076343/jobs/5417979864#step:11:1004

## Steps to Test

1. Apply this patch to VIP CLI.
2. Clone `vip-go-mu-plugins` repo, go to `__tests__/e2e`, run `npm cit`.
3. Observe ES does not spit security-related warnings.
