### PR TITLE
fix(dev-env): await handleCLIException() and set proper exit code

### DIFF
--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -126,5 +126,6 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 		await trackEvent( 'dev_env_create_command_success', trackingInfo );
 	} catch ( error ) {
 		await handleCLIException( error, 'dev_env_create_command_error', trackingInfo );
+		process.exitCode = 1;
 	}
 } );

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -63,5 +63,6 @@ command()
 			await trackEvent( 'dev_env_destroy_command_success', trackingInfo );
 		} catch ( error ) {
 			await handleCLIException( error, 'dev_env_destroy_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -65,6 +65,7 @@ command( { wildcardCommand: true } )
 			await exec( lando, slug, arg, options );
 			await trackEvent( 'dev_env_exec_command_success', trackingInfo );
 		} catch ( error ) {
-			handleCLIException( error, 'dev_env_exec_command_error', trackingInfo );
+			await handleCLIException( error, 'dev_env_exec_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-import-media.js
+++ b/src/bin/vip-dev-env-import-media.js
@@ -49,6 +49,7 @@ command( {
 			await importMediaPath( slug, filePath );
 			await trackEvent( 'dev_env_import_media_command_success', trackingInfo );
 		} catch ( error ) {
-			handleCLIException( error, 'dev_env_import_media_command_error', trackingInfo );
+			await handleCLIException( error, 'dev_env_import_media_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-import-sql.js
+++ b/src/bin/vip-dev-env-import-sql.js
@@ -94,6 +94,7 @@ command( {
 			await exec( lando, slug, addUserArg );
 			await trackEvent( 'dev_env_import_sql_command_success', trackingInfo );
 		} catch ( error ) {
-			handleCLIException( error, 'dev_env_import_sql_command_error', trackingInfo );
+			await handleCLIException( error, 'dev_env_import_sql_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -61,6 +61,7 @@ command()
 			}
 			await trackEvent( 'dev_env_info_command_success', trackingInfo );
 		} catch ( error ) {
-			handleCLIException( error, 'dev_env_info_command_error', trackingInfo );
+			await handleCLIException( error, 'dev_env_info_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-list.js
+++ b/src/bin/vip-dev-env-list.js
@@ -40,6 +40,7 @@ command()
 			await printAllEnvironmentsInfo( lando, {} );
 			await trackEvent( 'dev_env_list_command_success', trackingInfo );
 		} catch ( error ) {
-			handleCLIException( error, 'dev_env_list_command_error', trackingInfo );
+			await handleCLIException( error, 'dev_env_list_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -78,5 +78,6 @@ command()
 			await trackEvent( 'dev_env_start_command_success', successTrackingInfo );
 		} catch ( error ) {
 			await handleCLIException( error, 'dev_env_start_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -53,6 +53,7 @@ command()
 
 			await trackEvent( 'dev_env_stop_command_success', trackingInfo );
 		} catch ( error ) {
-			handleCLIException( error, 'dev_env_stop_command_error', trackingInfo );
+			await handleCLIException( error, 'dev_env_stop_command_error', trackingInfo );
+			process.exitCode = 1;
 		}
 	} );

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -95,9 +95,11 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	} catch ( error ) {
 		if ( 'ENOENT' === error.code ) {
 			const message = 'Environment was created before update was supported.\n\nTo update environment please destroy it and create a new one.';
-			handleCLIException( new Error( message ), 'dev_env_update_command_error', trackingInfo );
+			await handleCLIException( new Error( message ), 'dev_env_update_command_error', trackingInfo );
 		} else {
-			handleCLIException( error, 'dev_env_update_command_error', trackingInfo );
+			await handleCLIException( error, 'dev_env_update_command_error', trackingInfo );
 		}
+
+		process.exitCode = 1;
 	}
 } );

--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -565,7 +565,8 @@ async function updateWordPressImage( slug: string ): Promise<boolean> {
 		} else {
 			message = `An error prevented reading the configuration of: ${ slug }\n\n ${ error }`;
 		}
-		handleCLIException( new Error( message ) );
+
+		await handleCLIException( new Error( message ) );
 		return false;
 	}
 


### PR DESCRIPTION
## Description

There are several situations when we don't `await` a promise. Normally, such situations are caught by the [`no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises/) ESLint rule, but setting it up is another headache.

This PR:
* adds `await` where it is required;
* makes sure that abnormal termination happens with a non-zero exit code.

## Steps to Test

Apply the patch and check that dev env still works :-)

For additional testing, this patch has also been applied to #1203.
