### PR TITLE
ci: Pass correct node-version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
 


### PR DESCRIPTION
## Description

An unfortunate mistake has crept into the CI workflow: we run all tests on the Node LTS regardless of the Node version parameter.

This PR‌ fixes that.

## Steps to Test

Hopefully, the CI passes.
