### PR TITLE
Fix Windows artifact paths in prerelease promotion

### DIFF
--- a/internal/releasepromotion/contract.go
+++ b/internal/releasepromotion/contract.go
@@ -64,8 +64,9 @@ func ValidateArtifactManifest(artifacts []Artifact) (map[string]Artifact, error)
 	var unfinished []string
 	var duplicates []string
 	for _, artifact := range artifacts {
-		artifactPath := path.Clean(artifact.Path)
-		if artifactPath != artifact.Path {
+		normalizedPath := strings.ReplaceAll(artifact.Path, `\`, "/")
+		artifactPath := path.Clean(normalizedPath)
+		if artifactPath != normalizedPath {
 			unexpected = append(unexpected, artifact.Path)
 			continue
 		}
@@ -77,6 +78,7 @@ func ValidateArtifactManifest(artifacts []Artifact) (map[string]Artifact, error)
 			duplicates = append(duplicates, artifactPath)
 			continue
 		}
+		artifact.Path = artifactPath
 		manifest[artifactPath] = artifact
 		if artifact.State != "finished" {
 			unfinished = append(unfinished, artifactPath)

--- a/internal/releasepromotion/contract_test.go
+++ b/internal/releasepromotion/contract_test.go
@@ -62,6 +62,34 @@ func TestValidateArtifactManifest(t *testing.T) {
 	}
 }
 
+func TestValidateArtifactManifestNormalizesWindowsSeparators(t *testing.T) {
+	t.Parallel()
+	expected := ExpectedArtifactPaths()
+	artifacts := make([]Artifact, 0, len(expected))
+	for _, artifactPath := range expected {
+		buildkitePath := artifactPath
+		if strings.Contains(artifactPath, "-windows-") {
+			buildkitePath = strings.ReplaceAll(artifactPath, "/", `\`)
+		}
+		artifacts = append(artifacts, Artifact{Path: buildkitePath, State: "finished"})
+	}
+
+	manifest, err := ValidateArtifactManifest(artifacts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, artifactPath := range expected {
+		artifact, ok := manifest[artifactPath]
+		if !ok {
+			t.Errorf("manifest missing normalized path %q", artifactPath)
+			continue
+		}
+		if artifact.Path != artifactPath {
+			t.Errorf("artifact path = %q, want normalized %q", artifact.Path, artifactPath)
+		}
+	}
+}
+
 func TestValidateArtifactManifestRejectsInvalidSets(t *testing.T) {
 	t.Parallel()
 	valid := func() []Artifact {
@@ -106,6 +134,14 @@ func TestValidateArtifactManifestRejectsInvalidSets(t *testing.T) {
 				return artifacts
 			},
 			want: []string{"not finished", ExpectedArtifactPaths()[0]},
+		},
+		{
+			name: "windows traversal",
+			mutate: func(artifacts []Artifact) []Artifact {
+				artifacts[0].Path = `dist\..\vip-next-darwin-amd64.tar.gz`
+				return artifacts
+			},
+			want: []string{"unexpected", `dist\..\vip-next-darwin-amd64.tar.gz`},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- normalize Buildkite artifact paths from Windows separators to API-style forward slashes before exact manifest validation
- preserve strict rejection of unexpected, duplicate, unfinished, and traversal-shaped paths
- add a regression test matching the `dist\\vip-next-windows-*` paths returned by the failed `5.0.0-alpha.1` promotion

## Root cause

Buildkite reports artifacts uploaded by its Windows agent with backslashes in the `path` field. The prerelease helper compared those paths literally against its slash-separated ten-file manifest, so it reported the two Windows files as both missing and unexpected even though they existed.

## Verification

- `go test -race ./internal/releasepromotion ./cmd/vip-next-prerelease`
- `make test`
- `make lint`
- `gofmt -d internal/releasepromotion/contract.go internal/releasepromotion/contract_test.go`
- `git diff --check`
- independent review: no findings

No tag, draft release, or workflow run was modified by this PR.

## Changelog Description

Fixed VIP CLI 5 prerelease promotion when Buildkite returns Windows artifact paths with backslash separators.
