### PR TITLE
dev-env: Fix bug in getVersionList() when path doesn't exist

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -643,10 +643,15 @@ function isVersionListExpired( cacheFile: string, ttl: number ): boolean {
 export async function getVersionList(): Promise<WordPressTag[]> {
 	let res;
 	const mainEnvironmentPath = xdgBasedir.data || os.tmpdir();
-	const cacheFile = path.join( mainEnvironmentPath, 'vip', DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
-
+	const cacheFilePath = path.join( mainEnvironmentPath, 'vip' );
+	const cacheFile = path.join( cacheFilePath, DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
 	// Handle from cache
 	try {
+		// If the path for the cache file doesn't exist, create it
+		if ( ! fs.existsSync( cacheFilePath ) ) {
+			await fs.promises.mkdir( cacheFilePath, { recursive: true } );
+		}
+
 		// If the cache doesn't exist, create it
 		// If the cache is expired, refresh it
 		if ( ! fs.existsSync( cacheFile ) || isVersionListExpired( cacheFile, DEV_ENVIRONMENT_WORDPRESS_VERSION_TTL ) ) {


### PR DESCRIPTION
## Description

> fetchWordPressVersionList failed to retrieve an updated version list

This occurs if the `vip` folder hasn't been created yet.

## Steps to Test
0) `rm -rf /Users/<user>/.local/share/vip`
1) `npm run build`
2) `./dist/bin/vip-dev-env-create.js`
3) Do the below options:
```
✔ WordPress site title · VIP Dev
✔ Multisite (y/N) · false
✔ PHP version to use · 8.0
```
4) At `? WordPress - Which version would you like …`, ensure there's no error being thrown