### PR TITLE
Add caching type policy for `WPSite` data

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -90,6 +90,15 @@ export default async function API( { exitOnError = true } = {} ): Promise<Apollo
 
 	return new ApolloClient( {
 		link: ApolloLink.from( [ withToken, errorLink, authLink, httpLink ] ),
-		cache: new InMemoryCache(),
+		cache: new InMemoryCache( {
+			typePolicies: {
+				WPSite: {
+					// By default the cache key is assumed to be `id` which is not globally unique.
+					// So we are using `id` + `homeUrl` to prevent clashing keys.
+					// Change this to `blogId` + `homeUrl` when we switch to using wpSitesSDS
+					keyFields: [ 'id', 'homeUrl' ],
+				},
+			},
+		} ),
 	} );
 }


### PR DESCRIPTION
## Description

The ApolloClient's in-memory cache will copy objects into other objects if they have the same value in the `id` or `_id` field.

ApolloClient issue: https://github.com/apollographql/apollo-client/issues/605

Docs: https://www.apollographql.com/docs/react/caching/cache-configuration/#customizing-cache-ids

