### PR TITLE
Logged out `vip --version`

### DIFF
--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -62,6 +62,7 @@ const rootCmd = async function() {
 	let token = await Token.get();
 
 	const isHelpCommand = doesArgvHaveAtLeastOneParam( process.argv, [ 'help', '-h', '--help' ] );
+	const isVersionCommand = doesArgvHaveAtLeastOneParam( process.argv, [ '-v', '--version' ] );
 	const isLogoutCommand = doesArgvHaveAtLeastOneParam( process.argv, [ 'logout' ] );
 	const isLoginCommand = doesArgvHaveAtLeastOneParam( process.argv, [ 'login' ] );
 	const isDevEnvCommandWithoutEnv = doesArgvHaveAtLeastOneParam( process.argv, [ 'dev-env' ] ) && ! containsAppEnvArgument( process.argv );
@@ -70,7 +71,13 @@ const rootCmd = async function() {
 
 	if (
 		! isLoginCommand &&
-		( isLogoutCommand || isHelpCommand || isDevEnvCommandWithoutEnv || ( token && token.valid() ) )
+		(
+			isLogoutCommand ||
+			isHelpCommand ||
+			isVersionCommand ||
+			isDevEnvCommandWithoutEnv ||
+			( token && token.valid() )
+		)
 	) {
 		runCmd();
 	} else {

--- a/src/bin/vip.js
+++ b/src/bin/vip.js
@@ -54,16 +54,17 @@ const runCmd = async function() {
 	cmd.argv( process.argv );
 };
 
+function doesArgvHaveAtLeastOneParam( argv: Array, params: Array ) {
+	return argv.some( arg => params.includes( arg ) );
+}
+
 const rootCmd = async function() {
 	let token = await Token.get();
 
-	const isHelpCommand = process.argv.some(
-		arg => arg === 'help' || arg === '-h' || arg === '--help'
-	);
-	const isLogoutCommand = process.argv.some( arg => arg === 'logout' );
-	const isLoginCommand = process.argv.some( arg => arg === 'login' );
-	const isDevEnvCommandWithoutEnv =
-		process.argv.some( arg => arg === 'dev-env' ) && ! containsAppEnvArgument( process.argv );
+	const isHelpCommand = doesArgvHaveAtLeastOneParam( process.argv, [ 'help', '-h', '--help' ] );
+	const isLogoutCommand = doesArgvHaveAtLeastOneParam( process.argv, [ 'logout' ] );
+	const isLoginCommand = doesArgvHaveAtLeastOneParam( process.argv, [ 'login' ] );
+	const isDevEnvCommandWithoutEnv = doesArgvHaveAtLeastOneParam( process.argv, [ 'dev-env' ] ) && ! containsAppEnvArgument( process.argv );
 
 	debug( 'Argv:', process.argv );
 


### PR DESCRIPTION
Allow running `vip --version` when logged out.

Witthout this PR, we get thrown into the login flow:

```
vip --version

   _    __ ________         ________    ____
  | |  / //  _/ __        / ____/ /   /  _/
  | | / / / // /_/ /______/ /   / /    / /
  | |/ /_/ // ____//_____/ /___/ /____/ /
  |___//___/_/           ____/_____/___/

  VIP-CLI is your tool for interacting
```

With this PR, it shows the version:

```
node ./dist/bin/vip --version
2.23.0
```

## Steps to Test

1. Check out PR.
1. Run `npm run build`
2. Make sure you're logged out.
1. Test out various commands with `--version`: `node ./dist/bin/vip --version && node ./dist/bin/vip app --version && node ./dist/bin/vip app list --version` 
1. All should list out the version.
2. Try running a command without version (e.g. `node ./dist/bin/vip app` -- this should prompt you to log in.
3. Now log in with `node ./dist/bin/vip login`.
4. Now try `--version` again: `node ./dist/bin/vip --version && node ./dist/bin/vip app --version && node ./dist/bin/vip app list --version` 
5. All should still list the version.
