### PR TITLE
Fix prerelease reruns reusing draft releases

### DIFF
--- a/internal/releasepromotion/github.go
+++ b/internal/releasepromotion/github.go
@@ -72,6 +72,16 @@ func (c *GitHubClient) EnsureDraft(ctx context.Context, version, commit string) 
 	if status != http.StatusNotFound {
 		return Release{}, fmt.Errorf("look up release %q: HTTP %d", version, status)
 	}
+	existingDraft, err := c.findDraft(ctx, version)
+	if err != nil {
+		return Release{}, err
+	}
+	if existingDraft != nil {
+		if err := c.verifyTag(ctx, version, commit, false); err != nil {
+			return Release{}, err
+		}
+		return *existingDraft, nil
+	}
 
 	if err := c.ensureTag(ctx, version, commit); err != nil {
 		return Release{}, err
@@ -91,6 +101,24 @@ func (c *GitHubClient) EnsureDraft(ctx context.Context, version, commit string) 
 		return Release{}, err
 	}
 	return release, nil
+}
+
+func (c *GitHubClient) findDraft(ctx context.Context, version string) (*Release, error) {
+	endpoint := fmt.Sprintf("%s/repos/%s/releases?per_page=100", c.baseURL(), GitHubRepository)
+	var releases []Release
+	status, err := c.getJSON(ctx, endpoint, &releases)
+	if err != nil {
+		return nil, fmt.Errorf("list releases: %w", err)
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("list releases: HTTP %d", status)
+	}
+	for i := range releases {
+		if releases[i].Draft && releases[i].TagName == version {
+			return &releases[i], nil
+		}
+	}
+	return nil, nil
 }
 
 func (c *GitHubClient) ensureTag(ctx context.Context, version, commit string) error {

--- a/internal/releasepromotion/github_test.go
+++ b/internal/releasepromotion/github_test.go
@@ -31,6 +31,8 @@ func TestEnsureDraftCreatesReleaseAndTagAtCommit(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
 			http.NotFound(w, r)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases"):
+			writeJSON(t, w, []Release{})
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/ref/tags/"):
 			http.NotFound(w, r)
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git/refs"):
@@ -89,6 +91,49 @@ func TestEnsureDraftResumesSameCommitDraft(t *testing.T) {
 	}
 	if release.ID != 44 {
 		t.Fatalf("release ID = %d", release.ID)
+	}
+}
+
+func TestEnsureDraftFindsDraftWhenTagEndpointOmitsDraft(t *testing.T) {
+	t.Parallel()
+	const version = "5.0.0-rc.1"
+	const commit = "0123456789abcdef0123456789abcdef01234567"
+	var mutations int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			mutations++
+		}
+		switch {
+		case r.URL.Path == "/repos/Automattic/vip-cli/releases/tags/"+version:
+			http.NotFound(w, r)
+		case r.URL.Path == "/repos/Automattic/vip-cli/releases":
+			if r.URL.Query().Get("per_page") != "100" {
+				t.Fatalf("per_page = %q", r.URL.Query().Get("per_page"))
+			}
+			writeJSON(t, w, []Release{{
+				ID:         44,
+				TagName:    version,
+				Draft:      true,
+				Prerelease: true,
+				UploadURL:  serverURL(r) + "/uploads/44{?name,label}",
+			}})
+		case r.URL.Path == "/repos/Automattic/vip-cli/git/ref/tags/"+version:
+			writeJSON(t, w, map[string]any{
+				"ref":    "refs/tags/" + version,
+				"object": map[string]string{"type": "commit", "sha": commit},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	release, err := testGitHubClient(server.URL).EnsureDraft(context.Background(), version, commit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.ID != 44 || mutations != 0 {
+		t.Fatalf("release = %#v, mutations = %d", release, mutations)
 	}
 }
 
@@ -182,6 +227,8 @@ func TestEnsureDraftResumesExistingMatchingTagWithoutRelease(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/releases/tags/"):
 			http.NotFound(w, r)
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/releases"):
+			writeJSON(t, w, []Release{})
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/git/ref/tags/"):
 			writeJSON(t, w, map[string]any{
 				"ref":    "refs/tags/" + version,


### PR DESCRIPTION
## What changed

- fall back to the authenticated releases list when GitHub's release-by-tag endpoint omits an existing draft
- reuse the matching draft and verify its tag still points to the requested commit before continuing
- add regression coverage for a failed first attempt followed by a workflow rerun

## Why

GitHub Actions run 33828697786 failed after creating the `5.0.0-alpha.2` draft because its Buildkite build failed. On rerun, the release-by-tag endpoint returned 404 for that draft, so the promotion helper created a second release. The second release was populated and published successfully, but the first remained as an empty orphan draft.

## Verification

- `make test`
- `make lint`
- regression test was observed failing before the implementation and passing afterward

This PR does not delete the existing orphan draft or modify any published release.
