### PR TITLE
Fix regExp to categorize multisite tables during SQL Imports

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -322,9 +322,9 @@ const displayPlaybook = ( {
 			const multiSiteBreakdown = siteArray.map( wpSite => {
 				let siteRegex;
 				if ( wpSite.id === 1 ) {
-					siteRegex = /wp_[a-z]+/i;
+					siteRegex = /^wp_[a-z]+/i;
 				} else {
-					siteRegex = new RegExp( `wp_${ wpSite.id }_[a-z]+`, 'i' );
+					siteRegex = new RegExp( `^wp_${ wpSite.id }_[a-z]+`, 'i' );
 				}
 				const tableNamesInGroup = tableNames.filter( name => siteRegex.test( name ) );
 				return {


### PR DESCRIPTION
## Description

The Regular Expressions for selecting the tables to display in the SQL Import prompt, for a multisite is incorrect and fails for an edge case.

Here's an illustration:

<img width="259" alt="image" src="https://user-images.githubusercontent.com/14042477/199173321-bcd0ae09-9b35-429f-8bd5-ea11777f797c.png">

In the example above, the current regular expression is incorrectly selecting `wp_3_somethingwp_index` as a table of Blog 1 because it matches the end of the string.


