### PR TITLE
fix(dev-env): Resolve the "xdebugConfig is not defined" issue

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -157,6 +157,10 @@ function preProcessInstanceData( instanceData: InstanceData ): InstanceData {
 		newInstanceData.php = newInstanceData.php.slice( 'image:'.length );
 	}
 
+	if ( ! newInstanceData.xdebugConfig ) {
+		newInstanceData.xdebugConfig = '';
+	}
+
 	return newInstanceData;
 }
 
@@ -581,11 +585,6 @@ async function updateWordPressImage( slug ) {
 		// Write new data and stage for rebuild
 		envData.wordpress.tag = version.tag;
 		envData.wordpress.ref = version.ref;
-
-		// Ensure xdebugConfig is not undefined (needed by .lando.yml template)
-		if ( ! envData.xdebugConfig ) {
-			envData.xdebugConfig = '';
-		}
 
 		await updateEnvironment( envData );
 


### PR DESCRIPTION
## Description

Fixes: GH-1145

## Steps to Test

1. Apply the patch to the VIP CLI installation
2. Follow the "Steps to Reproduce" section from the original issue
3. Observe that the original issue does not happen anymore.


