### PR TITLE
Dev-env: Update ES to 7.17.8 to match prod

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -96,7 +96,7 @@ services:
   elasticsearch:
     type: compose
     services:
-      image: elasticsearch:7.17.2
+      image: elasticsearch:7.17.8
       command: /usr/local/bin/docker-entrypoint.sh
       environment:
         ELASTICSEARCH_IS_DEDICATED_NODE: 'no'


### PR DESCRIPTION
## Description

Update ES on dev-env from 7.17.2 to 7.17.8 to match prod closer

## Steps to Test

1) `npm run build && ./dist/bin/vip-dev-env-update.js --elasticsearch true`
2) Restart dev-env: `vip dev-env start`
3) Go to Elasticsearch URL and confirm the below in the JSON:
```
version": {
"number": "7.17.8",
```