### PR TITLE
fix(dev-env): Fix search/replace on SQL file import

### DIFF
--- a/src/lib/dev-environment/dev-environment-core.js
+++ b/src/lib/dev-environment/dev-environment-core.js
@@ -458,7 +458,7 @@ export async function getApplicationInformation( appId: number, envType: string 
 
 export async function resolveImportPath( slug: string, fileName: string, searchReplace: string | string[], inPlace: boolean ): Promise<SQLImportPaths> {
 	debug( `Will try to resolve path - ${ fileName }` );
-	const resolvedPath = resolvePath( fileName );
+	let resolvedPath = resolvePath( fileName );
 
 	const instancePath = getEnvironmentPath( slug );
 
@@ -493,6 +493,7 @@ export async function resolveImportPath( slug: string, fileName: string, searchR
 			throw new Error( 'Unable to determine location of the intermediate search & replace file.' );
 		}
 
+		resolvedPath = outputFileName;
 		baseName = path.basename( outputFileName );
 	} else {
 		baseName = path.basename( resolvedPath );


### PR DESCRIPTION
## Description

It looks like search/replace is currently broken:

```
vip dev-env exec -- wp db export - > db.sql
# Remove garbage from the top of db.sql
vip dev-env import sql db.sql -r 'vip-local,test'
vip dev-env exec -- wp option get home
```

The expected result is to get `http://test.vipdev.lndo.site`
The actual result is `http://vip-local.vipdev.lndo.site`

This PR fixes that.

## Steps to Test

Apply the patch and try the steps above.

This is also tested in 1762bf2.
