### PR TITLE
fix(dev-env): Do not check env is up for every action

### DIFF
--- a/__tests__/devenv-e2e/009-import-media.spec.js
+++ b/__tests__/devenv-e2e/009-import-media.spec.js
@@ -53,7 +53,7 @@ describe( 'vip dev-env import media', () => {
 		expect( result.rc ).toBe( 0 );
 		expect( checkEnvExists( slug ) ).toBe( true );
 
-		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvImportMedia, '--slug', slug, __dirname ], { env } );
+		result = await cliTest.spawn( [ process.argv[ 0 ], vipDevEnvImportMedia, '--slug', slug, __dirname ], { env }, true );
 		expect( result.rc ).toBe( 0 );
 
 		const uploadsPath = path.join( getEnvironmentPath( slug ), 'uploads' );

--- a/__tests__/devenv-e2e/helpers/utils.js
+++ b/__tests__/devenv-e2e/helpers/utils.js
@@ -7,7 +7,7 @@ import { expect } from '@jest/globals';
 /**
  * Internal dependencies
  */
-import { doesEnvironmentExist } from '../../../src/lib/dev-environment/dev-environment-core';
+import { doesEnvironmentExist, getEnvironmentPath } from '../../../src/lib/dev-environment/dev-environment-core';
 import { vipDevEnvCreate, vipDevEnvDestroy, vipDevEnvStart } from './commands';
 
 let id = 0;
@@ -27,7 +27,9 @@ export function getProjectSlug() {
  * @returns {NodeJS.ProcessEnv} Environment
  */
 export function prepareEnvironment( xdgDataHome ) {
-	const env = {};
+	const env = {
+		DO_NOT_TRACK: '1',
+	};
 
 	[ 'HOME', 'PATH', 'HOSTNAME', 'DOCKER_HOST' ].forEach( key => {
 		if ( process.env[ key ] ) {
@@ -43,13 +45,11 @@ export function prepareEnvironment( xdgDataHome ) {
 }
 
 /**
- * `doesEnvironmentExist()` will need `getEnvironmentPath()` after #1201 gets merged.
- *
  * @param {string} slug Environment slug
  * @returns {boolean} Whether the environment exists
  */
 export function checkEnvExists( slug ) {
-	return doesEnvironmentExist( slug );
+	return doesEnvironmentExist( getEnvironmentPath( slug ) );
 }
 
 /**

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -14,19 +14,22 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
-import { trackEvent } from 'lib/tracker';
-import command from 'lib/cli/command';
-import * as exit from 'lib/cli/exit';
-import { createEnvironment, printEnvironmentInfo, getApplicationInformation, doesEnvironmentExist } from 'lib/dev-environment/dev-environment-core';
-import { DEFAULT_SLUG, getEnvironmentName, promptForArguments, getEnvironmentStartCommand } from 'lib/dev-environment/dev-environment-cli';
-import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from 'lib/constants/dev-environment';
+import { trackEvent } from '../lib/tracker';
+import command from '../lib/cli/command';
+import * as exit from '../lib/cli/exit';
+import { createEnvironment, printEnvironmentInfo, getApplicationInformation, doesEnvironmentExist, getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
 import {
+	DEFAULT_SLUG,
+	getEnvironmentName,
+	promptForArguments,
+	getEnvironmentStartCommand,
 	addDevEnvConfigurationOptions,
 	getOptionsFromAppInfo,
 	handleCLIException,
 	processBooleanOption,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';
+import { DEV_ENVIRONMENT_FULL_COMMAND, DEV_ENVIRONMENT_SUBCOMMAND } from '../lib/constants/dev-environment';
 import type { InstanceOptions } from '../lib/dev-environment/types';
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
@@ -90,7 +93,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 
 	const startCommand = chalk.bold( getEnvironmentStartCommand( slug ) );
 
-	const environmentAlreadyExists = doesEnvironmentExist( slug );
+	const environmentAlreadyExists = doesEnvironmentExist( getEnvironmentPath( slug ) );
 	if ( environmentAlreadyExists ) {
 		const messageToShow = `Environment already exists\n\n\nTo start the environment run:\n\n${ startCommand }\n\n` +
 			`To create another environment use ${ chalk.bold( '--slug' ) } option with a unique name.\n`;

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -14,13 +14,13 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
-import { trackEvent } from 'lib/tracker';
-import command from 'lib/cli/command';
-import { destroyEnvironment } from 'lib/dev-environment/dev-environment-core';
-import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
-import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
+import { trackEvent } from '../lib/tracker';
+import command from '../lib/cli/command';
+import { destroyEnvironment } from '../lib/dev-environment/dev-environment-core';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import {
 	getEnvTrackingInfo,
+	getEnvironmentName,
 	handleCLIException,
 	validateDependencies,
 } from '../lib/dev-environment/dev-environment-cli';

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -15,7 +15,7 @@
 import { trackEvent } from '../lib/tracker';
 import command from '../lib/cli/command';
 import { getEnvTrackingInfo, getEnvironmentName, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
-import { exec } from '../lib/dev-environment/dev-environment-core';
+import { exec, getEnvironmentPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
 import UserError from '../lib/user-error';
@@ -63,7 +63,7 @@ command( { wildcardCommand: true } )
 			}
 
 			if ( ! opt.force ) {
-				const isUp = await isEnvUp( lando, slug );
+				const isUp = await isEnvUp( lando, getEnvironmentPath( slug ) );
 				if ( ! isUp ) {
 					throw new UserError( 'Environment needs to be started before running a command' );
 				}

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -12,13 +12,13 @@
 /**
  * Internal dependencies
  */
-import { trackEvent } from 'lib/tracker';
-import command from 'lib/cli/command';
-import { getEnvironmentName, handleCLIException } from 'lib/dev-environment/dev-environment-cli';
-import { exec } from 'lib/dev-environment/dev-environment-core';
-import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import { getEnvTrackingInfo, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
-import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
+import { trackEvent } from '../lib/tracker';
+import command from '../lib/cli/command';
+import { getEnvTrackingInfo, getEnvironmentName, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import { exec } from '../lib/dev-environment/dev-environment-core';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
+import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
+import UserError from '../lib/user-error';
 
 const examples = [
 	{
@@ -60,6 +60,13 @@ command( { wildcardCommand: true } )
 			let arg: string[] = [];
 			if ( argSplitterFound && argSplitterIx + 1 < process.argv.length ) {
 				arg = process.argv.slice( argSplitterIx + 1 );
+			}
+
+			if ( ! opt.force ) {
+				const isUp = await isEnvUp( lando, slug );
+				if ( ! isUp ) {
+					throw new UserError( 'Environment needs to be started before running a command' );
+				}
 			}
 
 			const options = { force: opt.force };

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -14,10 +14,9 @@
  */
 import { trackEvent } from 'lib/tracker';
 import command from '../lib/cli/command';
-import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import { getEnvironmentName, getEnvTrackingInfo, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 import { importMediaPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
-import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
 const examples = [
 	{

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -56,7 +56,6 @@ command( {
 		const slug = getEnvironmentName( opt );
 
 		const lando = await bootstrapLando();
-		lando.events.constructor.prototype.setMaxListeners( 100 );
 		await validateDependencies( lando, slug );
 
 		const trackingInfo = getEnvTrackingInfo( slug );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -17,7 +17,7 @@ import chalk from 'chalk';
 import { trackEvent } from '../lib/tracker';
 import command from '../lib/cli/command';
 import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, promptForBoolean, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
-import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
+import { exec, getEnvironmentPath, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import { validate } from '../lib/validations/sql';
 import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
@@ -66,7 +66,7 @@ command( {
 			const resolvedPath = await resolveImportPath( slug, fileName, searchReplace, inPlace );
 
 			if ( ! opt.skipValidate ) {
-				if ( ! isEnvUp( lando, slug ) ) {
+				if ( ! isEnvUp( lando, getEnvironmentPath( slug ) ) ) {
 					throw new UserError( 'Environment needs to be started first' );
 				}
 

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -78,7 +78,7 @@ command( {
 				} );
 			}
 
-			const fd = fs.openSync( resolvedPath, 'r' );
+			const fd = await fs.promises.open( resolvedPath, 'r' );
 			const importArg = [ 'db', '--disable-auto-rehash' ];
 			const origIsTTY = process.stdin.isTTY;
 

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -14,13 +14,14 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
-import { trackEvent } from 'lib/tracker';
+import { trackEvent } from '../lib/tracker';
 import command from '../lib/cli/command';
 import { getEnvironmentName, getEnvTrackingInfo, handleCLIException, promptForBoolean, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 import { exec, resolveImportPath } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import { validate } from '../lib/validations/sql';
-import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
+import { bootstrapLando, isEnvUp } from '../lib/dev-environment/dev-environment-lando';
+import UserError from '../lib/user-error';
 
 const examples = [
 	{
@@ -65,6 +66,10 @@ command( {
 			const resolvedPath = await resolveImportPath( slug, fileName, searchReplace, inPlace );
 
 			if ( ! opt.skipValidate ) {
+				if ( ! isEnvUp( lando, slug ) ) {
+					throw new UserError( 'Environment needs to be started first' );
+				}
+
 				const expectedDomain = `${ slug }.vipdev.lndo.site`;
 				await validate( resolvedPath, {
 					isImport: false,

--- a/src/bin/vip-dev-env-list.js
+++ b/src/bin/vip-dev-env-list.js
@@ -31,6 +31,7 @@ command()
 	.examples( examples )
 	.argv( process.argv, async () => {
 		const lando = await bootstrapLando();
+		lando.events.constructor.prototype.setMaxListeners( 1024 );
 		await validateDependencies( lando, '' );
 
 		const trackingInfo = { all: true };

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -15,10 +15,10 @@ import { exec } from 'child_process';
 /**
  * Internal dependencies
  */
-import { trackEvent } from 'lib/tracker';
-import command from 'lib/cli/command';
+import { trackEvent } from '../lib/tracker';
+import command from '../lib/cli/command';
 import { startEnvironment } from 'lib/dev-environment/dev-environment-core';
-import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
+import { DEV_ENVIRONMENT_FULL_COMMAND } from '../lib/constants/dev-environment';
 import { getEnvTrackingInfo, validateDependencies, getEnvironmentName, handleCLIException } from '../lib/dev-environment/dev-environment-cli';
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -14,13 +14,12 @@ import chalk from 'chalk';
 /**
  * Internal dependencies
  */
-import { trackEvent } from 'lib/tracker';
-import command from 'lib/cli/command';
-import { getEnvironmentName } from 'lib/dev-environment/dev-environment-cli';
+import { trackEvent } from '../lib/tracker';
+import command from '../lib/cli/command';
 import { DEV_ENVIRONMENT_FULL_COMMAND } from 'lib/constants/dev-environment';
-import { addDevEnvConfigurationOptions, getEnvTrackingInfo, handleCLIException, promptForArguments, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
+import { addDevEnvConfigurationOptions, getEnvTrackingInfo, getEnvironmentName, handleCLIException, promptForArguments, validateDependencies } from '../lib/dev-environment/dev-environment-cli';
 import type { InstanceOptions } from '../lib/dev-environment/types';
-import { doesEnvironmentExist, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
+import { doesEnvironmentExist, getEnvironmentPath, readEnvironmentData, updateEnvironment } from '../lib/dev-environment/dev-environment-core';
 import { DEV_ENVIRONMENT_NOT_FOUND, DEV_ENVIRONMENT_PHP_VERSIONS } from '../lib/constants/dev-environment';
 import { bootstrapLando } from '../lib/dev-environment/dev-environment-lando';
 
@@ -47,7 +46,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	await trackEvent( 'dev_env_update_command_execute', trackingInfo );
 
 	try {
-		const environmentAlreadyExists = doesEnvironmentExist( slug );
+		const environmentAlreadyExists = doesEnvironmentExist( getEnvironmentPath( slug ) );
 		if ( ! environmentAlreadyExists ) {
 			throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 		}

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -135,6 +135,7 @@ const VALIDATION_STEPS = [
 ];
 
 export const validateDependencies = async ( lando: Lando, slug: string, quiet?: boolean ) => {
+	const now = new Date();
 	const steps = slug ? VALIDATION_STEPS : VALIDATION_STEPS.filter( step => step.id !== 'dns' );
 	const progressTracker = new ProgressTracker( steps );
 	if ( ! quiet ) {
@@ -177,6 +178,9 @@ export const validateDependencies = async ( lando: Lando, slug: string, quiet?: 
 	if ( ! quiet ) {
 		progressTracker.stopPrinting();
 	}
+
+	const duration = new Date().getTime() - now.getTime();
+	debug( 'Validation checks completed in %d ms', duration );
 };
 
 export function getEnvironmentName( options: EnvironmentNameOptions ): string {

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -182,8 +182,7 @@ export async function destroyEnvironment( lando: Lando, slug: string, removeFile
 
 	debug( 'Instance path for', slug, 'is:', instancePath );
 
-	const environmentExists = fs.existsSync( instancePath );
-
+	const environmentExists = doesEnvironmentExist( instancePath );
 	if ( ! environmentExists ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
@@ -232,8 +231,7 @@ export async function printEnvironmentInfo( lando: Lando, slug: string, options:
 
 	debug( 'Instance path for', slug, 'is:', instancePath );
 
-	const environmentExists = fs.existsSync( instancePath );
-
+	const environmentExists = doesEnvironmentExist( instancePath );
 	if ( ! environmentExists ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
@@ -262,26 +260,12 @@ export async function exec( lando: Lando, slug: string, args: Array<string>, opt
 
 	debug( 'Instance path for', slug, 'is:', instancePath );
 
-	const environmentExists = fs.existsSync( instancePath );
-
-	if ( ! environmentExists ) {
-		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
-	}
-
-	const command = args.shift();
-
-	const commandArgs = [ ...args ];
-
+	const [ command, ...commandArgs ] = args;
 	await landoExec( lando, instancePath, command, commandArgs, options );
 }
 
-export function doesEnvironmentExist( slug: string ): boolean {
-	debug( 'Will check for environment', slug );
-
-	const instancePath = getEnvironmentPath( slug );
-
-	debug( 'Instance path for', slug, 'is:', instancePath );
-
+export function doesEnvironmentExist( instancePath: string ): boolean {
+	debug( 'Will check for environment at', instancePath );
 	return fs.existsSync( instancePath );
 }
 

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -479,7 +479,8 @@ export async function importMediaPath( slug: string, filePath: string ) {
 		throw new Error( 'The provided path does not exist or it is not valid (see "--help" for examples)' );
 	}
 
-	if ( ! doesEnvironmentExist( slug ) ) {
+	const environmentPath = getEnvironmentPath( slug );
+	if ( ! doesEnvironmentExist( environmentPath ) ) {
 		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 
@@ -496,7 +497,6 @@ export async function importMediaPath( slug: string, filePath: string ) {
 		}
 	}
 
-	const environmentPath = getEnvironmentPath( slug );
 	const uploadsPath = path.join( environmentPath, uploadPathString );
 
 	console.log( `${ chalk.yellow( '-' ) } Started copying files` );

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -332,12 +332,16 @@ async function getExtraServicesConnections( lando, app ) {
 }
 
 export async function isEnvUp( lando: Lando, instancePath: string ): Promise<boolean> {
+	const now = new Date();
 	const app = await getLandoApplication( lando, instancePath );
 
 	const reachableServices = app.info.filter( service => service.urls.length );
 	const urls = reachableServices.map( service => service.urls ).flat();
 
 	const scanResult = await app.scanUrls( urls, { max: 1 } );
+	const duration = new Date().getTime() - now.getTime();
+	debug( 'isEnvUp took %d ms', duration );
+
 	// If all the URLs are reachable then the app is considered 'up'
 	return scanResult?.length && scanResult.filter( result => result.status ).length === scanResult.length;
 }

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -14,13 +14,14 @@ import landoUtils from 'lando/plugins/lando-core/lib/utils';
 import landoBuildTask from 'lando/plugins/lando-tooling/lib/build';
 import chalk from 'chalk';
 import App from 'lando/lib/app';
-import UserError from '../user-error';
 import dns from 'dns';
 
 /**
  * Internal dependencies
  */
-import { readEnvironmentData, writeEnvironmentData } from './dev-environment-core';
+import { doesEnvironmentExist, readEnvironmentData, writeEnvironmentData } from './dev-environment-core';
+import { DEV_ENVIRONMENT_NOT_FOUND } from '../constants/dev-environment';
+
 /**
  * This file will hold all the interactions with lando library
  */
@@ -118,6 +119,10 @@ const appMap: Map<string, App> = new Map();
 async function getLandoApplication( lando: Lando, instancePath: string ): Promise<App> {
 	if ( appMap.has( instancePath ) ) {
 		return Promise.resolve( appMap.get( instancePath ) );
+	}
+
+	if ( ! doesEnvironmentExist( instancePath ) ) {
+		throw new Error( DEV_ENVIRONMENT_NOT_FOUND );
 	}
 
 	const app = lando.getApp( instancePath );

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -256,7 +256,7 @@ export async function landoInfo( lando: Lando, instancePath: string ) {
 	const reachableServices = app.info.filter( service => service.urls.length );
 	reachableServices.forEach( service => appInfo[ `${ service.service } urls` ] = service.urls );
 
-	const isUp = await isEnvUp( app );
+	const isUp = await isEnvUp( lando, instancePath );
 	const frontEndUrl = app.info
 		.find( service => 'nginx' === service.service )
 		?.urls[ 0 ];

--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -326,7 +326,9 @@ async function getExtraServicesConnections( lando, app ) {
 	return extraServices;
 }
 
-async function isEnvUp( app ) {
+export async function isEnvUp( lando: Lando, instancePath: string ): Promise<boolean> {
+	const app = await getLandoApplication( lando, instancePath );
+
 	const reachableServices = app.info.filter( service => service.urls.length );
 	const urls = reachableServices.map( service => service.urls ).flat();
 
@@ -337,14 +339,6 @@ async function isEnvUp( app ) {
 
 export async function landoExec( lando: Lando, instancePath: string, toolName: string, args: Array<string>, options: any ) {
 	const app = await getLandoApplication( lando, instancePath );
-
-	if ( ! options.force ) {
-		const isUp = await isEnvUp( app );
-
-		if ( ! isUp ) {
-			throw new UserError( 'Environment needs to be started before running wp command' );
-		}
-	}
 
 	const tool = app.config.tooling[ toolName ];
 	if ( ! tool ) {


### PR DESCRIPTION
## Description

This PR further improves #1200.

`landoExec()` checks if the environment is up every time it is called. This creates unnecessary load, I/O, and slows things down.

This PR extracts the `isEnvUp()` logic into a dedicated function (the Single Responsibility Principle is great) and gets rid of the `force` option.

This allows us to speed the application up even more. With this change, the size of the log file goes down to 29,011 bytes.

## Steps to Test

Apply the patch and verify that dev-env commands still work.