### PR TITLE
[dev-env] Substitute the check for forward slash to with a cross-platform regex when processing component argument value

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -7,6 +7,7 @@
  */
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import nock from 'nock';
+import os from 'os';
 /**
  * Internal dependencies
  */
@@ -150,14 +151,22 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 					tag: '/tmp/wp',
 				},
 			},
-			{ // if local is  allowed
+			// if local is allowed
+			( os.platform() === 'win32' ? {
+				param: 'C:\path',
+				allowLocal: true,
+				expected: {
+					mode: 'local',
+					dir: 'C:\path',
+				},
+			} : {
 				param: '~/path',
 				allowLocal: true,
 				expected: {
 					mode: 'local',
 					dir: '~/path',
 				},
-			},
+			} ),
 		] )( 'should process options and use defaults', async input => {
 			const result = processComponentOptionInput( input.param, input.allowLocal );
 

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -153,11 +153,11 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			},
 			// if local is allowed
 			( os.platform() === 'win32' ? {
-				param: 'C:\path',
+				param: 'C:\\path',
 				allowLocal: true,
 				expected: {
 					mode: 'local',
-					dir: 'C:\path',
+					dir: 'C:\\path',
 				},
 			} : {
 				param: '~/path',

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -134,7 +134,7 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 		} );
 	} );
 	describe( 'processComponentOptionInput', () => {
-		it.each( [
+		const cases = [
 			{ // base tag
 				param: testReleaseWP,
 				allowLocal: true,
@@ -151,23 +151,35 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 					tag: '/tmp/wp',
 				},
 			},
-			// if local is allowed
-			( os.platform() === 'win32' ? {
-				param: 'C:\\path',
-				allowLocal: true,
-				expected: {
-					mode: 'local',
-					dir: 'C:\\path',
-				},
-			} : {
+			{
 				param: '~/path',
 				allowLocal: true,
 				expected: {
 					mode: 'local',
 					dir: '~/path',
 				},
-			} ),
-		] )( 'should process options and use defaults', async input => {
+			},
+		];
+
+		if ( os.platform() === 'win32' ) {
+			cases.push( {
+				param: 'C:\\path',
+				allowLocal: true,
+				expected: {
+					mode: 'local',
+					dir: 'C:\\path',
+				},
+			},
+			{
+				param: 'C:/path',
+				allowLocal: true,
+				expected: {
+					mode: 'local',
+					dir: 'C:/path',
+				},
+			} );
+		}
+		it.each( cases )( 'should process options and use defaults', async input => {
 			const result = processComponentOptionInput( input.param, input.allowLocal );
 
 			expect( result ).toStrictEqual( input.expected );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -179,7 +179,8 @@ export function printTable( data: Object ) {
 export function processComponentOptionInput( passedParam: string, allowLocal: boolean ): ComponentConfig {
 	// cast to string
 	const param = passedParam + '';
-	if ( allowLocal && param.includes( '/' ) ) {
+	// This is a bit of a naive check
+	if ( allowLocal && param.includes( path.sep ) ) {
 		return {
 			mode: 'local',
 			dir: param,
@@ -303,16 +304,19 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 }
 
 async function processComponent( component: string, preselectedValue: string, defaultValue: string ) {
-	debug( `processing a component '${ component }', with preselected/deafault - ${ preselectedValue }/${ defaultValue }` );
+	debug( `processing a component '${ component }', with preselected/default - ${ preselectedValue }/${ defaultValue }` );
 	let result = null;
 
 	const allowLocal = component !== 'wordpress';
 	const defaultObject = defaultValue ? processComponentOptionInput( defaultValue, allowLocal ) : null;
 	if ( preselectedValue ) {
 		result = processComponentOptionInput( preselectedValue, allowLocal );
+		console.log( `${ chalk.green( '✓' ) } Path to your local ${ componentDisplayNames[ component] }: ${ preselectedValue }` );
 	} else {
 		result = await promptForComponent( component, allowLocal, defaultObject );
 	}
+
+	debug( result );
 
 	while ( 'local' === result?.mode ) {
 		const resolvedPath = resolvePath( result.dir || '' );
@@ -494,6 +498,8 @@ export async function promptForComponent( component: string, allowLocal: boolean
 
 		modeResult = await select.run();
 	}
+
+	debug( modeResult )
 
 	const messagePrefix = selectMode ? '\t' : `${ componentDisplayName } - `;
 	if ( 'local' === modeResult ) {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -191,7 +191,7 @@ export function processComponentOptionInput( passedParam: string, allowLocal: bo
 	// cast to string
 	const param = passedParam + '';
 	// This is a bit of a naive check
-	if ( allowLocal && param.includes( path.sep ) ) {
+	if ( allowLocal && /[\\\/]/.test(param) ) {
 		return {
 			mode: 'local',
 			dir: param,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -45,6 +45,17 @@ const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
 const DEFAULT_SLUG = 'vip-local';
 
+const componentDisplayNames = {
+	wordpress: 'WordPress',
+	muPlugins: 'vip-go-mu-plugins',
+	appCode: 'application code',
+};
+
+const componentDemoNames = {
+	muPlugins: 'vip-go-mu-plugins',
+	appCode: 'vip-go-skeleton',
+};
+
 // Forward declaratrion to avoid no-use-before-define
 declare function promptForComponent( component: 'wordpress', allowLocal: false, defaultObject: ComponentConfig | null ): Promise<WordPressConfig>;
 // eslint-disable-next-line no-redeclare
@@ -311,7 +322,7 @@ async function processComponent( component: string, preselectedValue: string, de
 	const defaultObject = defaultValue ? processComponentOptionInput( defaultValue, allowLocal ) : null;
 	if ( preselectedValue ) {
 		result = processComponentOptionInput( preselectedValue, allowLocal );
-		console.log( `${ chalk.green( '✓' ) } Path to your local ${ componentDisplayNames[ component] }: ${ preselectedValue }` );
+		console.log( `${ chalk.green( '✓' ) } Path to your local ${ componentDisplayNames[ component ] }: ${ preselectedValue }` );
 	} else {
 		result = await promptForComponent( component, allowLocal, defaultObject );
 	}
@@ -449,21 +460,11 @@ export async function promptForPhpVersion( initialValue: string ): Promise<strin
 	return resolvePhpVersion( answer );
 }
 
-const componentDisplayNames = {
-	wordpress: 'WordPress',
-	muPlugins: 'vip-go-mu-plugins',
-	appCode: 'application code',
-};
-const componentDemoyNames = {
-	muPlugins: 'vip-go-mu-plugins',
-	appCode: 'vip-go-skeleton',
-};
-
 // eslint-disable-next-line no-redeclare
 export async function promptForComponent( component: string, allowLocal: boolean, defaultObject: ComponentConfig | null ): Promise<ComponentConfig | WordPressConfig> {
 	debug( `Prompting for ${ component } with default:`, defaultObject );
 	const componentDisplayName = componentDisplayNames[ component ] || component;
-	const componentDemoName = componentDemoyNames[ component ] || component;
+	const componentDemoName = componentDemoNames[ component ] || component;
 	const modChoices = [];
 
 	if ( allowLocal ) {
@@ -499,7 +500,7 @@ export async function promptForComponent( component: string, allowLocal: boolean
 		modeResult = await select.run();
 	}
 
-	debug( modeResult )
+	debug( modeResult );
 
 	const messagePrefix = selectMode ? '\t' : `${ componentDisplayName } - `;
 	if ( 'local' === modeResult ) {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -191,7 +191,7 @@ export function processComponentOptionInput( passedParam: string, allowLocal: bo
 	// cast to string
 	const param = passedParam + '';
 	// This is a bit of a naive check
-	if ( allowLocal && /[\\\/]/.test(param) ) {
+	if ( allowLocal && /[\\\/]/.test( param ) ) {
 		return {
 			mode: 'local',
 			dir: param,


### PR DESCRIPTION
## Description

In #157122-z a customer reported that they don't see their code being properly mounted when using `vip dev-env create --app-code C:\Users\User\code`. 

Upon closer examination it turned out that `processComponentOptionInput` that processes wordpress ,mu-plugins, app-code used a simplistic check for forward slash to establish whether the path was valid or not. Windows supports both types of slashes. 

E.g. 

`C:\path\to\something`  and `C:/path/to/something` are equal and would resolve to `C:\path\to\something`.

This PR modifies the check to include both types of slashes.
Additionally this PR adds the output for pre-selected option.

## Steps to Test


1. Check out PR.
1. Run `npm run build`
1. Run `npm link`
1. On Windows: Run `vip dev-env create --app-code C:\My\Windows\Path\to\repo`
1. On Windows: Run `vip dev-env create --app-code C:/My/Windows/Path/to/repo`
1. On Mac/Linux: Run `vip dev-env create --app-code ~/path/to/repo`
1. Verify that .lando.yml has the correct mounts defined for client-code

A basic unit test case was added for Windows paths
