### PR TITLE
Dev-env: Throw error if more than one environment found when starting

### DIFF
--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -17,7 +17,7 @@ import { exec } from 'child_process';
  */
 import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
-import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
+import { startEnvironment, getAllEnvironmentNames } from 'lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { getEnvTrackingInfo, validateDependencies, getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 
@@ -39,6 +39,12 @@ command()
 	.option( [ 'w', 'skip-wp-versions-check' ], 'Skip propting for wordpress update if non latest' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
+		const allEnvNames = getAllEnvironmentNames();
+		if ( allEnvNames.length > 1 && typeof opt.slug !== 'string' ) {
+			console.log( `${ chalk.red( 'Error:' ) } More than one environment found: ${ chalk.blue.bold( allEnvNames.join( ', ' ) ) }. Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env start --slug <env-name>' ) }` );
+			return;
+		}
+
 		const slug = getEnvironmentName( opt );
 		await validateDependencies( slug );
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -73,12 +73,6 @@ type WordPressTag = {
 }
 
 export async function startEnvironment( slug: string, options: StartEnvironmentOptions ): Promise<void> {
-	const allEnvNames = getAllEnvironmentNames();
-	if ( allEnvNames.length > 1 ) {
-		throw new Error( `More than one environment found: ${ chalk.blue.bold( allEnvNames.join( ', ' ) ) }.
-		Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env start --slug <env-name>' ) }` );
-	}
-
 	debug( 'Will start an environment', slug );
 
 	const instancePath = getEnvironmentPath( slug );
@@ -347,7 +341,7 @@ async function prepareLandoEnv( instanceData: InstanceData, instancePath: string
 	debug( `Instance data file created in ${ instanceDataTargetPath }` );
 }
 
-function getAllEnvironmentNames() {
+export function getAllEnvironmentNames() {
 	const mainEnvironmentPath = xdgBasedir.data || os.tmpdir();
 
 	const baseDir = path.join( mainEnvironmentPath, 'vip', 'dev-environment' );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -75,7 +75,8 @@ type WordPressTag = {
 export async function startEnvironment( slug: string, options: StartEnvironmentOptions ): Promise<void> {
 	const allEnvNames = getAllEnvironmentNames();
 	if ( allEnvNames.length > 1 ) {
-		throw new Error( `More than one environment found: ${ chalk.blue.bold( allEnvNames.join(', ' ) ) }. Please re-run command with the --slug parameter: ${ chalk.bold( "vip dev-env start --slug <env-name>" ) }` );
+		throw new Error( `More than one environment found: ${ chalk.blue.bold( allEnvNames.join( ', ' ) ) }.
+		Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env start --slug <env-name>' ) }` );
 	}
 
 	debug( 'Will start an environment', slug );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -73,6 +73,11 @@ type WordPressTag = {
 }
 
 export async function startEnvironment( slug: string, options: StartEnvironmentOptions ): Promise<void> {
+	const allEnvNames = getAllEnvironmentNames();
+	if ( allEnvNames.length > 1 ) {
+		throw new Error( `More than one environment found: ${ chalk.blue.bold( allEnvNames.join(', ' ) ) }. Please re-run command with the --slug parameter: ${ chalk.bold( "vip dev-env start --slug <env-name>" ) }` );
+	}
+
 	debug( 'Will start an environment', slug );
 
 	const instancePath = getEnvironmentPath( slug );


### PR DESCRIPTION
## Description

When we create more than one environment and use `vip dev-env start`, it is confusing because it starts by the default (aka first) environment.  
<img width="754" alt="Screenshot 2022-11-18 at 2 55 48 PM" src="https://user-images.githubusercontent.com/16962021/202809735-e18a8b53-57dc-4c60-864f-741e6db520f9.png">


## Steps to Test

1) Create more than one environment with `vip dev-env create`
2) `npm run build`
3) `./dist/bin/vip-dev-env-start.js`