### PR TITLE
fix(dev-env): Update `max_allowed_packet` to mirror prod envs

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -67,7 +67,7 @@ services:
     type: compose
     services:
       image: mariadb:<%= mariadb %>
-      command: docker-entrypoint.sh mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+      command: docker-entrypoint.sh mysqld --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION --max_allowed_packet=67M
       ports:
         - ":3306"
       environment:


### PR DESCRIPTION
## Description

This PR updates MariaDB's `max_allowed_packet` to match our production environment
