### PR TITLE
chore(deps): bump ghcr.io/automattic/vip-container-images/nginx from 1.21.6 to 1.23.2

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -27,7 +27,7 @@ services:
     ssl: true
     sslExpose: false
     services:
-      image: ghcr.io/automattic/vip-container-images/nginx:1.21.6
+      image: ghcr.io/automattic/vip-container-images/nginx:1.23.1
       command: nginx -g "daemon off;"
       volumes:
         - ./nginx/extra.conf:/etc/nginx/conf.extra/extra.conf

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -27,7 +27,7 @@ services:
     ssl: true
     sslExpose: false
     services:
-      image: ghcr.io/automattic/vip-container-images/nginx:1.23.1
+      image: ghcr.io/automattic/vip-container-images/nginx:1.23.2
       command: nginx -g "daemon off;"
       volumes:
         - ./nginx/extra.conf:/etc/nginx/conf.extra/extra.conf


### PR DESCRIPTION
## Description

This PR updates the version of the ghcr.io/automattic/vip-container-images/nginx image used in the Lando template.

## Steps to Test

Create a new dev env with this nginx image and make sure that it works.
