### PR TITLE
chore(deps): Replace deprecated json2csv with @json2csv/plainjs

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3648,6 +3648,21 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@json2csv/formatters": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@json2csv/formatters/-/formatters-6.0.0.tgz",
+      "integrity": "sha512-KKHo9XbOkY+cu3756RaXoiVsP3JAfapSLdQeMb5xn3AzgN/hx99pAYJVmMVagA5PQ56IcX7K46djxbAcovaU+Q=="
+    },
+    "@json2csv/plainjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@json2csv/plainjs/-/plainjs-6.0.0.tgz",
+      "integrity": "sha512-2SLX3gNh5NhmWJd5r29DskjWIehLibcSdBo9vlscHTlmecWvOPjpBd9m/zldXi1mvyVphTd8H5KeLToeFmvABw==",
+      "requires": {
+        "@json2csv/formatters": "^6.0.0",
+        "@streamparser/json": "^0.0.9",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "@lando/platformsh": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@lando/platformsh/-/platformsh-0.6.0.tgz",
@@ -3740,6 +3755,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
       "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q=="
+    },
+    "@streamparser/json": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.9.tgz",
+      "integrity": "sha512-GsL1VYYm1opUU4TFBfPIsD6IHvvH76nWpVPSIfhM4N5GieRYinZZq9KjFG2fS14PwAi4upaKUzNlGsk+VEReLA=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -9916,23 +9936,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-    },
-    "json2csv": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.6.tgz",
-      "integrity": "sha512-0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==",
-      "requires": {
-        "commander": "^6.1.0",
-        "jsonparse": "^1.3.1",
-        "lodash.get": "^4.4.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
-        }
-      }
     },
     "json5": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.6",
     "@automattic/vip-search-replace": "^1.0.15",
+    "@json2csv/plainjs": "^6.0.0",
     "args": "5.0.3",
     "chalk": "4.1.2",
     "cli-columns": "^4.0.0",
@@ -124,7 +125,6 @@
     "graphql-tag": "2.12.5",
     "https-proxy-agent": "^5.0.1",
     "ini": "2.0.0",
-    "json2csv": "5.0.6",
     "jwt-decode": "2.2.0",
     "lando": "git+https://github.com/Automattic/lando-cli.git#v3.5.2-patch2022_09_05",
     "node-fetch": "^2.6.1",

--- a/src/lib/cli/format.js
+++ b/src/lib/cli/format.js
@@ -57,7 +57,7 @@ function ids( data: Array<any> ): string {
 }
 
 function csv( data: Array<any> ): string {
-	const { Parser } = require( 'json2csv' );
+	const { Parser } = require( '@json2csv/plainjs' );
 	const fields = Object.keys( data[ 0 ] );
 
 	const parser = new Parser( { fields: formatFields( fields ) } );


### PR DESCRIPTION
## Description

`json2csv` is [deprecated](https://github.com/juanjoDiaz/json2csv-legacy/tree/package_deprecation_notice) and should be replaced with [@json2csv/plainjs](https://www.npmjs.com/package/@json2csv/plainjs).

Supersedes: #1160 

## Steps to Test

The CI should pass; `__tests__/bin/vip-logs.js` verifies this change.