### PR TITLE
Fix regression in vip dev-env import sql related to the fact we don't mount User's home dir anymore

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -339,7 +339,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 
 			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 			jest.spyOn( fs, 'lstatSync' ).mockReturnValue( { isDirectory: () => false } );
-			jest.spyOn( fs, 'renameSync' ).mockReturnValue( undefined );
+			jest.spyOn( fs, 'copyFileSync' ).mockReturnValue( undefined );
 
 			const searchReplace = 'testsite.com,testsite.net';
 
@@ -371,7 +371,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 
 			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 			jest.spyOn( fs, 'lstatSync' ).mockReturnValue( { isDirectory: () => false } );
-			jest.spyOn( fs, 'renameSync' ).mockReturnValue( undefined );
+			jest.spyOn( fs, 'copyFileSync' ).mockReturnValue( undefined );
 
 			await resolveImportPath( 'foo', 'testfile.sql', searchReplace, true );
 

--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -307,11 +307,16 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			);
 		} );
 
-		it( 'should resolve the path and replace it with /user', async () => {
+		it( 'should resolve the path and copy the file to /app', async () => {
 			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 			jest.spyOn( fs, 'lstatSync' ).mockReturnValue( { isDirectory: () => false } );
+			jest.spyOn( fs, 'copyFileSync' ).mockReturnValue( undefined );
+
 			const resolvedPath = `${ os.homedir() }/testfile.sql`;
 			resolvePath.mockReturnValue( resolvedPath );
+
+			const expectedResolvedPath = getEnvironmentPath( 'foo' ) + '/testfile.sql';
+			const expectedInContainerPath = '/app/testfile.sql';
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );
 
@@ -319,25 +324,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 
 			await expect( promise ).resolves.toEqual(
 				{
-					resolvedPath: resolvedPath,
-					inContainerPath: resolvedPath.replace( os.homedir(), '/user' ),
-				}
-			);
-		} );
-
-		it( 'should handle windows path correctly', async () => {
-			path.sep = '\\';
-			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
-			jest.spyOn( fs, 'lstatSync' ).mockReturnValue( { isDirectory: () => false } );
-			const resolvedPath = `${ os.homedir() }\\somewhere\\testfile.sql`;
-			resolvePath.mockReturnValue( resolvedPath );
-
-			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );
-
-			await expect( promise ).resolves.toEqual(
-				{
-					resolvedPath: resolvedPath,
-					inContainerPath: '/user/somewhere/testfile.sql',
+					resolvedPath: expectedResolvedPath,
+					inContainerPath: expectedInContainerPath,
 				}
 			);
 		} );
@@ -364,11 +352,12 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 				inPlace: false,
 			} );
 
-			const expectedPath = path.join( getEnvironmentPath( 'foo' ), 'testfile.sql' );
+			const expectedResolvedPath = path.join( getEnvironmentPath( 'foo' ), 'testfile.sql' );
+			const expectedInContainerPath = '/app/testfile.sql';
 
 			await expect( promise ).resolves.toEqual( {
-				resolvedPath: expectedPath,
-				inContainerPath: expectedPath,
+				resolvedPath: expectedResolvedPath,
+				inContainerPath: expectedInContainerPath,
 			} );
 		} );
 

--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -315,7 +315,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			const resolvedPath = `${ os.homedir() }/testfile.sql`;
 			resolvePath.mockReturnValue( resolvedPath );
 
-			const expectedResolvedPath = getEnvironmentPath( 'foo' ) + '/testfile.sql';
+			const expectedResolvedPath = path.join( getEnvironmentPath( 'foo' ), 'testfile.sql' );
 			const expectedInContainerPath = '/app/testfile.sql';
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prepare": "npm run clean && npm run build",
     "postinstall": "node ./helpers/check-version.js",
     "build": "babel src -d dist",
-    "build:watch": "babel src -d dist --watch",
+    "build:watch": "babel src -d dist --watch --source-maps",
     "flow": "flow",
     "jest": "jest",
     "lint": "eslint index.js src __tests__",

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -74,9 +74,7 @@ command( {
 			const importArg = [ 'wp', 'db', 'import', inContainerPath ];
 			await exec( lando, slug, importArg );
 
-			if ( searchReplace && searchReplace.length && ! inPlace ) {
-				fs.unlinkSync( resolvedPath );
-			}
+			fs.unlinkSync( resolvedPath );
 
 			const cacheArg = [ 'wp', 'cache', 'flush' ];
 			await exec( lando, slug, cacheArg );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -50,8 +50,6 @@ const landoFileName = '.lando.yml';
 const nginxFileName = 'extra.conf';
 const instanceDataFileName = 'instance_data.json';
 
-const homeDirPathInsideContainers = '/user';
-
 const uploadPathString = 'uploads';
 const nginxPathString = 'nginx';
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -523,7 +523,7 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 
 	debug( `Import file path ${ resolvedPath } will be mapped to ${ inContainerPath }` );
 	return {
-		resolvedPath,
+		resolvedPath: targetPath,
 		inContainerPath,
 	};
 }

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -517,7 +517,7 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 	 * However lando maps os.homedir() to /user in the container. So if we replace the path in the same way
 	 * in the Docker container will get the file from within the mapped volume under /user.
 	 */
-	let inContainerPath = resolvedPath.replace( os.homedir(), homeDirPathInsideContainers );
+	let inContainerPath = `/app/${ path.basename( resolvedPath ) }`; //resolvedPath.replace( os.homedir(), homeDirPathInsideContainers );
 	if ( path.sep === '\\' ) {
 		// Because the file path generated for windows will have \ instead of / we need to replace that as well so that the path inside the container (unix) still works.
 		inContainerPath = inContainerPath.replace( /\\/g, '/' );


### PR DESCRIPTION
## Description

https://github.com/Automattic/vip-cli/pull/1186 introduced a regression where the import file became not accessible because we used the user mount rather than the path in the container. 

The root cause was that we tried to use the mounted path inside the container, even though we copied the file into the `app` mount. We've addressed this by using the proper in-container path when importing. 

## Steps to Test

Example:

1. Check out PR.
1. Run `npm run build`
1. `vip dev-env start`
1. `vip dev-env import ~/path/to/sql`
1. Wait for it to finish and make sure it was imported successfully.

