### PR TITLE
feat(dev-env): Add support for MailHog

### DIFF
--- a/__tests__/e2e_test.bat
+++ b/__tests__/e2e_test.bat
@@ -14,7 +14,7 @@ rem dev-env tests
 
 echo "== Creating dev-env"
 
-call vip dev-env create --app-code image --title Test --multisite false --php 8.0 --wordpress 6.0 --mu-plugins image -e false -p false -x false
+call vip dev-env create --app-code image --title Test --multisite false --php 8.0 --wordpress 6.0 --mu-plugins image -e false -p false -x false --mailhog false
 
 if NOT %errorlevel% == 0 (
     echo "== Failed to create dev-env"

--- a/__tests__/lib/dev-environment/dev-environment-cli.js
+++ b/__tests__/lib/dev-environment/dev-environment-cli.js
@@ -351,9 +351,9 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const result = await promptForArguments( input.preselected, input.default );
 
 			if ( 'multisite' in input.preselected ) {
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 3 );
-			} else {
 				expect( confirmRunMock ).toHaveBeenCalledTimes( 4 );
+			} else {
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 5 );
 			}
 
 			const expectedValue = 'multisite' in input.preselected ? input.preselected.multisite : input.default.multisite;
@@ -388,9 +388,9 @@ describe( 'lib/dev-environment/dev-environment-cli', () => {
 			const result = await promptForArguments( input.preselected, input.default );
 
 			if ( input.preselected.mediaRedirectDomain ) {
-				expect( confirmRunMock ).toHaveBeenCalledTimes( 3 );
-			} else {
 				expect( confirmRunMock ).toHaveBeenCalledTimes( 4 );
+			} else {
+				expect( confirmRunMock ).toHaveBeenCalledTimes( 5 );
 			}
 
 			const expectedValue = input.preselected.mediaRedirectDomain ? input.preselected.mediaRedirectDomain : input.default.mediaRedirectDomain;

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -174,6 +174,11 @@ services:
       clientcode_vipconfig: {}
 <% } %>
 
+<% if ( mailhog ) { %>
+  mailhog:
+    type: mailhog
+<% } %>
+
 tooling:
   wp:
     service: php

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -70,6 +70,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			statsd: currentInstanceData.statsd,
 			phpmyadmin: currentInstanceData.phpmyadmin,
 			xdebug: currentInstanceData.xdebug,
+			mailhog: currentInstanceData.mailhog,
 			mediaRedirectDomain: currentInstanceData.mediaRedirectDomain,
 			multisite: false,
 			title: '',

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -257,11 +257,13 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		xdebug: false,
 		xdebugConfig: preselectedOptions.xdebugConfig,
 		siteSlug: '',
+		mailhog: false,
 	};
 
 	const promptLabels = {
 		xdebug: 'XDebug',
 		phpmyadmin: 'phpMyAdmin',
+		mailhog: 'MailHog',
 	};
 
 	if ( ! instanceData.mediaRedirectDomain && defaultOptions.mediaRedirectDomain ) {
@@ -297,7 +299,7 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		instanceData.statsd = false;
 	}
 
-	for ( const service of [ 'phpmyadmin', 'xdebug' ] ) {
+	for ( const service of [ 'phpmyadmin', 'xdebug', 'mailhog' ] ) {
 		if ( service in instanceData ) {
 			if ( service in preselectedOptions ) {
 				instanceData[ service ] = preselectedOptions[ service ];
@@ -557,7 +559,8 @@ export function addDevEnvConfigurationOptions( command: Command ): any {
 		.option( 'elasticsearch', 'Enable Elasticsearch (needed by Enterprise Search)', undefined, processBooleanOption )
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
-		.option( 'php', 'Explicitly choose PHP version to use' );
+		.option( 'php', 'Explicitly choose PHP version to use' )
+		.option( 'mailhog', 'Enable MailHog. By default it is disabled', undefined, processBooleanOption );
 }
 
 /**

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -266,7 +266,7 @@ async function isEnvUp( app ) {
 	const urls = reachableServices.map( service => service.urls ).flat();
 
 	const scanResult = await app.scanUrls( urls, { max: 1 } );
-	// If all the URLs are reachable than the app is considered 'up'
+	// If all the URLs are reachable then the app is considered 'up'
 	return scanResult?.length && scanResult.filter( result => result.status ).length === scanResult.length;
 }
 
@@ -287,7 +287,7 @@ export async function landoExec( instancePath: string, toolName: string, args: A
 
 	const tool = app.config.tooling[ toolName ];
 	if ( ! tool ) {
-		throw new Error( 'wp is not a known lando task' );
+		throw new Error( `${ toolName } is not a known lando task` );
 	}
 
 	/*

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -13,6 +13,7 @@ export interface InstanceOptions {
 	phpmyadmin?: boolean;
 	xdebug?: boolean;
 	xdebugConfig?: string;
+	mailhog?: boolean;
 
 	[index: string]: string | boolean;
 }
@@ -68,6 +69,7 @@ export interface InstanceData {
 	mariadb: string;
 	php: string;
 	elasticsearch?: string | boolean;
+	mailhog: boolean;
 
 	[index: string]: WordPressConfig | ComponentConfig | string | boolean;
 }


### PR DESCRIPTION
## Description

This PR adds support for the MailHog service, an email testing tool.

Depends on: Automattic/vip-container-images#381

## Steps to Test

Apply this patch to `@automattic/vip` and try different scenarios with `vip dev-env`: create, update, start, destroy.
