### PR TITLE
fix(dev-env)!: remove support for statsd

### DIFF
--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -40,7 +40,6 @@ services:
       command: run.sh
       working_dir: /wp
       environment:
-        STATSD: <%= statsd ? 'enable' : 'disable' %>
         XDEBUG: <%= xdebug ? 'enable' : 'disable' %>
 <% if ( xdebugConfig ) { %>
         XDEBUG_CONFIG: "<%= xdebugConfig %>"
@@ -111,13 +110,6 @@ services:
         - search_data:/usr/share/elasticsearch/data
     volumes:
       search_data:
-<% } %>
-<% if ( statsd ) { %>
-  statsd:
-    type: compose
-    services:
-      image: ghcr.io/automattic/vip-container-images/statsd:v0.9.0
-      command: node stats.js /config/statsd-config.js
 <% } %>
 
   wordpress:

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -70,7 +70,6 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 			elasticsearch: currentInstanceData.elasticsearch,
 			php: currentInstanceData.php || DEV_ENVIRONMENT_PHP_VERSIONS.default,
 			mariadb: currentInstanceData.mariadb,
-			statsd: currentInstanceData.statsd,
 			phpmyadmin: currentInstanceData.phpmyadmin,
 			xdebug: currentInstanceData.xdebug,
 			mailhog: currentInstanceData.mailhog,

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -290,7 +290,6 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		appCode: {
 			mode: 'image',
 		},
-		statsd: false,
 		phpmyadmin: false,
 		xdebug: false,
 		xdebugConfig: preselectedOptions.xdebugConfig,
@@ -329,12 +328,6 @@ export async function promptForArguments( preselectedOptions: InstanceOptions, d
 		instanceData.elasticsearch = !! preselectedOptions.elasticsearch;
 	} else {
 		instanceData.elasticsearch = await promptForBoolean( 'Enable Elasticsearch (needed by Enterprise Search)?', !! defaultOptions.elasticsearch );
-	}
-
-	if ( instanceData.elasticsearch ) {
-		instanceData.statsd = preselectedOptions.statsd || defaultOptions.statsd || false;
-	} else {
-		instanceData.statsd = false;
 	}
 
 	for ( const service of [ 'phpmyadmin', 'xdebug', 'mailhog' ] ) {
@@ -602,7 +595,6 @@ export function addDevEnvConfigurationOptions( command: Command ): any {
 		.option( 'wordpress', 'Use a specific WordPress version' )
 		.option( [ 'u', 'mu-plugins' ], 'Use a specific mu-plugins changeset or local directory' )
 		.option( 'app-code', 'Use the application code from a local directory or use "demo" for VIP skeleton code' )
-		.option( 'statsd', 'Enable statsd component. By default it is disabled', undefined, processBooleanOption )
 		.option( 'phpmyadmin', 'Enable PHPMyAdmin component. By default it is disabled', undefined, processBooleanOption )
 		.option( 'xdebug', 'Enable XDebug. By default it is disabled', undefined, processBooleanOption )
 		.option( 'xdebug_config', 'Extra configuration to pass to xdebug via XDEBUG_CONFIG environment variable' )

--- a/src/lib/dev-environment/types.js
+++ b/src/lib/dev-environment/types.js
@@ -9,7 +9,6 @@ export interface InstanceOptions {
 	mariadb?: string;
 	php?: string;
 	mediaRedirectDomain?: string;
-	statsd?: boolean;
 	phpmyadmin?: boolean;
 	xdebug?: boolean;
 	xdebugConfig?: string;
@@ -62,7 +61,6 @@ export interface InstanceData {
 	muPlugins: ComponentConfig;
 	appCode: ComponentConfig;
 	mediaRedirectDomain: string;
-	statsd: boolean;
 	phpmyadmin: boolean;
 	xdebug: boolean;
 	xdebugConfig?: string;


### PR DESCRIPTION
## Description

Because we are replacing statsd with Prometheus, we don't need stated anymore.

Ref: https://github.com/Automattic/vip-go-mu-plugins/pull/3960

## Steps to Test

Once the patch is applied, dev env should no longer start `statsd` container.
