### PR TITLE
feat(dev-env): Do not mount home directory into containers

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -65,6 +65,7 @@ function getLandoConfig() {
 		],
 		proxyName: 'vip-dev-env-proxy',
 		userConfRoot: getLandoUserConfigurationRoot(),
+		home: '',
 	};
 }
 


### PR DESCRIPTION
## Description

This PR modifies Lando configuration so that it does not mount user's home directory to all containers. This is good both for performance (especially on MacOS) and security (no rogue plugin can steal SSH or GPG keys).

For example, if you create a dev env with `vip dev-env create --slug test-mount` and then exec into it with `docker exec -u www-data -it testmount-php-1 /bin/sh` (or `docker exec -u www-data -it testmount_php_1 /bin/sh` for Docker Compose v1), you will be able to do something like:

```
$ wc /user/.ssh/id_rsa*
       27        33      1675 /user/.ssh/id_rsa
        1         3       413 /user/.ssh/id_rsa.pub
       28        36      2088 total
```

Which means that the untrusted code has an ability to read and steal the keys :-)

## Steps to Test

1. Create and start a dev environment *without* this patch: `vip dev-env create --slug test-mount && vip dev-env start --slug test-mount`
2. Run `grep -RF ':/user:cached' /tmp/lando/compose/testmount` (I tested this on a Linux box; for MacOS, the path may differ)
3. Observe that the output is not empty
4. Stop the environment: `vip dev-env stop --slug test-mount`
5. Apply the patch
6. Remove Lando directory: `rm -rf /tmp/lando` (this is safe if no other envs are running; if they are, try removing `/tmp/lando/compose/testmount` instead - not tested)
7. Start the environment: `vip dev-env start --slug test-mount`
8. Run `grep -RF ':/user:cached' /tmp/lando/compose/testmount` again
9. Ensure the output is empty.
