### PR TITLE
Pull correct environment's details from API when displaying Multisite SQL Import preflight details

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -272,6 +272,7 @@ const displayPlaybook = ( {
 	fileName,
 	domain,
 	formattedEnvironment,
+	unformattedEnvironment,
 	isMultiSite,
 	app,
 } ) => {
@@ -293,7 +294,8 @@ const displayPlaybook = ( {
 	if ( isMultiSite ) {
 		// eslint-disable-next-line no-multi-spaces
 		console.log( `  multisite: ${ isMultiSite.toString() }` );
-		siteArray = app?.environments[ 0 ]?.wpSites?.nodes;
+		const selectedEnvironmentObj = app?.environments?.find( env => unformattedEnvironment === env.type );
+		siteArray = selectedEnvironmentObj?.wpSites?.nodes;
 	}
 
 	if ( ! tableNames.length ) {
@@ -426,6 +428,7 @@ command( {
 			fileName,
 			domain,
 			formattedEnvironment,
+			unformattedEnvironment: opts.env.type,
 			isMultiSite,
 			app,
 		} );


### PR DESCRIPTION
## Description

In the context of a Multisite's SQL Import, when importing data into a non-production environment, the command's preflight checks memo does not reflect the correct information about the data to be imported. 

This PR fixes this issue by pulling data from the API for the environment selected by the user.


