### PR TITLE
fix(dev-env): Set SQL_MODE to match our production environment

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -67,7 +67,7 @@ services:
     type: compose
     services:
       image: mariadb:<%= mariadb %>
-      command: docker-entrypoint.sh mysqld
+      command: docker-entrypoint.sh mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
       ports:
         - ":3306"
       environment:


### PR DESCRIPTION
## Description

This PR sets the `SQL_MODE` to match what we have in our production environment.

See p9zhOE-2yQ for details.

## Steps to Test

1. Check out PR.
2. Run `npm run build`
3. Run `./dist/bin/vip-dev-env-create.js` and `./dist/bin/vip-dev-env-start.js`
4. Ensure the environment is up and running.
5. Try to run `insert into wp_posts set post_author = -1; \W`. If everything goes well, there will be no errors, just warnings.

