### PR TITLE
fix(dev-env): increase max number of event listeners for AsyncEvents

### DIFF
--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -54,6 +54,7 @@ command( {
 		const slug = getEnvironmentName( opt );
 
 		const lando = await bootstrapLando();
+		lando.events.constructor.prototype.setMaxListeners( 100 );
 		await validateDependencies( lando, slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );


### PR DESCRIPTION
## Description

This PR fixes these warnings:

```
(node:29693) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 65 post-init listeners added to [AsyncEvents]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
(node:29693) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 65 post-start listeners added to [AsyncEvents]. Use emitter.setMaxListeners() to increase limit
```

which fire when running `vip dev-env import sql` command.

## Steps to Test

Apply the patch and make sure that `vip dev-env import sql` command does not produce these warnings anymore.