### PR TITLE
refactor(dev-env): Bootstrap Lando only once

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -28,6 +28,7 @@ import {
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -75,7 +76,8 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		slug = getEnvironmentName( environmentNameOptions );
 	}
 
-	await validateDependencies( slug );
+	const lando = await bootstrapLando();
+	await validateDependencies( lando, slug );
 
 	debug( 'Args: ', arg, 'Options: ', opt );
 
@@ -116,7 +118,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	try {
 		await createEnvironment( instanceData );
 
-		await printEnvironmentInfo( slug, { extended: false } );
+		await printEnvironmentInfo( lando, slug, { extended: false } );
 
 		const message = '\n' + chalk.green( '✓' ) + ` environment created.\n\nTo start it please run:\n\n${ startCommand }\n`;
 		console.log( message );

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -24,6 +24,7 @@ import {
 	handleCLIException,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -44,7 +45,9 @@ command()
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
-		await validateDependencies( slug );
+
+		const lando = await bootstrapLando();
+		await validateDependencies( lando, slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_destroy_command_execute', trackingInfo );
@@ -53,7 +56,7 @@ command()
 
 		try {
 			const removeFiles = ! ( opt.soft || false );
-			await destroyEnvironment( slug, removeFiles );
+			await destroyEnvironment( lando, slug, removeFiles );
 
 			const message = chalk.green( '✓' ) + ' Environment destroyed.\n';
 			console.log( message );

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -17,6 +17,7 @@ import command from '../lib/cli/command';
 import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 import { importMediaPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const examples = [
 	{
@@ -37,7 +38,9 @@ command( {
 	.argv( process.argv, async ( unmatchedArgs: string[], opt ) => {
 		const [ filePath ] = unmatchedArgs;
 		const slug = getEnvironmentName( opt );
-		await validateDependencies( slug );
+
+		const lando = await bootstrapLando();
+		await validateDependencies( lando, slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_import_media_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -19,6 +19,7 @@ import { printEnvironmentInfo, printAllEnvironmentsInfo } from 'lib/dev-environm
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { getEnvTrackingInfo, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -40,7 +41,9 @@ command()
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
-		await validateDependencies( slug );
+
+		const lando = await bootstrapLando();
+		await validateDependencies( lando, slug );
 
 		const trackingInfo = opt.all ? { all: true } : getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_info_command_execute', trackingInfo );
@@ -52,9 +55,9 @@ command()
 				extended: !! opt.extended,
 			};
 			if ( opt.all ) {
-				await printAllEnvironmentsInfo( options );
+				await printAllEnvironmentsInfo( lando, options );
 			} else {
-				await printEnvironmentInfo( slug, options );
+				await printEnvironmentInfo( lando, slug, options );
 			}
 			await trackEvent( 'dev_env_info_command_success', trackingInfo );
 		} catch ( error ) {

--- a/src/bin/vip-dev-env-list.js
+++ b/src/bin/vip-dev-env-list.js
@@ -18,6 +18,7 @@ import { printAllEnvironmentsInfo } from 'lib/dev-environment/dev-environment-co
 import { handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const examples = [
 	{
@@ -29,12 +30,14 @@ const examples = [
 command()
 	.examples( examples )
 	.argv( process.argv, async () => {
-		await validateDependencies();
+		const lando = await bootstrapLando();
+		await validateDependencies( lando, '' );
+
 		const trackingInfo = { all: true };
 		await trackEvent( 'dev_env_list_command_execute', trackingInfo );
 
 		try {
-			await printAllEnvironmentsInfo( {} );
+			await printAllEnvironmentsInfo( lando, {} );
 			await trackEvent( 'dev_env_list_command_success', trackingInfo );
 		} catch ( error ) {
 			handleCLIException( error, 'dev_env_list_command_error', trackingInfo );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -20,6 +20,7 @@ import command from 'lib/cli/command';
 import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { getEnvTrackingInfo, validateDependencies, getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -40,7 +41,9 @@ command()
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
-		await validateDependencies( slug );
+
+		const lando = await bootstrapLando();
+		await validateDependencies( lando, slug );
 
 		const startProcessing = new Date();
 
@@ -68,7 +71,7 @@ command()
 				} );
 			}
 
-			await startEnvironment( slug, options );
+			await startEnvironment( lando, slug, options );
 
 			const processingTime = Math.ceil( ( new Date() - startProcessing ) / 1000 ); // in seconds
 			const successTrackingInfo = { ...trackingInfo, processing_time: processingTime };

--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -20,6 +20,7 @@ import { stopEnvironment } from 'lib/dev-environment/dev-environment-core';
 import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
 import { validateDependencies, getEnvTrackingInfo } from '../lib/dev-environment/dev-environment-cli';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -35,7 +36,9 @@ command()
 	.examples( examples )
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = getEnvironmentName( opt );
-		await validateDependencies( slug );
+
+		const lando = await bootstrapLando();
+		await validateDependencies( lando, slug );
 
 		debug( 'Args: ', arg, 'Options: ', opt );
 
@@ -43,7 +46,7 @@ command()
 		await trackEvent( 'dev_env_stop_command_execute', trackingInfo );
 
 		try {
-			await stopEnvironment( slug );
+			await stopEnvironment( lando, slug );
 
 			const message = chalk.green( '✓' ) + ' environment stopped.\n';
 			console.log( message );

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -22,6 +22,7 @@ import { addDevEnvConfigurationOptions, getEnvTrackingInfo, handleCLIException, 
 import type { InstanceOptions } from '../lib/dev-environment/types';
 import { doesEnvironmentExist, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND, DEV_ENVIRONMENT_PHP_VERSIONS } from '../lib/constants/dev-environment';
+import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const debug = debugLib( '@automattic/vip:bin:dev-environment' );
 
@@ -38,7 +39,9 @@ addDevEnvConfigurationOptions( cmd );
 cmd.examples( examples );
 cmd.argv( process.argv, async ( arg, opt ) => {
 	const slug = getEnvironmentName( opt );
-	await validateDependencies( slug );
+
+	const lando = await bootstrapLando();
+	await validateDependencies( lando, slug );
 
 	const trackingInfo = getEnvTrackingInfo( slug );
 	await trackEvent( 'dev_env_update_command_execute', trackingInfo );

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -122,13 +122,15 @@ const VALIDATION_STEPS = [
 	{ id: 'access', name: 'Check access to docker for current user' },
 	{ id: 'dns', name: 'Check DNS resolution' },
 ];
-export const validateDependencies = async ( slug: string ) => {
-	const progressTracker = new ProgressTracker( VALIDATION_STEPS );
+
+export const validateDependencies = async ( lando: Lando, slug: string ) => {
+	const steps = slug ? VALIDATION_STEPS : VALIDATION_STEPS.filter( step => step.id !== 'dns' );
+	const progressTracker = new ProgressTracker( steps );
 	console.log( 'Running validation steps...' );
 	progressTracker.startPrinting();
 	progressTracker.stepRunning( 'docker' );
 	try {
-		await validateDockerInstalled();
+		await validateDockerInstalled( lando );
 	} catch ( exception ) {
 		throw new UserError( exception.message );
 	}
@@ -137,7 +139,7 @@ export const validateDependencies = async ( slug: string ) => {
 	progressTracker.print();
 
 	try {
-		await validateDockerAccess();
+		await validateDockerAccess( lando );
 	} catch ( exception ) {
 		throw new UserError( exception.message );
 	}
@@ -145,11 +147,12 @@ export const validateDependencies = async ( slug: string ) => {
 	progressTracker.stepSuccess( 'access' );
 	progressTracker.print();
 
-	await verifyDNSResolution( slug );
+	if ( slug ) {
+		await verifyDNSResolution( slug );
+		progressTracker.stepSuccess( 'dns' );
+		progressTracker.print();
+	}
 
-	progressTracker.stepSuccess( 'dns' );
-
-	progressTracker.print();
 	progressTracker.stopPrinting();
 };
 

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -69,11 +69,14 @@ function getLandoConfig() {
 	};
 }
 
-export async function landoStart( instancePath: string ) {
-	debug( 'Will start lando app on path:', instancePath );
-
+export async function bootstrapLando(): Promise<Lando> {
 	const lando = new Lando( getLandoConfig() );
 	await lando.bootstrap();
+	return lando;
+}
+
+export async function landoStart( lando: Lando, instancePath: string ) {
+	debug( 'Will start lando app on path:', instancePath );
 
 	const app = lando.getApp( instancePath );
 	await app.init();
@@ -83,11 +86,8 @@ export async function landoStart( instancePath: string ) {
 	await app.start();
 }
 
-export async function landoRebuild( instancePath: string ) {
+export async function landoRebuild( lando: Lando, instancePath: string ) {
 	debug( 'Will rebuild lando app on path:', instancePath );
-
-	const lando = new Lando( getLandoConfig() );
-	await lando.bootstrap();
 
 	const app = lando.getApp( instancePath );
 	await app.init();
@@ -152,11 +152,8 @@ async function healthcheckHook( app: App, lando: Lando ) {
 	}
 }
 
-export async function landoStop( instancePath: string ) {
+export async function landoStop( lando: Lando, instancePath: string ) {
 	debug( 'Will stop lando app on path:', instancePath );
-
-	const lando = new Lando( getLandoConfig() );
-	await lando.bootstrap();
 
 	const app = lando.getApp( instancePath );
 	await app.init();
@@ -164,10 +161,8 @@ export async function landoStop( instancePath: string ) {
 	await app.stop();
 }
 
-export async function landoDestroy( instancePath: string ) {
+export async function landoDestroy( lando: Lando, instancePath: string ) {
 	debug( 'Will destroy lando app on path:', instancePath );
-	const lando = new Lando( getLandoConfig() );
-	await lando.bootstrap();
 
 	const app = lando.getApp( instancePath );
 	await app.init();
@@ -175,10 +170,7 @@ export async function landoDestroy( instancePath: string ) {
 	await app.destroy();
 }
 
-export async function landoInfo( instancePath: string ) {
-	const lando = new Lando( getLandoConfig() );
-	await lando.bootstrap();
-
+export async function landoInfo( lando: Lando, instancePath: string ) {
 	const app = lando.getApp( instancePath );
 	await app.init();
 
@@ -271,10 +263,7 @@ async function isEnvUp( app ) {
 	return scanResult?.length && scanResult.filter( result => result.status ).length === scanResult.length;
 }
 
-export async function landoExec( instancePath: string, toolName: string, args: Array<string>, options: any ) {
-	const lando = new Lando( getLandoConfig() );
-	await lando.bootstrap();
-
+export async function landoExec( lando: Lando, instancePath: string, toolName: string, args: Array<string>, options: any ) {
 	const app = lando.getApp( instancePath );
 	await app.init();
 
@@ -341,10 +330,7 @@ async function ensureNoOrphantProxyContainer( lando ) {
 	await proxyContainer.remove();
 }
 
-export async function validateDockerInstalled() {
-	const lando = new Lando( getLandoConfig() );
-	await lando.bootstrap();
-
+export async function validateDockerInstalled( lando: Lando ) {
 	lando.log.verbose( 'docker-engine exists: %s', lando.engine.dockerInstalled );
 	if ( lando.engine.dockerInstalled === false ) {
 		throw Error( 'docker could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/' );
@@ -355,10 +341,7 @@ export async function validateDockerInstalled() {
 	}
 }
 
-export async function validateDockerAccess() {
-	const lando = new Lando( getLandoConfig() );
-	await lando.bootstrap();
-
+export async function validateDockerAccess( lando: Lando ) {
 	const docker = lando.engine.docker;
 	lando.log.verbose( 'Fetching docker info to verify user is in docker group' );
 	try {


### PR DESCRIPTION
## Description

This PR‌ refactors the way we instantiate Lando to speed things up.

How it used to be:
* we instantiated and bootstrapped Lando and its ecosystem twice during sanity checks (in `validateDockerInstalled()` and `validateDockerAccess()`);
* then we instantiated and bootstrapped Lando at least once again when doing what the user has asked us to do (e.g., start or stop the environment);
* if we had to run a command inside a container (`vip dev-env import sql`), we bootstrapped Lando for every command.

How we do it now:
* we instantiate and bootstrap Lando only once: right before we run the sanity checks;
* we pass the bootstrapped Lando instance to the functions used to bootstrap Lando.

The benefits:
* things are faster now. For example, `vip dev-env list` with one environment takes on average 0.5 seconds less to execute.

As a side effect, this PR fixes mocks in `dev-environment-core.js` so that the tests do not depend on each other when it comes to mocked implementations of `fs` functions.

## Steps to Test

Apply the patch and try dev-env commands.
