### PR TITLE
fix(dev-env): Do not load integrations for Acquia, Lagoon, Pantheon

### DIFF
--- a/src/lib/dev-environment/dev-environment-lando.js
+++ b/src/lib/dev-environment/dev-environment-lando.js
@@ -59,10 +59,6 @@ function getLandoConfig() {
 		postLandoFiles: [ '.lando.local.yml' ],
 		pluginDirs: [
 			landoPath,
-			{
-				path: path.join( landoPath, 'integrations' ),
-				subdir: '.',
-			},
 		],
 		proxyName: 'vip-dev-env-proxy',
 		userConfRoot: getLandoUserConfigurationRoot(),


### PR DESCRIPTION
## Description

This PR speeds things up a bit by disabling Lando's integrations with Acquia, Lagoon, and Pantheon.

## Steps to Test

Apply the patch and make sure dev env still works.
