### PR TITLE
Add filename validation to sql import

### DIFF
--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -265,6 +265,15 @@ If you are confident the file does not contain unsupported statements, you can r
 	return getTableNames();
 }
 
+function validateFilename( filename ) {
+	const re = /^[a-z0-9!\-_\.\*\'()]+$/i;
+
+	// Exits if filename contains anything outside a-z A-Z ! - _ . * ( )
+	if ( ! re.test( filename ) ) {
+		exit.withError( 'Error: The characters used in the name of a file for import is limited to [0-9,a-z,A-Z,-,_,.].' );
+	}
+}
+
 const displayPlaybook = ( {
 	launched,
 	tableNames,
@@ -410,6 +419,9 @@ command( {
 		const launched = opts.env.launched;
 
 		let fileNameToUpload = fileName;
+
+		// Exit if filename contains unsafe character
+		validateFilename( fileNameToUpload );
 
 		// SQL file validations
 		const tableNames = await validateAndGetTableNames( {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -266,7 +266,7 @@ If you are confident the file does not contain unsupported statements, you can r
 }
 
 function validateFilename( filename ) {
-	const re = /^[a-z0-9\-_\.]+$/i;
+	const re = /^[a-z0-9\-\_\.]+$/i;
 
 	// Exits if filename contains anything outside a-z A-Z - _ .
 	if ( ! re.test( filename ) ) {

--- a/src/bin/vip-import-sql.js
+++ b/src/bin/vip-import-sql.js
@@ -266,9 +266,9 @@ If you are confident the file does not contain unsupported statements, you can r
 }
 
 function validateFilename( filename ) {
-	const re = /^[a-z0-9!\-_\.\*\'()]+$/i;
+	const re = /^[a-z0-9\-_\.]+$/i;
 
-	// Exits if filename contains anything outside a-z A-Z ! - _ . * ( )
+	// Exits if filename contains anything outside a-z A-Z - _ .
 	if ( ! re.test( filename ) ) {
 		exit.withError( 'Error: The characters used in the name of a file for import is limited to [0-9,a-z,A-Z,-,_,.].' );
 	}


### PR DESCRIPTION
## Description

Uploading a file to AWS S3 fails if the filename contains some listed characters in this [doc](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html).

One such example filename is `10+TRIBAL+prod2-sites-ca-gov-2022-08-25-17-30-26.sql.gz`, and a customer faced this issue when trying to upload the file. 

In this PR, we are adding a validation of the filename. Basically we will abort the command with the following message if the filename contains anything outside `A-Z` `a-z` `0-9` `-` `_` `.` : 
```
Error: The characters used in the name of a file for import is limited to [0-9,a-z,A-Z,-,_,.].
```

Our VIP doc is also updated to convey this [limitation](https://docs.wpvip.com/how-tos/migrate-content-databases/#h-limitations).

## Steps to Test

1. Check out PR.
1. Run `npm run build`
2. Export any db backup, and rename it to contain a character outside the list. Ex: `some+backup.sql.gz`
1. Run `./dist/bin/vip-import-sql.js @saroshaga-test.Develop.Saroshaga-Test-Develop some+backup.sql.gz `
1. You should see the error.

