### PR TITLE
feat(dev-env): Pipe files to Docker instead of copying them when doing SQL import

### DIFF
--- a/__tests__/lib/dev-environment/dev-environment-core.js
+++ b/__tests__/lib/dev-environment/dev-environment-core.js
@@ -289,14 +289,8 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 		} );
 	} );
 	describe( 'resolveImportPath', () => {
-		afterEach( () => {
-			path.sep = '/';
-		} );
-
 		it( 'should throw if file does not exist', async () => {
-			jest.spyOn( fs, 'existsSync' )
-				.mockReturnValueOnce( true ) // env exists
-				.mockReturnValue( false ); // import file does not exist
+			jest.spyOn( fs, 'existsSync' ).mockReturnValue( false ); // import file does not exist
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );
 
@@ -307,30 +301,21 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 			);
 		} );
 
-		it( 'should resolve the path and copy the file to /app', async () => {
+		it( 'should resolve the path', () => {
 			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 			jest.spyOn( fs, 'lstatSync' ).mockReturnValue( { isDirectory: () => false } );
-			jest.spyOn( fs, 'copyFileSync' ).mockReturnValue( undefined );
 
 			const resolvedPath = `${ os.homedir() }/testfile.sql`;
 			resolvePath.mockReturnValue( resolvedPath );
-
-			const expectedResolvedPath = path.join( getEnvironmentPath( 'foo' ), 'testfile.sql' );
-			const expectedInContainerPath = '/app/testfile.sql';
 
 			const promise = resolveImportPath( 'foo', 'testfile.sql', null, false );
 
 			expect( searchAndReplace ).not.toHaveBeenCalled();
 
-			await expect( promise ).resolves.toEqual(
-				{
-					resolvedPath: expectedResolvedPath,
-					inContainerPath: expectedInContainerPath,
-				}
-			);
+			return expect( promise ).resolves.toEqual( resolvedPath );
 		} );
 
-		it( 'should call search and replace not in place with the proper arguments', async () => {
+		it( 'should call search and replace not in place with the proper arguments', () => {
 			searchAndReplace.mockReturnValue( {
 				outputFileName: 'testfile.sql',
 			} );
@@ -339,7 +324,6 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 
 			jest.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 			jest.spyOn( fs, 'lstatSync' ).mockReturnValue( { isDirectory: () => false } );
-			jest.spyOn( fs, 'copyFileSync' ).mockReturnValue( undefined );
 
 			const searchReplace = 'testsite.com,testsite.net';
 
@@ -352,13 +336,7 @@ describe( 'lib/dev-environment/dev-environment-core', () => {
 				inPlace: false,
 			} );
 
-			const expectedResolvedPath = path.join( getEnvironmentPath( 'foo' ), 'testfile.sql' );
-			const expectedInContainerPath = '/app/testfile.sql';
-
-			await expect( promise ).resolves.toEqual( {
-				resolvedPath: expectedResolvedPath,
-				inContainerPath: expectedInContainerPath,
-			} );
+			return expect( promise ).resolves.toEqual( 'testfile.sql' );
 		} );
 
 		it( 'should call search and replace in place with the proper arguments', async () => {

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -191,7 +191,7 @@ tooling:
     service: php
     description: "Connect to the DB using mysql client (e.g. allow to run imports)"
     cmd:
-      - mysql -hdatabase -uwordpress -pwordpress wordpress
+      - mysql -hdatabase -uwordpress -pwordpress -Dwordpress
 
 <% function wpVolumes() { %>
         - ./config:/wp/config

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -41,20 +41,6 @@ const examples = [
 	},
 ];
 
-async function openStream( stream: fs.ReadStream ): Promise<void> {
-	if ( false === stream.pending ) {
-		return Promise.resolve();
-	}
-
-	return new Promise( ( resolve, reject ) => {
-		stream.on( 'open', () => {
-			stream.off( 'error', reject );
-			resolve();
-		} );
-		stream.on( 'error', reject );
-	} );
-}
-
 command( {
 	requiredArgs: 1,
 } )
@@ -87,8 +73,7 @@ command( {
 				} );
 			}
 
-			const stream = fs.createReadStream( resolvedPath, { encoding: 'utf-8' } );
-			await openStream( stream );
+			const fd = fs.openSync( resolvedPath, 'r' );
 			const importArg = [ 'db', '--disable-auto-rehash' ];
 			const origIsTTY = process.stdin.isTTY;
 
@@ -101,7 +86,7 @@ command( {
 				 * Therefore, for the things to work, we have to pretend that stdin is not a TTY :-)
 				 */
 				process.stdin.isTTY = false;
-				await exec( lando, slug, importArg, { stdio: [ stream, 'pipe', 'pipe' ] } );
+				await exec( lando, slug, importArg, { stdio: [ fd, 'pipe', 'pipe' ] } );
 				console.log( `${ chalk.green.bold( 'Success:' ) } Database imported.` );
 			} finally {
 				process.stdin.isTTY = origIsTTY;

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -41,6 +41,16 @@ const examples = [
 	},
 ];
 
+async function openStream( stream: fs.ReadStream ): Promise<void> {
+	return new Promise( ( resolve, reject ) => {
+		stream.on( 'open', () => {
+			stream.off( 'error', reject );
+			resolve();
+		} );
+		stream.on( 'error', reject );
+	} );
+}
+
 command( {
 	requiredArgs: 1,
 } )
@@ -74,6 +84,7 @@ command( {
 			}
 
 			const stream = fs.createReadStream( resolvedPath );
+			await openStream( stream );
 			const importArg = [ 'db', '--disable-auto-rehash' ];
 			const origIsTTY = process.stdin.isTTY;
 

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -9,6 +9,7 @@
  * External dependencies
  */
 import fs from 'fs';
+import chalk from 'chalk';
 
 /**
  * Internal dependencies
@@ -73,7 +74,7 @@ command( {
 			}
 
 			const stream = fs.createReadStream( resolvedPath );
-			const importArg = [ 'wp', 'db', 'import', '-' ];
+			const importArg = [ 'db', '--disable-auto-rehash' ];
 			const origIsTTY = process.stdin.isTTY;
 
 			try {
@@ -86,6 +87,7 @@ command( {
 				 */
 				process.stdin.isTTY = false;
 				await exec( lando, slug, importArg, { stdio: [ stream, 'pipe', 'pipe' ] } );
+				console.log( `${ chalk.green.bold( 'Success:' ) } Database imported.` );
 			} finally {
 				process.stdin.isTTY = origIsTTY;
 			}

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -42,6 +42,10 @@ const examples = [
 ];
 
 async function openStream( stream: fs.ReadStream ): Promise<void> {
+	if ( false === stream.pending ) {
+		return Promise.resolve();
+	}
+
 	return new Promise( ( resolve, reject ) => {
 		stream.on( 'open', () => {
 			stream.off( 'error', reject );
@@ -83,7 +87,7 @@ command( {
 				} );
 			}
 
-			const stream = fs.createReadStream( resolvedPath );
+			const stream = fs.createReadStream( resolvedPath, { encoding: 'utf-8' } );
 			await openStream( stream );
 			const importArg = [ 'db', '--disable-auto-rehash' ];
 			const origIsTTY = process.stdin.isTTY;

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -61,7 +61,7 @@ command( {
 		await trackEvent( 'dev_env_import_sql_command_execute', trackingInfo );
 
 		try {
-			const { resolvedPath, inContainerPath } = await resolveImportPath( slug, fileName, searchReplace, inPlace );
+			const resolvedPath = await resolveImportPath( slug, fileName, searchReplace, inPlace );
 
 			if ( ! opt.skipValidate ) {
 				const expectedDomain = `${ slug }.vipdev.lndo.site`;
@@ -72,10 +72,27 @@ command( {
 				} );
 			}
 
-			const importArg = [ 'wp', 'db', 'import', inContainerPath ];
-			await exec( lando, slug, importArg );
+			const stream = fs.createReadStream( resolvedPath );
+			const importArg = [ 'wp', 'db', 'import', '-' ];
+			const origIsTTY = process.stdin.isTTY;
 
-			fs.unlinkSync( resolvedPath );
+			try {
+				/**
+				 * When stdin is a TTY, Lando passes the `--tty` flag to Docker.
+				 * This breaks our code when we pass the stream as stdin to Docker.
+				 * exec() then fails with "the input device is not a TTY".
+				 *
+				 * Therefore, for the things to work, we have to pretend that stdin is not a TTY :-)
+				 */
+				process.stdin.isTTY = false;
+				await exec( lando, slug, importArg, { stdio: [ stream, 'pipe', 'pipe' ] } );
+			} finally {
+				process.stdin.isTTY = origIsTTY;
+			}
+
+			if ( searchReplace && searchReplace.length && ! inPlace ) {
+				fs.unlinkSync( resolvedPath );
+			}
 
 			const cacheArg = [ 'wp', 'cache', 'flush' ];
 			await exec( lando, slug, cacheArg );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -58,11 +58,6 @@ type StartEnvironmentOptions = {
 	skipWpVersionsCheck: boolean
 };
 
-type SQLImportPaths = {
-	resolvedPath: string,
-	inContainerPath: string
-}
-
 type WordPressTag = {
 	ref: string;
 	tag: string;
@@ -456,30 +451,19 @@ export async function getApplicationInformation( appId: number, envType: string 
 	return appData;
 }
 
-export async function resolveImportPath( slug: string, fileName: string, searchReplace: string | string[], inPlace: boolean ): Promise<SQLImportPaths> {
+export async function resolveImportPath( slug: string, fileName: string, searchReplace: string | string[], inPlace: boolean ): Promise<string> {
 	debug( `Will try to resolve path - ${ fileName }` );
-	const resolvedPath = resolvePath( fileName );
-
-	const instancePath = getEnvironmentPath( slug );
-
-	debug( `Instance path for ${ slug } is ${ instancePath }` );
-
-	const environmentExists = fs.existsSync( instancePath );
-
-	if ( ! environmentExists ) {
-		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
-	}
+	let resolvedPath = resolvePath( fileName );
 
 	debug( `Filename ${ fileName } resolved to ${ resolvedPath }` );
 
 	if ( ! fs.existsSync( resolvedPath ) ) {
 		throw new UserError( `The provided file ${ resolvedPath } does not exist or it is not valid (see "--help" for examples)` );
 	}
+
 	if ( fs.lstatSync( resolvedPath ).isDirectory() ) {
 		throw new UserError( `The provided file ${ resolvedPath } is a directory. Please point to a sql file.` );
 	}
-
-	let baseName: string;
 
 	// Run Search and Replace if the --search-replace flag was provided
 	if ( searchReplace && searchReplace.length ) {
@@ -493,22 +477,10 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 			throw new Error( 'Unable to determine location of the intermediate search & replace file.' );
 		}
 
-		baseName = path.basename( outputFileName );
-	} else {
-		baseName = path.basename( resolvedPath );
+		resolvedPath = outputFileName;
 	}
 
-	const targetPath = path.join( instancePath, baseName );
-	const inContainerPath = `/app/${ baseName }`;
-	debug( `Copying ${ resolvedPath } to ${ targetPath }` );
-	fs.copyFileSync( resolvedPath, targetPath, fs.constants.COPYFILE_FICLONE );
-	debug( `Copied ${ resolvedPath } to ${ targetPath }` );
-
-	debug( `Import file path ${ resolvedPath } will be mapped to ${ inContainerPath }` );
-	return {
-		resolvedPath: targetPath,
-		inContainerPath,
-	};
+	return resolvedPath;
 }
 
 export async function importMediaPath( slug: string, filePath: string ) {

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -315,6 +315,10 @@ export async function landoExec( lando: Lando, instancePath: string, toolName: s
 	tool.app = app;
 	tool.name = toolName;
 
+	if ( options.stdio ) {
+		tool.stdio = options.stdio;
+	}
+
 	const task = landoBuildTask( tool, lando );
 
 	const argv = {


### PR DESCRIPTION
## Description

`vip dev-env sql import` copies the SQL dump into the PHP container. This can be undesirable when the file is large: it creates unnecessary I/O, duplicates the file, and can potentially upset Docker if the copy operation exceeds the disk quota.

In this PR, we pipe the file to Docker instead.

## Steps to Test

Apply the patch and test all `vip dev-env sql import` scenarios.
