### PR TITLE
chore(deps): Bump uuid from 8.3.2 to 9.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14142,9 +14142,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "socket.io-stream": "0.9.1",
     "socks-proxy-agent": "^5.0.1",
     "update-notifier": "4.1.3",
-    "uuid": "8.3.2",
+    "uuid": "9.0.0",
     "xdg-basedir": "^4.0.0",
     "xml2js": "^0.4.23"
   },


### PR DESCRIPTION
## Description

This PR updates `uuid` to the [latest version](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md#900-2022-09-05).

## Steps to Test

The CI should pass.