### PR TITLE
chore(deps): Bump flow-bin from 0.172.0 to 0.190.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -490,7 +490,7 @@
         },
         "@babel/template": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "resolved": false,
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
           "dev": true,
           "requires": {
@@ -628,7 +628,7 @@
         },
         "@babel/template": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "resolved": false,
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
           "dev": true,
           "requires": {
@@ -897,7 +897,7 @@
         },
         "@babel/template": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "resolved": false,
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
           "dev": true,
           "requires": {
@@ -1285,7 +1285,7 @@
         },
         "@babel/template": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "resolved": false,
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
           "dev": true,
           "requires": {
@@ -2349,7 +2349,7 @@
         },
         "@babel/template": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "resolved": false,
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
           "dev": true,
           "requires": {
@@ -2573,7 +2573,7 @@
         },
         "@babel/template": {
           "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "resolved": false,
           "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
           "dev": true,
           "requires": {
@@ -7645,9 +7645,9 @@
       "dev": true
     },
     "flow-bin": {
-      "version": "0.172.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.172.0.tgz",
-      "integrity": "sha512-v9KolEk3qd+wFc2ABPaSr5/7VWbHOjdAzRaWwynEtaeMcKN0awlx0Q7b71g/XgVf/fWMR+K8q+3s/TCH+Gky/Q==",
+      "version": "0.190.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.190.1.tgz",
+      "integrity": "sha512-5c9/6eEkMTTfdNuK2WwssrKfsUXKMUXlZVJZnrlWiqJpDSVc70/Smwyi9sXict9k/oq0f+Mo5wVH0d7peBYREg==",
       "dev": true
     },
     "follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "eslint-plugin-no-async-foreach": "0.1.1",
     "eslint-plugin-react": "7.26.0",
     "eslint-plugin-wpcalypso": "5.0.0",
-    "flow-bin": "0.172.0",
+    "flow-bin": "0.190.1",
     "jest": "27.2.1",
     "nock": "13.0.11",
     "prettier": "npm:wp-prettier@2.0.5",


### PR DESCRIPTION
## Description

This PR updates flow-bin to the latest release.

This:
  * improves performance
  * improves stability
  * provides better definitions of some built-in functions (notably, FS-related)

We need this update to refactor some parts of the dev-env code.

Ref: https://github.com/facebook/flow/releases

## Steps to Test

No visible changes.
