### PR TITLE
Override WordPress image cache key in tests

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -51,6 +51,16 @@ const scope = nock( 'https://raw.githubusercontent.com' )
 	} ] );
 scope.persist( true );
 
+jest.mock( '../../../src/lib/constants/dev-environment', () => {
+	const devEnvironmentConstants = jest.requireActual( '../../../src/lib/constants/dev-environment' );
+
+	return {
+		...devEnvironmentConstants,
+		// Use separate version file to avoid overwriting actual cached images with mocked values
+		DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY: 'test-wordpress-versions.json',
+	};
+} );
+
 describe( 'lib/dev-environment/dev-environment-cli', () => {
 	beforeEach( () => {
 		prompt.mockReset();


### PR DESCRIPTION
## Description

This is a fix for an issue that occurs when running tests (`npm run test`) during development in `vip dev-env`.

I noticed sometimes during development that my configured WordPress instance options (like `6.1`) were not available as an option:

```bash
# (WordPress configured to tag 6.1)

$ vip dev-env start
Running validation steps...
# ...
The most recent WordPress version available is: 5.9.1
Environment WordPress version is: 5.9 (5.9)
? Would You like to change the WordPress version?  …
❯ yes
  no
  no (don't ask anymore)
```

The root cause is that `wordpress-versions.json` is overwritten in `dev-environment-core.js`'s `getVersionList()` function when running tests, as the tests nock a [hardcoded result set](https://github.com/Automattic/vip-cli/blob/53a2ad448b56cdd7e484250a4cbb2c8f055aff54/__tests__/lib/dev-environment/dev-environment-cli.js#L39-L51). Due to the caching TTL, the cached WordPress versions file lasts a day before updating to the correct set. When tests complete, `vip dev-env start` no longer accepts WordPress versions outside of the mocked set of results.

Here's a quick reproduction of the issue:

```
$ rm ~/.local/share/vip/wordpress-versions.json
$ npm run test

> @automattic/vip@2.23.0 test /Users/alec/projects/vip-cli
> npm run lint && npm run flow && jest --coverage

# ...

$ cat ~/.local/share/vip/wordpress-versions.json
[{"ref":"3ae9f9ffe311e546b0fd5f82d456b3539e3b8e74","tag":"5.9.1","cacheable":true,"locked":false,"prerelease":true},{"ref":"5.9","tag":"5.9","cacheable":true,"locked":false,"prerelease":false}]
```

## Fix

The fix applied here is to mock the constants in `constants/dev-environment` to replace `DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY` in tests. It's a bit ugly but the best solution I found.

My initial solution tried to use a function wrapper in `dev-environment-core` like this:

```diff
export async function getVersionList(): Promise<WordPressTag[]> {
    let res;
    const mainEnvironmentPath = xdgBasedir.data || os.tmpdir();
    const cacheFilePath = path.join( mainEnvironmentPath, 'vip' );
-   const cacheFile = path.join( cacheFilePath, DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY );
+   const cacheFile = path.join( cacheFilePath, getVersionCacheKey() );
    // ...
}

export function getVersionCacheKey() {
    return DEV_ENVIRONMENT_WORDPRESS_CACHE_KEY;
}
```

(and then in test code):

```js
jest.mock('lib/dev-environment/dev-environment-core', () => ({
  getVersionCacheKey () {
    return 'test-file-name';
  }
}))
```

However that doesn't work because `getVersionCacheKey()` is called internally in the core module and jest's override isn't invoked. There's some [tricky ways to get this working](https://github.com/facebook/jest/issues/936#issuecomment-545080082), but these seem to require more changes than worthwhile here.

If you have any other suggestions for a better way to achieve this result, let me know!

## Steps to Test

Changed tests can be run in the `fix/dev-env-test-cache-file-overwrite` branch via:

```
npx jest dev-environment-cli
```

To test that the test cache file is created correctly:

1. Remove the existing WordPress versions file:

    ```bash
    rm -f ~/.local/share/vip/wordpress-versions.json
    ```

2. Run tests:

    ```bash
    npx jest dev-environment-cli
    ```

3. Verify the version cache file is untouched, and a separate test file is created:

    ```bash
    $ cat ~/.local/share/vip/wordpress-versions.json
    cat: ~/.local/share/vip/wordpress-versions.json: No such file or directory

    $ cat ~/.local/share/vip/test-wordpress-versions.json 
    [{"ref":"3ae9f9ffe311e546b0fd5f82d456b3539e3b8e74","tag":"5.9.1","cacheable":true,"locked":false,"prerelease":true},{"ref":"5.9","tag":"5.9","cacheable":true,"locked":false,"prerelease":false}]   
    ```

4. Run a `vip dev-env start` and ensure that WordPress versions outside of `5.9` load correctly with a fresh version file.
