### PR TITLE
feat(dev-env): Add quiet mode to `vip dev-env exec`

### DIFF
--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -38,12 +38,13 @@ const examples = [
 command( { wildcardCommand: true } )
 	.option( 'slug', 'Custom name of the dev environment' )
 	.option( 'force', 'Disabling validations before task execution', undefined, value => 'false' !== value?.toLowerCase?.() )
+	.option( 'quiet', 'Suppress output', undefined, value => 'false' !== value?.toLowerCase?.() )
 	.examples( examples )
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const slug = getEnvironmentName( opt );
 
 		const lando = await bootstrapLando();
-		await validateDependencies( lando, slug );
+		await validateDependencies( lando, slug, opt.quiet );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_exec_command_execute', trackingInfo );


### PR DESCRIPTION
## Description

This PR adds the "quiet mode" to the `vip dev-env exec` command. In this mode, the CLI reports only errors (to stderr) and suppresses informational messages.

One of the use cases - run a command and redirect its output to a file, like
```
vip dev-env exec --quiet -- wp db export - > db.sql
```

## Steps to Test

1. Check out the PR
2. Run `npm run build`
3. Create a dev environment
4. Run `./dist/bin/vip-dev-env-exec.js --quiet -- wp db export - > db.sql`
5. Verify there is no extraneous messages in the file

