### PR TITLE
chore(deps): Bump json2csv from 5.0.6 to 5.0.7

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9918,9 +9918,9 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json2csv": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.6.tgz",
-      "integrity": "sha512-0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
+      "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
       "requires": {
         "commander": "^6.1.0",
         "jsonparse": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "graphql-tag": "2.12.5",
     "https-proxy-agent": "^5.0.1",
     "ini": "2.0.0",
-    "json2csv": "5.0.6",
+    "json2csv": "5.0.7",
     "jwt-decode": "2.2.0",
     "lando": "git+https://github.com/Automattic/lando-cli.git#v3.5.2-patch2022_09_05",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
## Description

This PR bumps `json2csv` to the [latest version](https://github.com/zemirco/json2csv/blob/v5/CHANGELOG.md)

⚠️ `json2csv` is (or will be soon) [deprecated](https://github.com/zemirco/json2csv/pull/575); we may need to look for a replacement.

## Steps to Test

The CI should pass; `__tests__/bin/vip-logs.js` verifies this change.
