### PR TITLE
Validate env before resolving path

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -270,7 +270,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 		} );
 
 		it( 'should throw if file does not exist', async () => {
-			fs.existsSync.mockReturnValue( false );
+			fs.existsSync.mockReturnValueOnce( true ); // env exists
+			fs.existsSync.mockReturnValue( false ); // import file does not exist
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -446,6 +446,16 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 	debug( `Will try to resolve path - ${ fileName }` );
 	let resolvedPath = resolvePath( fileName );
 
+	const instancePath = getEnvironmentPath( slug );
+
+	debug( 'Instance path for', slug, 'is:', instancePath );
+
+	const environmentExists = fs.existsSync( instancePath );
+
+	if ( ! environmentExists ) {
+		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
+	}
+
 	debug( `Filename ${ fileName } resolved to ${ resolvedPath }` );
 
 	if ( ! fs.existsSync( resolvedPath ) ) {
@@ -467,10 +477,9 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 			throw new Error( 'Unable to determine location of the intermediate search & replace file.' );
 		}
 
-		const environmentPath = getEnvironmentPath( slug );
 		const baseName = path.basename( outputFileName );
 
-		resolvedPath = path.join( environmentPath, baseName );
+		resolvedPath = path.join( instancePath, baseName );
 		fs.renameSync( outputFileName, resolvedPath );
 	}
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -448,7 +448,7 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 
 	const instancePath = getEnvironmentPath( slug );
 
-	debug( 'Instance path for', slug, 'is:', instancePath );
+	debug( `Instance path for ${ slug } is ${ instancePath }` );
 
 	const environmentExists = fs.existsSync( instancePath );
 


### PR DESCRIPTION
## Description

We would not validate environment if doing search-replace during the SQL import soon enough. This would result in confusing error.

This change adds extra validation to catch this scenario.

## Steps to Test

```
npm run build && ./dist/bin/vip-dev-env-import-sql.js --slug=wrong ~/Downloads/test --skip-validate --search-replace=a,b

Error: Environment doesn't exist.


To create a new environment run:

vip dev-env create

```

