### PR TITLE
chore(deps): Bump debug from 4.3.3 to 4.3.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5821,9 +5821,9 @@
       "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "cli-columns": "^4.0.0",
     "cli-table": "github:automattic/cli-table#7b14232",
     "configstore": "5.0.1",
-    "debug": "4.3.3",
+    "debug": "4.3.4",
     "ejs": "^3.1.8",
     "enquirer": "2.3.6",
     "graphql": "15.5.1",


### PR DESCRIPTION
## Description

This PR bumps `debug` to the [latest version](https://github.com/debug-js/debug/compare/4.3.3...4.3.4).

## Steps to Test

There are no breaking changes; the CI should pass.
