### PR TITLE
fix(dev-env): Errors should go to stderr, not stdout

### DIFF
--- a/src/lib/cli/exit.js
+++ b/src/lib/cli/exit.js
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 import env from 'lib/env';
 
 export function withError( message: string ) {
-	console.log( `${ chalk.red( 'Error: ' ) } ${ message.toString().replace( /^Error:\s*/, '' ) }` );
+	console.error( `${ chalk.red( 'Error: ' ) } ${ message.toString().replace( /^Error:\s*/, '' ) }` );
 
 	// Debug ouput is printed below error output both for information
 	// hierarchy and to make it more likely that the user copies it to their

--- a/src/lib/dev-environment/dev-environment-cli.js
+++ b/src/lib/dev-environment/dev-environment-cli.js
@@ -81,27 +81,27 @@ export async function handleCLIException( exception: Error, trackKey?: string, t
 		const createCommand = chalk.bold( DEV_ENVIRONMENT_FULL_COMMAND + ' create' );
 
 		const message = `Environment doesn't exist.\n\n\nTo create a new environment run:\n\n${ createCommand }\n`;
-		console.log( errorPrefix, message );
+		console.error( errorPrefix, message );
 	} else {
 		let message = exception.message;
 		// if the message has already ERROR prefix we should drop it as we are adding our own cool red Error-prefix
 		message = message.replace( 'ERROR: ', '' );
 
-		console.log( errorPrefix, message );
+		console.error( errorPrefix, message );
 
 		if ( trackKey ) {
 			try {
 				const errorTrackingInfo = { ...trackBaseInfo, failure: message, stack: exception.stack };
 				await trackEvent( trackKey, errorTrackingInfo );
 			} catch ( trackException ) {
-				console.log( errorPrefix, `Failed to record track event ${ trackKey }`, trackException.message );
+				console.warn( errorPrefix, `Failed to record track event ${ trackKey }`, trackException.message );
 			}
 		}
 
 		if ( ! process.env.DEBUG ) {
-			console.log( `\nPlease re-run the command with "--debug ${ chalk.bold( '@automattic/vip:bin:dev-environment' ) }" appended to it and provide the stack trace on the support ticket.` );
-			console.log( chalk.bold( '\nExample:\n' ) );
-			console.log( 'vip dev-env <command> <arguments> --debug @automattic/vip:bin:dev-environment \n' );
+			console.error( `\nPlease re-run the command with "--debug ${ chalk.bold( '@automattic/vip:bin:dev-environment' ) }" appended to it and provide the stack trace on the support ticket.` );
+			console.error( chalk.bold( '\nExample:\n' ) );
+			console.error( 'vip dev-env <command> <arguments> --debug @automattic/vip:bin:dev-environment \n' );
 		}
 
 		debug( exception );


### PR DESCRIPTION
## Description

By convention, error and diagnostics messages are sent to stderr, allowing output and errors to be distinguished. This PR updates a couple of functions to use `console.error()` instead of `console.log()` to output error messages.

This also simplifies E2E tests :-)

## Steps to Test

Everything should work as expected.
