### PR TITLE
fix(dev-env): Fix ambiguous short option for MailHog/MariaDB

### DIFF
--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -598,7 +598,7 @@ export function addDevEnvConfigurationOptions( command: Command ): any {
 		.option( 'mariadb', 'Explicitly choose MariaDB version to use' )
 		.option( [ 'r', 'media-redirect-domain' ], 'Domain to redirect for missing media files. This can be used to still have images without the need to import them locally.' )
 		.option( 'php', 'Explicitly choose PHP version to use' )
-		.option( 'mailhog', 'Enable MailHog. By default it is disabled', undefined, processBooleanOption );
+		.option( [ 'A', 'mailhog' ], 'Enable MailHog. By default it is disabled', undefined, processBooleanOption );
 }
 
 /**


### PR DESCRIPTION
## Description

The short option for MariaDB and MailHog is ambiguous:

```
vip dev-env create --help
...
    -M, --mailhog                Enable MailHog. By default it is disabled
    -M, --mariadb                Explicitly choose MariaDB version to use
...
```

This PR sets `-A` as a short option for MailHog.

## Steps to Test

1. Apply the patch
2. `vip dev-env create --help` should show `-A` as a short option for MailHog
