### PR TITLE
Dev-env: Throw UserError in getEnvironmentName() instead and default to first one if only one env

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -139,10 +139,10 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 		it( 'should throw an error', () => {
 			const options = {};
 
-			const expectedErrorMessage = `More than one environment found: ${ chalk.blue.bold( 'single-site, ms-site' ) }. Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env <subcommand> --slug <env-name>' ) }`;
+			const errorMsg = `More than one environment found: ${ chalk.blue.bold( 'single-site, ms-site' ) }. Please re-run command with the --slug parameter for the targeted environment.`;
 			expect( () => {
 				getEnvironmentName( options );
-			} ).toThrow( expectedErrorMessage );
+			} ).toThrow( errorMsg );
 		} );
 	} );
 	describe( 'getEnvironmentStartCommand', () => {

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -5,14 +5,15 @@
 /**
  * External dependencies
  */
+import chalk from 'chalk';
 import { prompt, selectRunMock, confirmRunMock } from 'enquirer';
 import nock from 'nock';
 /**
  * Internal dependencies
  */
 
-import { getEnvironmentName, getEnvironmentStartCommand, processComponentOptionInput, promptForText, promptForComponent } from 'lib/dev-environment/dev-environment-cli';
-import { promptForArguments } from '../../../src/lib/dev-environment/dev-environment-cli';
+import { getEnvironmentName, getEnvironmentStartCommand, processComponentOptionInput, promptForText, promptForComponent, promptForArguments } from 'lib/dev-environment/dev-environment-cli';
+import * as devEnvCore from 'lib/dev-environment/dev-environment-core';
 
 jest.mock( 'enquirer', () => {
 	const _selectRunMock = jest.fn();
@@ -56,7 +57,12 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 		prompt.mockReset();
 		confirmRunMock.mockReset();
 	} );
-	describe( 'getEnvironmentName', () => {
+	describe( 'getEnvironmentName with no environments present', () => {
+		beforeEach( () => {
+			const getAllEnvironmentNamesMock = jest.spyOn( devEnvCore, 'getAllEnvironmentNames' );
+			getAllEnvironmentNamesMock.mockReturnValue( [] );
+		} );
+
 		it.each( [
 			{ // default value
 				options: {},
@@ -107,6 +113,33 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			};
 
 			const expectedErrorMessage = "This command does not support @app.env notation. Use '--slug=123-bar' to target the local environment.";
+			expect( () => {
+				getEnvironmentName( options );
+			} ).toThrow( expectedErrorMessage );
+		} );
+	} );
+	describe( 'getEnvironmentName with 1 environment present', () => {
+		beforeEach( () => {
+			const getAllEnvironmentNamesMock = jest.spyOn( devEnvCore, 'getAllEnvironmentNames' );
+			getAllEnvironmentNamesMock.mockReturnValue( [ 'single-site' ] );
+		} );
+
+		it( 'should return first environment found if only one present', () => {
+			const result = getEnvironmentName( {} );
+
+			expect( result ).toStrictEqual( 'single-site' );
+		} );
+	} );
+	describe( 'getEnvironmentName with multiple environments present', () => {
+		beforeEach( () => {
+			const getAllEnvironmentNamesMock = jest.spyOn( devEnvCore, 'getAllEnvironmentNames' );
+			getAllEnvironmentNamesMock.mockReturnValue( [ 'single-site', 'ms-site' ] );
+		} );
+
+		it( 'should throw an error', () => {
+			const options = {};
+
+			const expectedErrorMessage = `More than one environment found: ${ chalk.blue.bold( 'single-site, ms-site' ) }. Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env <subcommand> --slug <env-name>' ) }`;
 			expect( () => {
 				getEnvironmentName( options );
 			} ).toThrow( expectedErrorMessage );

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -18,7 +18,7 @@ import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
 import * as exit from 'lib/cli/exit';
 import { createEnvironment, printEnvironmentInfo, getApplicationInformation, doesEnvironmentExist } from 'lib/dev-environment/dev-environment-core';
-import { getEnvironmentName, promptForArguments, getEnvironmentStartCommand } from 'lib/dev-environment/dev-environment-cli';
+import { DEFAULT_SLUG, getEnvironmentName, promptForArguments, getEnvironmentStartCommand } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
 import {
 	addDevEnvConfigurationOptions,
@@ -69,7 +69,11 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		env: opt.env,
 		allowAppEnv: true,
 	};
-	const slug = getEnvironmentName( environmentNameOptions );
+
+	let slug = DEFAULT_SLUG;
+	if ( ( Object.keys( opt ).length !== 0 ) ) {
+		slug = getEnvironmentName( environmentNameOptions );
+	}
 
 	await validateDependencies( slug );
 

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -17,7 +17,7 @@ import { exec } from 'child_process';
  */
 import { trackEvent } from 'lib/tracker';
 import command from 'lib/cli/command';
-import { startEnvironment, getAllEnvironmentNames } from 'lib/dev-environment/dev-environment-core';
+import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { getEnvTrackingInfo, validateDependencies, getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 
@@ -39,12 +39,6 @@ command()
 	.option( [ 'w', 'skip-wp-versions-check' ], 'Skip prompting for wordpress update if non latest' )
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
-		const allEnvNames = getAllEnvironmentNames();
-		if ( allEnvNames.length > 1 && typeof opt.slug !== 'string' ) {
-			console.log( `${ chalk.red( 'Error:' ) } More than one environment found: ${ chalk.blue.bold( allEnvNames.join( ', ' ) ) }. Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env start --slug <env-name>' ) }` );
-			return;
-		}
-
 		const slug = getEnvironmentName( opt );
 		await validateDependencies( slug );
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -28,7 +28,7 @@ import {
 	DEV_ENVIRONMENT_NOT_FOUND,
 	DEV_ENVIRONMENT_PHP_VERSIONS,
 } from '../constants/dev-environment';
-import { getVersionList, readEnvironmentData } from './dev-environment-core';
+import { getAllEnvironmentNames, getVersionList, readEnvironmentData } from './dev-environment-core';
 import type {
 	AppInfo,
 	ComponentConfig,
@@ -159,7 +159,15 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 		throw new UserError( message );
 	}
 
-	return DEFAULT_SLUG;
+	const envs = getAllEnvironmentNames();
+	if ( envs.length === 1 ) {
+		return envs[ 0 ];
+	}
+	if ( envs.length > 1 && typeof options.slug !== 'string' ) {
+		throw new UserError( `More than one environment found: ${ chalk.blue.bold( envs.join( ', ' ) ) }. Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env <subcommand> --slug <env-name>' ) }` );
+	}
+
+	return DEFAULT_SLUG; // Fall back to the default slug if we don't have any, e.g. during the env creation purpose
 }
 
 export function getEnvironmentStartCommand( slug: string ): string {

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -172,7 +172,7 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 }
 
 export function getEnvironmentStartCommand( slug: string ): string {
-	if ( ! slug || slug === DEFAULT_SLUG ) {
+	if ( ! slug ) {
 		return `${ DEV_ENVIRONMENT_FULL_COMMAND } start`;
 	}
 

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -43,7 +43,7 @@ import typeof Command from 'lib/cli/command';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
-const DEFAULT_SLUG = 'vip-local';
+export const DEFAULT_SLUG = 'vip-local';
 
 // Forward declaratrion to avoid no-use-before-define
 declare function promptForComponent( component: 'wordpress', allowLocal: false, defaultObject: ComponentConfig | null ): Promise<WordPressConfig>;
@@ -164,7 +164,8 @@ export function getEnvironmentName( options: EnvironmentNameOptions ): string {
 		return envs[ 0 ];
 	}
 	if ( envs.length > 1 && typeof options.slug !== 'string' ) {
-		throw new UserError( `More than one environment found: ${ chalk.blue.bold( envs.join( ', ' ) ) }. Please re-run command with the --slug parameter: ${ chalk.bold( 'vip dev-env <subcommand> --slug <env-name>' ) }` );
+		const msg = `More than one environment found: ${ chalk.blue.bold( envs.join( ', ' ) ) }. Please re-run command with the --slug parameter for the targeted environment.`;
+		throw new UserError( msg );
 	}
 
 	return DEFAULT_SLUG; // Fall back to the default slug if we don't have any, e.g. during the env creation purpose


### PR DESCRIPTION
## Description

This is a re-work of https://github.com/Automattic/vip-cli/pull/1175 because we want consistency across all commands where it looks for the environment name.  Also:
- it uses the first environment found, especially in the case where we do not create an slugless environment
- it revises the start command to show `--slug` even for slugless environments so they are aware of the name of their environment

## Steps to Test

1. Create more than one environment with vip dev-env create
2. `npm run build`
3.  Expect to see error thrown @ `./dist/bin/vip-dev-env-start.js`, `./dist/bin/vip-dev-env-stop.js`, `./dist/bin/vip-dev-env-exec.js`
4. Do not expect to see error thrown @ `./dist/bin/vip-dev-env-create.js`
5. Create slugless environment via step 4) and see:
```
To start it please run:

vip dev-env start --slug vip-local
```