### PR TITLE
Add first-class podman support to vip dev-env

### DIFF
--- a/.github/workflows/devenv-e2e.yml
+++ b/.github/workflows/devenv-e2e.yml
@@ -12,10 +12,13 @@ env:
 
 jobs:
   test:
-    name: Run E2E Tests, shard ${{ matrix.shard }}
+    name: Run E2E Tests, ${{ matrix.engine }}, shard ${{ matrix.shard }}
     strategy:
       fail-fast: false
       matrix:
+        engine:
+          - docker
+          - podman
         shard:
           - 1
           - 2
@@ -23,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--localstorage-file=/tmp/localstorage'
+      VIP_DEV_ENV_TEST_ENGINE: ${{ matrix.engine }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -45,6 +49,15 @@ jobs:
           REPO="docker/compose"
           LATEST_RELEASE=$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" --silent "https://api.github.com/repos/${REPO}/releases/latest" | jq -r .tag_name)
           sudo curl -L "https://github.com/${REPO}/releases/download/${LATEST_RELEASE}/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose && sudo chmod 0755 /usr/local/bin/docker-compose
+
+      - name: Install rootless podman
+        if: matrix.engine == 'podman'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+          sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80
+          systemctl --user enable --now podman.socket
+          echo "DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')" >> "$GITHUB_ENV"
 
       - name: Preload Docker images
         run: |

--- a/__fixtures__/dev-environment/docker-info.json
+++ b/__fixtures__/dev-environment/docker-info.json
@@ -1,0 +1,112 @@
+{
+	"ID": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+	"Containers": 3,
+	"ContainersRunning": 2,
+	"ContainersPaused": 0,
+	"ContainersStopped": 1,
+	"Images": 12,
+	"Driver": "overlay2",
+	"SystemStatus": null,
+	"Plugins": {
+		"Volume": [ "local" ],
+		"Network": [ "bridge", "host", "ipvlan", "macvlan", "null", "overlay" ],
+		"Authorization": null,
+		"Log": [ "awslogs", "fluentd", "gcplogs", "gelf", "journald", "json-file", "local", "splunk", "syslog" ]
+	},
+	"MemoryLimit": true,
+	"SwapLimit": true,
+	"KernelMemory": false,
+	"KernelMemoryTCP": false,
+	"CpuCfsPeriod": true,
+	"CpuCfsQuota": true,
+	"CPUShares": true,
+	"CPUSet": true,
+	"OomKillDisable": true,
+	"IPv4Forwarding": true,
+	"BridgeNfIptables": false,
+	"BridgeNfIp6tables": false,
+	"Debug": false,
+	"NFd": 42,
+	"OomScoreAdj": 0,
+	"NGoroutines": 60,
+	"SystemTime": "2026-09-07T12:00:00.000000000Z",
+	"LoggingDriver": "json-file",
+	"CgroupDriver": "cgroupfs",
+	"CgroupVersion": "2",
+	"NEventsListener": 0,
+	"KernelVersion": "6.6.87.2-microsoft-standard-WSL2",
+	"OperatingSystem": "Docker Desktop",
+	"OSVersion": "",
+	"OSType": "linux",
+	"Architecture": "aarch64",
+	"IndexServerAddress": "https://index.docker.io/v1/",
+	"RegistryConfig": {
+		"AllowNondistributableArtifactsCIDRs": [],
+		"AllowNondistributableArtifactsHostnames": [],
+		"InsecureRegistryCIDRs": [ "127.0.0.0/8" ],
+		"IndexConfigs": {
+			"docker.io": {
+				"Name": "docker.io",
+				"Mirrors": [],
+				"Secure": true,
+				"Official": true
+			}
+		},
+		"Mirrors": []
+	},
+	"NCPU": 6,
+	"MemTotal": 8221151232,
+	"GenericResources": null,
+	"DockerRootDir": "/var/lib/docker",
+	"HttpProxy": "",
+	"HttpsProxy": "",
+	"NoProxy": "",
+	"Name": "docker-desktop",
+	"Labels": [],
+	"ExperimentalBuild": false,
+	"ServerVersion": "27.3.1",
+	"ClusterStore": "",
+	"Runtimes": {
+		"io.containerd.runc.v2": { "path": "runc" },
+		"runc": { "path": "runc" }
+	},
+	"DefaultRuntime": "runc",
+	"Swarm": {
+		"NodeID": "",
+		"NodeAddr": "",
+		"LocalNodeState": "inactive",
+		"ControlAvailable": false,
+		"Error": "",
+		"RemoteManagers": null
+	},
+	"LiveRestoreEnabled": false,
+	"Isolation": "",
+	"InitBinary": "docker-init",
+	"ContainerdCommit": { "ID": "8a1c8f22e59f43deed918b7d1006ec7f0e1a1c50" },
+	"RuncCommit": { "ID": "v1.1.14-0-g2c9f560" },
+	"InitCommit": { "ID": "de40ad0" },
+	"SecurityOptions": [ "name=seccomp,profile=builtin" ],
+	"ProductLicense": "Community Engine",
+	"Warnings": null,
+	"ServerErrors": null,
+	"ClientInfo": {
+		"Debug": false,
+		"Plugins": [
+			{
+				"SchemaVersion": "0.1.0",
+				"Vendor": "Docker Inc.",
+				"Version": "v2.29.7",
+				"Name": "compose",
+				"Path": "/usr/libexec/docker/cli-plugins/docker-compose"
+			},
+			{
+				"SchemaVersion": "0.1.0",
+				"Vendor": "Docker Inc.",
+				"Version": "v0.19.0",
+				"Name": "buildx",
+				"Path": "/usr/libexec/docker/cli-plugins/docker-buildx"
+			}
+		],
+		"Warnings": null
+	}
+}

--- a/__fixtures__/dev-environment/podman-info.json
+++ b/__fixtures__/dev-environment/podman-info.json
@@ -1,0 +1,193 @@
+{
+    "host": {
+        "arch": "arm64",
+        "buildahVersion": "1.45.0",
+        "cgroupManager": "systemd",
+        "cgroupVersion": "v2",
+        "cgroupControllers": [
+            "cpu",
+            "io",
+            "memory",
+            "pids"
+        ],
+        "cdiSpecDirs": [
+            "/etc/cdi",
+            "/var/run/cdi"
+        ],
+        "conmon": {
+            "package": "conmon-2.2.1-2.fc44.aarch64",
+            "path": "/usr/bin/conmon",
+            "version": "conmon version 2.2.1, commit: "
+        },
+        "cpus": 6,
+        "cpuUtilization": {
+            "userPercent": 2.69,
+            "systemPercent": 1.95,
+            "idlePercent": 95.35
+        },
+        "databaseBackend": "sqlite",
+        "distribution": {
+            "distribution": "fedora",
+            "variant": "podman-machine-os",
+            "version": "44"
+        },
+        "eventLogger": "journald",
+        "freeLocks": 2009,
+        "hostname": "localhost.localdomain",
+        "idMappings": {
+            "gidmap": [
+                {
+                    "container_id": 0,
+                    "host_id": 1000,
+                    "size": 1
+                },
+                {
+                    "container_id": 1,
+                    "host_id": 100000,
+                    "size": 1000000
+                }
+            ],
+            "uidmap": [
+                {
+                    "container_id": 0,
+                    "host_id": 501,
+                    "size": 1
+                },
+                {
+                    "container_id": 1,
+                    "host_id": 100000,
+                    "size": 1000000
+                }
+            ]
+        },
+        "kernel": "7.1.8-200.fc44.aarch64",
+        "logDriver": "journald",
+        "memFree": 267460608,
+        "memAvailable": 9067139072,
+        "memTotal": 12495929344,
+        "networkBackend": "netavark",
+        "networkBackendInfo": {
+            "backend": "netavark",
+            "version": "netavark 2.1.0",
+            "package": "netavark-2.1.0-1.fc44.aarch64",
+            "path": "/usr/libexec/podman/netavark",
+            "dns": {
+                "version": "aardvark-dns 2.1.0",
+                "package": "aardvark-dns-2.1.0-1.fc44.aarch64",
+                "path": "/usr/libexec/podman/aardvark-dns"
+            },
+            "defaultNetwork": "podman"
+        },
+        "ociRuntime": {
+            "name": "crun",
+            "package": "crun-1.29.1-1.fc44.aarch64",
+            "path": "/usr/bin/crun",
+            "version": "crun version 1.29.1\ncommit: f0d911de5587342cfeb16473bf32ecdfeaf25957\nrundir: /run/user/501/crun\nspec: 1.0.0\n+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +LIBKRUN +WASM:wasmedge +JSON_C"
+        },
+        "os": "linux",
+        "remoteSocket": {
+            "path": "unix:///run/user/501/podman/podman.sock",
+            "exists": true
+        },
+        "rootlessNetworkCmd": "pasta",
+        "rootlessPortForwarder": "rootlessport",
+        "serviceIsRemote": true,
+        "security": {
+            "apparmorEnabled": false,
+            "capabilities": "CAP_CHOWN,CAP_DAC_OVERRIDE,CAP_FOWNER,CAP_FSETID,CAP_KILL,CAP_NET_BIND_SERVICE,CAP_SETFCAP,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT",
+            "rootless": true,
+            "seccompEnabled": true,
+            "seccompProfilePath": "/usr/share/containers/seccomp.json",
+            "selinuxEnabled": true
+        },
+        "pasta": {
+            "executable": "/usr/bin/pasta",
+            "package": "passt-0^20260728.gf8df3f1-2.fc44.aarch64",
+            "version": "pasta 0^20260728.gf8df3f1-2.fc44.aarch64-pasta\nCopyright Red Hat\nGNU General Public License, version 2 or later\n  <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n"
+        },
+        "swapFree": 0,
+        "swapTotal": 0,
+        "uptime": "2h 13m 10.00s (Approximately 0.08 days)",
+        "variant": "v8",
+        "linkmode": "dynamic",
+        "emulatedArchitectures": [
+            "linux/386",
+            "linux/amd64",
+            "linux/arm64be"
+        ]
+    },
+    "store": {
+        "containerStore": {
+            "number": 18,
+            "paused": 0,
+            "running": 16,
+            "stopped": 2
+        },
+        "graphDriverName": "overlay",
+        "graphOptions": {
+            "overlay.mountopt": "nodev"
+        },
+        "graphRoot": "/var/home/core/.local/share/containers/storage",
+        "graphRootAllocated": 106769133568,
+        "graphRootUsed": 13860491264,
+        "graphStatus": {
+            "Backing Filesystem": "xfs",
+            "Native Overlay Diff": "true",
+            "Supports d_type": "true",
+            "Supports shifting": "false",
+            "Supports volatile": "true",
+            "Using metacopy": "false"
+        },
+        "imageCopyTmpDir": "/var/tmp",
+        "imageStore": {
+            "number": 49
+        },
+        "runRoot": "/run/user/501/containers",
+        "volumePath": "/var/home/core/.local/share/containers/storage/volumes",
+        "transientStore": false
+    },
+    "registries": {
+        "search": [
+            "docker.io"
+        ]
+    },
+    "plugins": {
+        "volume": [
+            "local"
+        ],
+        "network": [
+            "bridge",
+            "macvlan",
+            "ipvlan"
+        ],
+        "log": [
+            "k8s-file",
+            "none",
+            "passthrough",
+            "journald"
+        ],
+        "authorization": null
+    },
+    "version": {
+        "APIVersion": "6.1.1",
+        "Version": "6.1.1",
+        "GoVersion": "go1.26.7-X:nodwarf5",
+        "GitCommit": "8303f2e25b675ea7f82099d615c60969aec15870",
+        "BuiltTime": "Wed Sep  2 08:00:00 2026",
+        "Built": 1788307200,
+        "BuildOrigin": "Copr: packit/podman-container-tools-podman-29700",
+        "OsArch": "linux/arm64",
+        "Os": "linux"
+    },
+    "Client": {
+        "APIVersion": "6.1.1",
+        "Version": "6.1.1",
+        "GoVersion": "go1.27.1",
+        "GitCommit": "",
+        "BuiltTime": "Wed Sep  2 21:12:23 2026",
+        "Built": 1788354743,
+        "BuildOrigin": "brew",
+        "OsArch": "darwin/arm64",
+        "Os": "darwin"
+    }
+}

--- a/__tests__/devenv-e2e/015-podman-proxy.spec.js
+++ b/__tests__/devenv-e2e/015-podman-proxy.spec.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { CliTest } from './helpers/cli-test';
+import { createDockerClient, killProjectContainers } from './helpers/docker-utils';
+import {
+	createAndStartEnvironment,
+	destroyEnvironment,
+	getProjectSlug,
+	prepareEnvironment,
+} from './helpers/utils';
+
+const podmanDescribe = process.env.VIP_DEV_ENV_TEST_ENGINE === 'podman' ? describe : describe.skip;
+
+jest.setTimeout( 600 * 1000 ).retryTimes( 1, { logErrorsBeforeRetry: true } );
+
+podmanDescribe( 'vip dev-env under podman', () => {
+	let cliTest;
+	let env;
+	let tmpPath;
+	let docker;
+	let slug;
+
+	beforeAll( async () => {
+		cliTest = new CliTest();
+
+		tmpPath = await mkdtemp( path.join( os.tmpdir(), 'vip-dev-env-' ) );
+		process.env.XDG_DATA_HOME = tmpPath;
+
+		env = prepareEnvironment( tmpPath );
+
+		docker = await createDockerClient();
+	} );
+
+	afterAll( () => rm( tmpPath, { recursive: true, force: true } ) );
+
+	afterEach( async () => {
+		await destroyEnvironment( cliTest, slug, env );
+		await killProjectContainers( docker, slug );
+	} );
+
+	it( 'serves WordPress content through the proxy', async () => {
+		slug = getProjectSlug();
+		await createAndStartEnvironment( cliTest, slug, env );
+
+		const response = await fetch( `http://${ slug }.vipdev.lndo.site/` );
+		const body = await response.text();
+
+		expect( [ 200, 301, 302, 303, 307, 308 ] ).toContain( response.status );
+		expect( body ).toContain( 'wp-content' );
+	} );
+} );

--- a/__tests__/devenv-e2e/helpers/docker-utils.js
+++ b/__tests__/devenv-e2e/helpers/docker-utils.js
@@ -1,11 +1,18 @@
 /* eslint-disable id-length */
 
+import Docker from 'dockerode';
 import { dockerComposify } from 'lando/lib/utils';
 
+import { getDockerSocket } from '../../../src/lib/dev-environment/docker-utils';
+
 /**
- * @typedef {import('dockerode')} Docker
  * @typedef {import('dockerode').ContainerInfo} ContainerInfo
  */
+
+export async function createDockerClient() {
+	const socketPath = await getDockerSocket();
+	return socketPath ? new Docker( { socketPath } ) : new Docker();
+}
 
 /**
  * @param {Docker} docker  Docker instance

--- a/__tests__/lib/dev-environment/dev-environment-lando.js
+++ b/__tests__/lib/dev-environment/dev-environment-lando.js
@@ -1,0 +1,127 @@
+import { expect } from '@jest/globals';
+import ejs from 'ejs';
+import * as yaml from 'js-yaml';
+import path from 'node:path';
+
+const templatePath = path.join(
+	__dirname,
+	'..',
+	'..',
+	'..',
+	'assets',
+	'dev-env.lando.template.yml.ejs'
+);
+
+const baseTemplateData = {
+	siteSlug: 'my-site',
+	domain: 'vipdev.lndo.site',
+	multisite: false,
+	phpmyadmin: true,
+	mailpit: true,
+	elasticsearch: false,
+	photon: false,
+	xdebug: false,
+	xdebugConfig: undefined,
+	autologinKey: undefined,
+	cron: false,
+	mariadb: false,
+	php: 'ghcr.io/automattic/vip-container-images/php:8.2',
+	wpTitle: 'My Site',
+	adminPassword: 'password',
+	wordpress: { mode: 'image', tag: '6.5' },
+};
+
+async function renderTemplate( overrides ) {
+	const rendered = await ejs.renderFile( templatePath, { ...baseTemplateData, ...overrides } );
+	return yaml.load( rendered );
+}
+
+function getInitOnlyServiceNames( config ) {
+	return Object.keys( config.services ).filter(
+		serviceName => config.services[ serviceName ].initOnly
+	);
+}
+
+function getWpMountTargets( config ) {
+	const targets = new Set();
+	Object.values( config.services ).forEach( service => {
+		const volumes = service.services?.volumes ?? [];
+		volumes.forEach( volume => {
+			const target = typeof volume === 'string' ? volume.split( ':' )[ 1 ] : volume.target;
+			if ( target?.startsWith( '/wp/' ) ) {
+				targets.add( target.slice( '/wp/'.length ) );
+			}
+		} );
+	} );
+	return [ ...targets ];
+}
+
+describe( 'assets/dev-env.lando.template.yml.ejs', () => {
+	it.each( [
+		[
+			'image mode (mu-plugins + app-code images)',
+			{ muPlugins: { mode: 'image' }, appCode: { mode: 'image' } },
+		],
+		[
+			'local mode (mu-plugins + app-code directories)',
+			{
+				muPlugins: { mode: 'local', dir: './mu-plugins' },
+				appCode: { mode: 'local', dir: './app-code' },
+			},
+		],
+	] )(
+		'no initOnly service dependency waits only for service_started (%s)',
+		async ( _label, overrides ) => {
+			const config = await renderTemplate( overrides );
+			const initOnlyServices = getInitOnlyServiceNames( config );
+
+			expect( initOnlyServices ).toEqual( expect.arrayContaining( [ 'wordpress' ] ) );
+
+			const initOnlyDependencies = Object.entries( config.services ).flatMap(
+				( [ serviceName, service ] ) => {
+					const dependsOn = service.services?.depends_on ?? {};
+					return Object.entries( dependsOn )
+						.filter( ( [ dependencyName ] ) => initOnlyServices.includes( dependencyName ) )
+						.map( ( [ dependencyName, dependency ] ) => ( {
+							service: serviceName,
+							dependsOn: dependencyName,
+							condition: dependency.condition,
+						} ) );
+				}
+			);
+
+			expect( initOnlyDependencies.length ).toBeGreaterThan( 0 );
+			initOnlyDependencies.forEach( entry => {
+				expect( entry.condition ).toBe( 'service_completed_successfully' );
+			} );
+		}
+	);
+
+	it.each( [
+		[
+			'image mode (mu-plugins + app-code images)',
+			{ muPlugins: { mode: 'image' }, appCode: { mode: 'image' } },
+		],
+		[
+			'local mode (mu-plugins + app-code directories)',
+			{
+				muPlugins: { mode: 'local', dir: './mu-plugins' },
+				appCode: { mode: 'local', dir: './app-code' },
+			},
+		],
+	] )(
+		"the init container's rsync never deletes a sibling service's mount target (%s)",
+		async ( _label, overrides ) => {
+			const config = await renderTemplate( overrides );
+			const wpMountTargets = getWpMountTargets( config );
+
+			expect( wpMountTargets.length ).toBeGreaterThan( 0 );
+
+			const entrypoint = config.services.wordpress.entrypoint;
+
+			wpMountTargets.forEach( target => {
+				expect( entrypoint ).toContain( `--exclude=/${ target }` );
+			} );
+		}
+	);
+} );

--- a/__tests__/lib/dev-environment/docker-utils.spec.js
+++ b/__tests__/lib/dev-environment/docker-utils.spec.js
@@ -130,6 +130,91 @@ if ( platform() !== 'win32' ) {
 			process.env = { DOCKER_HOST: 'unix://mother/mary/this/is/scary' };
 			return expect( getDockerSocket() ).resolves.toBe( expectedPath );
 		} );
+
+		it( 'a podman machine socket on mac is found when no docker candidate exists', () => {
+			const expectedPath = path.join(
+				homedir(),
+				'.local',
+				'share',
+				'containers',
+				'podman',
+				'machine',
+				'podman.sock'
+			);
+
+			jest.spyOn( promises, 'stat' ).mockImplementation( fpath => {
+				if ( fpath !== expectedPath ) {
+					throw new Error( 'ENOENT' );
+				}
+				return { isSocket: () => true };
+			} );
+
+			jest.spyOn( promises, 'access' ).mockResolvedValueOnce( undefined );
+
+			process.env = {};
+			return expect( getDockerSocket() ).resolves.toBe( expectedPath );
+		} );
+
+		it( 'a podman rootless socket under XDG_RUNTIME_DIR is found when no earlier candidate exists', () => {
+			const runtimeDir = '/run/user/1000';
+			const expectedPath = path.join( runtimeDir, 'podman', 'podman.sock' );
+
+			jest.spyOn( promises, 'stat' ).mockImplementation( fpath => {
+				if ( fpath !== expectedPath ) {
+					throw new Error( 'ENOENT' );
+				}
+				return { isSocket: () => true };
+			} );
+
+			jest.spyOn( promises, 'access' ).mockResolvedValueOnce( undefined );
+
+			process.env = { XDG_RUNTIME_DIR: runtimeDir };
+			return expect( getDockerSocket() ).resolves.toBe( expectedPath );
+		} );
+
+		it( 'the podman machine inspect fallback is used only when a podman binary is present', async () => {
+			jest.spyOn( promises, 'stat' ).mockRejectedValue( new Error( 'ENOENT' ) );
+			process.env = {};
+
+			const exec = jest.fn().mockRejectedValue( new Error( 'ENOENT' ) );
+
+			await expect( getDockerSocket( exec ) ).resolves.toBeNull();
+			expect( exec ).toHaveBeenCalledWith( 'podman', [ '--version' ] );
+			expect( exec ).not.toHaveBeenCalledWith( 'podman', [ 'machine', 'inspect' ] );
+		} );
+
+		it( 'a socket resolved via podman machine inspect is returned when no static candidate exists', () => {
+			const expectedPath =
+				'/Users/tester/.local/share/containers/podman/machine/podman-machine-default/podman.sock';
+
+			jest.spyOn( promises, 'stat' ).mockImplementation( fpath => {
+				if ( fpath !== expectedPath ) {
+					throw new Error( 'ENOENT' );
+				}
+				return { isSocket: () => true };
+			} );
+			jest.spyOn( promises, 'access' ).mockResolvedValueOnce( undefined );
+
+			process.env = {};
+
+			const exec = jest.fn().mockImplementation( ( bin, args ) => {
+				if ( args[ 0 ] === '--version' ) {
+					return Promise.resolve( { stdout: 'podman version 5.0.0' } );
+				}
+
+				return Promise.resolve( {
+					stdout: JSON.stringify( [
+						{
+							ConnectionInfo: {
+								PodmanSocket: { Path: expectedPath },
+							},
+						},
+					] ),
+				} );
+			} );
+
+			return expect( getDockerSocket( exec ) ).resolves.toBe( expectedPath );
+		} );
 	} );
 }
 

--- a/__tests__/lib/dev-environment/docker-utils.spec.js
+++ b/__tests__/lib/dev-environment/docker-utils.spec.js
@@ -4,6 +4,7 @@ import { homedir, platform } from 'node:os';
 import path from 'node:path';
 
 import {
+	getDockerBin,
 	getDockerSocket,
 	getEngineConfig,
 	splitca,
@@ -217,6 +218,36 @@ if ( platform() !== 'win32' ) {
 		} );
 	} );
 }
+
+describe( 'getDockerBin', () => {
+	it( "a machine with a docker binary keeps today's resolution unchanged", async () => {
+		const exec = jest.fn().mockResolvedValue( { stdout: 'Docker version 27.0.0' } );
+
+		await expect( getDockerBin( exec ) ).resolves.toBeNull();
+		expect( exec ).toHaveBeenCalledWith( 'docker', [ '--version' ] );
+		expect( exec ).not.toHaveBeenCalledWith( 'podman', [ '--version' ] );
+	} );
+
+	it( 'vip-cli resolves the podman binary as its docker CLI when no docker binary exists', async () => {
+		const exec = jest.fn().mockImplementation( bin => {
+			if ( bin === 'docker' ) {
+				return Promise.reject( new Error( 'ENOENT' ) );
+			}
+
+			return Promise.resolve( { stdout: 'podman version 5.0.0' } );
+		} );
+
+		await expect( getDockerBin( exec ) ).resolves.toBe( 'podman' );
+		expect( exec ).toHaveBeenCalledWith( 'docker', [ '--version' ] );
+		expect( exec ).toHaveBeenCalledWith( 'podman', [ '--version' ] );
+	} );
+
+	it( 'a machine with neither docker nor podman resolves to null, preserving the could-not-be-located error path', async () => {
+		const exec = jest.fn().mockRejectedValue( new Error( 'ENOENT' ) );
+
+		await expect( getDockerBin( exec ) ).resolves.toBeNull();
+	} );
+} );
 
 describe( 'getEngineConfig', () => {
 	const env = { ...process.env };

--- a/__tests__/lib/dev-environment/engine-preflight.spec.js
+++ b/__tests__/lib/dev-environment/engine-preflight.spec.js
@@ -1,0 +1,107 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { composeRequirement, podmanPreflight } from '../../../src/lib/dev-environment/engine';
+
+const dockerEngineInfo = {
+	engine: 'docker',
+	serverVersion: '27.3.1',
+	socketPath: '/var/run/docker.sock',
+	rootless: false,
+};
+
+const podmanEngineInfo = {
+	engine: 'podman',
+	serverVersion: '6.1.1',
+	socketPath: '/run/user/501/podman/podman.sock',
+	rootless: true,
+};
+
+describe( 'composeRequirement', () => {
+	it( 'docker always passes regardless of compose binary presence', () => {
+		expect( composeRequirement( dockerEngineInfo ) ).toEqual( { ok: true } );
+		expect(
+			composeRequirement( { ...dockerEngineInfo, composeBinaryVersion: undefined } )
+		).toEqual( { ok: true } );
+	} );
+
+	it( 'podman without docker-compose v2 refuses with an actionable remedy', () => {
+		const result = composeRequirement( podmanEngineInfo );
+
+		expect( result.ok ).toBe( false );
+		expect( result ).toEqual(
+			expect.objectContaining( {
+				ok: false,
+				reason: expect.stringContaining( 'no standalone docker-compose binary' ),
+				remedy: expect.stringContaining( 'docs.docker.com/compose/install' ),
+			} )
+		);
+	} );
+
+	it( 'podman with a pre-v2 docker-compose binary refuses with an actionable remedy', () => {
+		const result = composeRequirement( { ...podmanEngineInfo, composeBinaryVersion: '1.29.2' } );
+
+		expect( result.ok ).toBe( false );
+		expect( result ).toEqual(
+			expect.objectContaining( {
+				ok: false,
+				reason: expect.stringContaining( '1.29.2' ),
+			} )
+		);
+	} );
+
+	it( 'podman with a real docker-compose v2 binary passes', () => {
+		expect( composeRequirement( { ...podmanEngineInfo, composeBinaryVersion: '2.29.7' } ) ).toEqual(
+			{ ok: true }
+		);
+	} );
+} );
+
+describe( 'podmanPreflight', () => {
+	it( 'docker never produces findings, even when probes indicate the sysctl is unset', () => {
+		const findings = podmanPreflight( dockerEngineInfo, {
+			unprivilegedPortStartAllowsPort80: false,
+			isPodmanMacMachine: false,
+		} );
+
+		expect( findings ).toEqual( [] );
+	} );
+
+	it( 'podman with the sysctl already allowing port 80 produces zero findings', () => {
+		const findings = podmanPreflight( podmanEngineInfo, {
+			unprivilegedPortStartAllowsPort80: true,
+			isPodmanMacMachine: false,
+		} );
+
+		expect( findings ).toEqual( [] );
+	} );
+
+	it( 'podman on a mac machine with the sysctl unset produces exactly one finding naming the machine ssh remedy', () => {
+		const findings = podmanPreflight( podmanEngineInfo, {
+			unprivilegedPortStartAllowsPort80: false,
+			isPodmanMacMachine: true,
+		} );
+
+		expect( findings ).toHaveLength( 1 );
+		expect( findings[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				severity: 'error',
+				remedy: expect.stringContaining( 'podman machine ssh' ),
+			} )
+		);
+	} );
+
+	it( 'podman on a linux host with the sysctl unset produces exactly one finding naming the sysctl.d remedy', () => {
+		const findings = podmanPreflight( podmanEngineInfo, {
+			unprivilegedPortStartAllowsPort80: false,
+			isPodmanMacMachine: false,
+		} );
+
+		expect( findings ).toHaveLength( 1 );
+		expect( findings[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				severity: 'error',
+				remedy: expect.stringContaining( '/etc/sysctl.d' ),
+			} )
+		);
+	} );
+} );

--- a/__tests__/lib/dev-environment/engine.spec.js
+++ b/__tests__/lib/dev-environment/engine.spec.js
@@ -2,7 +2,11 @@ import { describe, expect, it } from '@jest/globals';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { detectEngine } from '../../../src/lib/dev-environment/engine';
+import {
+	detectEngine,
+	proxyPublishAddress,
+	proxySocketMount,
+} from '../../../src/lib/dev-environment/engine';
 
 const fixturesDir = path.join( __dirname, '..', '..', '..', '__fixtures__', 'dev-environment' );
 const podmanInfoJson = readFileSync( path.join( fixturesDir, 'podman-info.json' ), 'utf8' );
@@ -78,5 +82,80 @@ describe( 'detectEngine', () => {
 			socketPath: '/var/run/docker.sock',
 			rootless: false,
 		} );
+	} );
+} );
+
+describe( 'proxyPublishAddress', () => {
+	it( 'publishes the proxy on 0.0.0.0 under podman', () => {
+		expect(
+			proxyPublishAddress( {
+				engine: 'podman',
+				serverVersion: '6.1.1',
+				socketPath: '/run/user/501/podman/podman.sock',
+				rootless: true,
+			} )
+		).toBe( '0.0.0.0' );
+	} );
+
+	it( 'keeps publishing the proxy on 127.0.0.1 under docker', () => {
+		expect(
+			proxyPublishAddress( {
+				engine: 'docker',
+				serverVersion: '27.3.1',
+				socketPath: '/var/run/docker.sock',
+				rootless: false,
+			} )
+		).toBe( '127.0.0.1' );
+	} );
+} );
+
+describe( 'proxySocketMount', () => {
+	it( 'mounts the real podman socket for the proxy under podman', () => {
+		const mount = proxySocketMount( {
+			engine: 'podman',
+			serverVersion: '6.1.1',
+			socketPath: '/run/user/501/podman/podman.sock',
+			rootless: true,
+		} );
+
+		expect( mount.source ).toBe( '/run/user/501/podman/podman.sock' );
+		expect( mount.target ).toBe( '/var/run/docker.sock' );
+	} );
+
+	it( 'never marks the socket mount selinux-disabled off a non-selinux host, even under podman', () => {
+		const mount = proxySocketMount( {
+			engine: 'podman',
+			serverVersion: '6.1.1',
+			socketPath: '/run/user/501/podman/podman.sock',
+			rootless: true,
+		} );
+
+		expect( mount.selinuxLabelDisable ).toBe( false );
+	} );
+
+	it( 'keeps mounting the existing docker socket unchanged under docker', () => {
+		const mount = proxySocketMount( {
+			engine: 'docker',
+			serverVersion: '27.3.1',
+			socketPath: '/var/run/docker.sock',
+			rootless: false,
+		} );
+
+		expect( mount ).toEqual( {
+			source: '/var/run/docker.sock',
+			target: '/var/run/docker.sock',
+			selinuxLabelDisable: false,
+		} );
+	} );
+
+	it( 'falls back to the default docker socket path when none was discovered', () => {
+		const mount = proxySocketMount( {
+			engine: 'docker',
+			serverVersion: 'unknown',
+			socketPath: '',
+			rootless: false,
+		} );
+
+		expect( mount.source ).toBe( '/var/run/docker.sock' );
 	} );
 } );

--- a/__tests__/lib/dev-environment/engine.spec.js
+++ b/__tests__/lib/dev-environment/engine.spec.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { detectEngine } from '../../../src/lib/dev-environment/engine';
+
+const fixturesDir = path.join( __dirname, '..', '..', '..', '__fixtures__', 'dev-environment' );
+const podmanInfoJson = readFileSync( path.join( fixturesDir, 'podman-info.json' ), 'utf8' );
+const dockerInfoJson = readFileSync( path.join( fixturesDir, 'docker-info.json' ), 'utf8' );
+
+const execReturning = stdout => async () => ( { stdout } );
+
+describe( 'detectEngine', () => {
+	it( 'detects podman as the dev-env engine from its own info output', async () => {
+		const engineInfo = await detectEngine(
+			'docker',
+			'/run/user/501/podman/podman.sock',
+			execReturning( podmanInfoJson )
+		);
+
+		expect( engineInfo.engine ).toBe( 'podman' );
+		expect( engineInfo.serverVersion ).toBe( '6.1.1' );
+		expect( engineInfo.socketPath ).toBe( '/run/user/501/podman/podman.sock' );
+		expect( engineInfo.rootless ).toBe( true );
+	} );
+
+	it( 'detects docker as the dev-env engine from its own info output', async () => {
+		const engineInfo = await detectEngine(
+			'docker',
+			'/var/run/docker.sock',
+			execReturning( dockerInfoJson )
+		);
+
+		expect( engineInfo.engine ).toBe( 'docker' );
+		expect( engineInfo.serverVersion ).toBe( '27.3.1' );
+		expect( engineInfo.composePlugin ).toBe( 'v2.29.7' );
+		expect( engineInfo.rootless ).toBe( false );
+	} );
+
+	it( "falls back to today's docker/unknown classification for unrecognized info output", async () => {
+		const engineInfo = await detectEngine(
+			'docker',
+			'/var/run/docker.sock',
+			execReturning( JSON.stringify( { someUnexpectedShape: true } ) )
+		);
+
+		expect( engineInfo ).toEqual( {
+			engine: 'docker',
+			serverVersion: 'unknown',
+			socketPath: '/var/run/docker.sock',
+			rootless: false,
+		} );
+	} );
+
+	it( 'never throws when the info command itself fails', async () => {
+		const engineInfo = await detectEngine( 'docker', '/var/run/docker.sock', async () => {
+			throw new Error( 'docker: command not found' );
+		} );
+
+		expect( engineInfo ).toEqual( {
+			engine: 'docker',
+			serverVersion: 'unknown',
+			socketPath: '/var/run/docker.sock',
+			rootless: false,
+		} );
+	} );
+
+	it( 'never throws when the info command returns unparseable output', async () => {
+		const engineInfo = await detectEngine(
+			'docker',
+			'/var/run/docker.sock',
+			execReturning( 'not json' )
+		);
+
+		expect( engineInfo ).toEqual( {
+			engine: 'docker',
+			serverVersion: 'unknown',
+			socketPath: '/var/run/docker.sock',
+			rootless: false,
+		} );
+	} );
+} );

--- a/assets/dev-env.lando.template.yml.ejs
+++ b/assets/dev-env.lando.template.yml.ejs
@@ -67,7 +67,7 @@ services:
           condition: service_completed_successfully
 <% if ( muPlugins.mode == 'image' ) { %>
         vip-mu-plugins:
-          condition: service_started
+          condition: service_completed_successfully
 <% } %>
 <% if ( appCode.mode == 'image' ) { %>
         demo-app-code:
@@ -204,7 +204,7 @@ services:
         - devtools:/dev-tools
         - scripts:/scripts
     initOnly: true
-    entrypoint: /bin/sh -c '/usr/bin/rsync -ac --delete --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/; /usr/bin/rsync -ac --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} --delete /dev-tools-orig/ /dev-tools/'
+    entrypoint: /bin/sh -c '/usr/bin/rsync -ac --delete <%= wpSiblingMountExcludes() %> --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} /wp/ /shared/; /usr/bin/rsync -ac --chown=${LANDO_HOST_USER_ID}:${LANDO_HOST_GROUP_ID} --delete /dev-tools-orig/ /dev-tools/'
     volumes:
       devtools:
       scripts:
@@ -311,65 +311,63 @@ tooling:
     cmd:
       - mysql -hdatabase -uwordpress -pwordpress -Dwordpress
 
+<%
+	function wpSubMounts() {
+		const mounts = [
+			{ target: 'config', source: './config' },
+			{ target: 'log', source: './log' },
+			{ target: 'wp-content/uploads', source: './uploads' },
+			{ target: 'config/integrations-config', source: './integrations-config' },
+		];
+
+		if ( muPlugins.mode == 'image' ) {
+			mounts.push( { target: 'wp-content/mu-plugins', volume: 'mu-plugins' } );
+		} else {
+			mounts.push( { target: 'wp-content/mu-plugins', source: muPlugins.dir } );
+		}
+
+		if ( appCode.mode == 'image' ) {
+			mounts.push(
+				{ target: 'wp-content/client-mu-plugins', volume: 'clientcode_clientmuPlugins' },
+				{ target: 'wp-content/images', volume: 'clientcode_images' },
+				{ target: 'wp-content/languages', volume: 'clientcode_languages' },
+				{ target: 'wp-content/plugins', volume: 'clientcode_plugins' },
+				{ target: 'wp-content/private', volume: 'clientcode_private' },
+				{ target: 'wp-content/themes', volume: 'clientcode_themes' },
+				{ target: 'vip-config', volume: 'clientcode_vipconfig' }
+			);
+		} else {
+			mounts.push(
+				{ target: 'wp-content/client-mu-plugins', source: `${ appCode.dir }/client-mu-plugins` },
+				{ target: 'wp-content/images', source: `${ appCode.dir }/images` },
+				{ target: 'wp-content/languages', source: `${ appCode.dir }/languages` },
+				{ target: 'wp-content/plugins', source: `${ appCode.dir }/plugins` },
+				{ target: 'wp-content/private', source: `${ appCode.dir }/private` },
+				{ target: 'wp-content/themes', source: `${ appCode.dir }/themes` },
+				{ target: 'vip-config', source: `${ appCode.dir }/vip-config` }
+			);
+		}
+
+		return mounts;
+	}
+
+	function wpSiblingMountExcludes() {
+		return wpSubMounts()
+			.map( mount => `--exclude=/${ mount.target }` )
+			.join( ' ' );
+	}
+%>
 <% function wpVolumes() { %>
-        - ./config:/wp/config
-        - ./log:/wp/log
-        - ./uploads:/wp/wp-content/uploads
         - ./wordpress:/wp
-        - ./integrations-config:/wp/config/integrations-config
-<% if ( muPlugins.mode == 'image' ) { %>
+<% wpSubMounts().forEach( function ( mount ) { %>
+<% if ( mount.volume ) { %>
         - type: volume
-          source: mu-plugins
-          target: /wp/wp-content/mu-plugins
+          source: <%= mount.volume %>
+          target: /wp/<%= mount.target %>
           volume:
             nocopy: true
 <% } else { %>
-        - <%= muPlugins.dir %>:/wp/wp-content/mu-plugins
+        - <%= mount.source %>:/wp/<%= mount.target %>
 <% } %>
-<% if ( appCode.mode == 'image' ) { %>
-        - type: volume
-          source: clientcode_clientmuPlugins
-          target: /wp/wp-content/client-mu-plugins
-          volume:
-            nocopy: true
-        - type: volume
-          source: clientcode_images
-          target: /wp/wp-content/images
-          volume:
-            nocopy: true
-        - type: volume
-          source: clientcode_languages
-          target: /wp/wp-content/languages
-          volume:
-            nocopy: true
-        - type: volume
-          source: clientcode_plugins
-          target: /wp/wp-content/plugins
-          volume:
-            nocopy: true
-        - type: volume
-          source: clientcode_private
-          # FIXME: Do we need this to be out of /wp for local development?
-          target: /wp/wp-content/private
-          volume:
-            nocopy: true
-        - type: volume
-          source: clientcode_themes
-          target: /wp/wp-content/themes
-          volume:
-            nocopy: true
-        - type: volume
-          source: clientcode_vipconfig
-          target: /wp/vip-config
-          volume:
-            nocopy: true
-<% } else { %>
-        - <%= appCode.dir %>/client-mu-plugins:/wp/wp-content/client-mu-plugins
-        - <%= appCode.dir %>/images:/wp/wp-content/images
-        - <%= appCode.dir %>/languages:/wp/wp-content/languages
-        - <%= appCode.dir %>/plugins:/wp/wp-content/plugins
-        - <%= appCode.dir %>/private:/wp/wp-content/private
-        - <%= appCode.dir %>/themes:/wp/wp-content/themes
-        - <%= appCode.dir %>/vip-config:/wp/vip-config
-<% } %>
+<% } ); %>
 <% } %>

--- a/cmd/vip-next/commands/devenv_lifecycle.go
+++ b/cmd/vip-next/commands/devenv_lifecycle.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os/exec"
+	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,10 +18,42 @@ import (
 	"github.com/Automattic/vip/internal/devenv"
 	"github.com/Automattic/vip/internal/devenv/compose"
 	"github.com/Automattic/vip/internal/devenv/devlog"
+	"github.com/Automattic/vip/internal/devenv/dockercli"
 	"github.com/Automattic/vip/internal/devenv/instancedata"
+	"github.com/Automattic/vip/internal/devenv/proxy"
 	"github.com/Automattic/vip/internal/httpproxy"
 	"github.com/Automattic/vip/internal/nodeflags"
 )
+
+func validateDockerEngine(cmd *cobra.Command) error {
+	r := &dockercli.Runner{}
+	socketPath, _ := dockercli.DockerSocket()
+	info, err := r.DetectEngine(socketPath)
+	if err != nil {
+		return nil
+	}
+	requirement := dockercli.ComposeRequirement(info, dockercli.DockerComposeVersionProbe)
+	if !requirement.OK {
+		return fmt.Errorf("%s\nRemedy: %s", requirement.Reason, requirement.Remedy)
+	}
+	findings := proxy.Preflight(info, podmanPreflightProbes())
+	for _, f := range findings {
+		fmt.Fprintf(cmd.ErrOrStderr(), "podman preflight: %s\nRemedy: %s\n", f.Message, f.Remedy)
+	}
+	return nil
+}
+
+func podmanPreflightProbes() proxy.PreflightProbes {
+	out, err := exec.Command("sysctl", "-n", "net.ipv4.ip_unprivileged_port_start").Output()
+	if err != nil {
+		return proxy.PreflightProbes{}
+	}
+	start, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return proxy.PreflightProbes{}
+	}
+	return proxy.PreflightProbes{UnprivilegedPortStart: start, RunsInsideMachine: runtime.GOOS == "darwin"}
+}
 
 // openDevEnvLog opens a per-env, per-invocation session log, points its footer
 // at stdout, and returns a context carrying the logger plus a finish func that
@@ -300,6 +335,9 @@ func parseWordPressTags(body []byte) []string {
 }
 
 func runDevEnvCreate(cmd *cobra.Command, _ []string) error {
+	if err := validateDockerEngine(cmd); err != nil {
+		return err
+	}
 	// When invoked as `@app.env dev-env create`, seed the wizard from the app's
 	// environment (Node parity: getApplicationInformation + getOptionsFromAppInfo).
 	// Best-effort: a nil result (no alias, or a failed fetch) falls back to the
@@ -575,6 +613,9 @@ func devEnvStartCmd() *cobra.Command {
 	c := &cobra.Command{Use: "start", Short: "Start a local environment", SilenceUsage: true, SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			_ = skipWPVersions // accepted for Node parity; the Go port has no WP-version prompt to skip.
+			if err := validateDockerEngine(cmd); err != nil {
+				return err
+			}
 			slug, err := ResolveSlug(cmd)
 			if err != nil {
 				return err

--- a/docs/dev-environment-podman.md
+++ b/docs/dev-environment-podman.md
@@ -1,0 +1,36 @@
+# Running `vip dev-env` on Podman
+
+`vip dev-env` supports Podman as an alternative to Docker (Docker Desktop,
+Colima, OrbStack). Docker remains the default and unaffected engine; this
+page covers the extra Podman requirements.
+
+## Requirements
+
+- Podman 5 or newer, either as a rootless Linux install or as the Podman
+  machine on macOS.
+- A real standalone `docker-compose` v2 binary on `PATH`. `podman-compose`
+  is not supported — `vip dev-env` refuses to start under Podman until a
+  Compose v2 `docker-compose` is found.
+- `net.ipv4.ip_unprivileged_port_start` set to `80` or lower, so Podman's
+  rootless proxy can publish port 80. `vip-cli` never changes this setting
+  for you; if it is missing, `vip dev-env start` prints the exact remedy
+  command for your platform (Podman machine vs. Linux host) as part of its
+  preflight output.
+
+## What's different from Docker
+
+- The dev-env proxy publishes on `0.0.0.0` instead of `127.0.0.1` under
+  Podman, since Podman's rootless networking needs the explicit bind.
+- The proxy container mounts the discovered Podman socket in place of
+  `/var/run/docker.sock`, with `security_opt: [label=disable]` added on
+  SELinux-enforcing hosts.
+
+None of this requires manual configuration — `vip dev-env` detects Podman
+automatically and applies these adjustments on its own.
+
+## Getting the preflight remedy
+
+Run `vip dev-env start`. If a requirement above is unmet, the command exits
+with the specific check that failed and the exact command to fix it — that
+printed remedy is the authoritative text; this page intentionally does not
+duplicate it.

--- a/internal/devenv/devenv.go
+++ b/internal/devenv/devenv.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -31,7 +32,7 @@ func newRunner(ctx context.Context) (*dockercli.Runner, error) {
 	if _, err := dockercli.DockerSocket(); err != nil {
 		return nil, err
 	}
-	return &dockercli.Runner{Log: devlog.FromContext(ctx)}, nil
+	return &dockercli.Runner{Log: devlog.FromContext(ctx), DockerBin: dockercli.DockerBin(exec.LookPath)}, nil
 }
 
 func goos() string { return runtime.GOOS }

--- a/internal/devenv/devenv.go
+++ b/internal/devenv/devenv.go
@@ -148,6 +148,11 @@ func startStack(ctx context.Context, r *dockercli.Runner, deps lifecycle.Deps, s
 		d.PullAfter = &now
 		_ = instancedata.Write(slug, d) // best-effort: pull succeeded; a stale timestamp only re-pulls next time
 	}
+	socketPath, _ := dockercli.DockerSocket()
+	engineInfo, err := r.DetectEngine(socketPath)
+	if err != nil {
+		engineInfo = dockercli.EngineInfo{Engine: dockercli.EngineDocker, ServerVersion: "unknown", SocketPath: socketPath}
+	}
 	_, err = lifecycle.Start(ctx, deps, lifecycle.StartParams{
 		Project:      slug,
 		View:         view,
@@ -158,6 +163,7 @@ func startStack(ctx context.Context, r *dockercli.Runner, deps lifecycle.Deps, s
 		Pull:         pull,
 		SkipRebuild:  opts.SkipRebuild,
 		GOOS:         goos(),
+		Engine:       engineInfo,
 	})
 	return err
 }

--- a/internal/devenv/dockercli/compose.go
+++ b/internal/devenv/dockercli/compose.go
@@ -2,6 +2,7 @@ package dockercli
 
 import (
 	"os/exec"
+	"strings"
 )
 
 // composeInvocation decides how to invoke Compose: the `docker compose` plugin
@@ -27,4 +28,35 @@ func (r *Runner) composeInv() []string {
 			})
 	})
 	return r.composeCmd
+}
+
+type ComposeRequirementResult struct {
+	OK     bool
+	Reason string
+	Remedy string
+}
+
+const podmanComposeRequirementRemedy = "install docker-compose v2 (e.g. `brew install docker-compose`, or the docker-compose-plugin package) so `docker-compose version` reports a v2.x release; podman-compose is not supported"
+
+func ComposeRequirement(info EngineInfo, dockerComposeVersion func() (string, error)) ComposeRequirementResult {
+	if info.Engine != EnginePodman {
+		return ComposeRequirementResult{OK: true}
+	}
+	version, err := dockerComposeVersion()
+	if err == nil && strings.Contains(version, "v2") {
+		return ComposeRequirementResult{OK: true}
+	}
+	return ComposeRequirementResult{
+		OK:     false,
+		Reason: "podman requires a real docker-compose v2 binary; podman-compose is not supported",
+		Remedy: podmanComposeRequirementRemedy,
+	}
+}
+
+func DockerComposeVersionProbe() (string, error) {
+	out, err := exec.Command("docker-compose", "version", "--short").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/devenv/dockercli/compose_test.go
+++ b/internal/devenv/dockercli/compose_test.go
@@ -33,3 +33,43 @@ func TestComposeInvocationDefaultsToPlugin(t *testing.T) {
 		t.Fatalf("want [docker compose] default, got %v", inv)
 	}
 }
+
+func TestComposeRequirementAlwaysOKForDocker(t *testing.T) {
+	result := ComposeRequirement(EngineInfo{Engine: EngineDocker}, func() (string, error) {
+		t.Fatal("dockerComposeVersion should not be probed for the docker engine")
+		return "", nil
+	})
+	if !result.OK {
+		t.Fatalf("got %+v, want OK for docker regardless of compose probe", result)
+	}
+}
+
+func TestComposeRequirementOKForPodmanWithDockerComposeV2(t *testing.T) {
+	result := ComposeRequirement(EngineInfo{Engine: EnginePodman}, func() (string, error) {
+		return "v2.29.7", nil
+	})
+	if !result.OK {
+		t.Fatalf("got %+v, want OK when docker-compose reports v2", result)
+	}
+}
+
+func TestComposeRequirementRefusesPodmanWithoutDockerComposeV2(t *testing.T) {
+	result := ComposeRequirement(EngineInfo{Engine: EnginePodman}, func() (string, error) {
+		return "", errNotFound
+	})
+	if result.OK {
+		t.Fatal("want refusal when docker-compose v2 is absent")
+	}
+	if result.Remedy == "" {
+		t.Fatal("refusal must carry a remedy the CLI can print")
+	}
+}
+
+func TestComposeRequirementRefusesPodmanWithComposeV1(t *testing.T) {
+	result := ComposeRequirement(EngineInfo{Engine: EnginePodman}, func() (string, error) {
+		return "1.29.2", nil
+	})
+	if result.OK {
+		t.Fatal("want refusal for a v1 docker-compose binary")
+	}
+}

--- a/internal/devenv/dockercli/engine.go
+++ b/internal/devenv/dockercli/engine.go
@@ -1,0 +1,115 @@
+package dockercli
+
+import (
+	"encoding/json"
+	"os/exec"
+)
+
+type Engine string
+
+const (
+	EngineDocker Engine = "docker"
+	EnginePodman Engine = "podman"
+)
+
+type EngineInfo struct {
+	Engine        Engine
+	ServerVersion string
+	ComposePlugin bool
+	SocketPath    string
+	Rootless      bool
+}
+
+type InfoRunner func(dockerBin string, args ...string) ([]byte, error)
+
+func dockerFallbackEngineInfo(socketPath string) EngineInfo {
+	return EngineInfo{Engine: EngineDocker, ServerVersion: "unknown", SocketPath: socketPath}
+}
+
+type dockerInfoShape struct {
+	ServerVersion string `json:"ServerVersion"`
+	ClientInfo    struct {
+		Plugins []struct {
+			Name string `json:"Name"`
+		} `json:"Plugins"`
+	} `json:"ClientInfo"`
+}
+
+type podmanInfoShape struct {
+	Version struct {
+		Version string `json:"Version"`
+	} `json:"version"`
+	Host struct {
+		RemoteSocket struct {
+			Path string `json:"path"`
+		} `json:"remoteSocket"`
+		Security struct {
+			Rootless bool `json:"rootless"`
+		} `json:"security"`
+	} `json:"host"`
+	Store struct {
+		GraphDriverName string `json:"graphDriverName"`
+	} `json:"store"`
+}
+
+func hasComposePlugin(shape dockerInfoShape) bool {
+	for _, p := range shape.ClientInfo.Plugins {
+		if p.Name == "compose" {
+			return true
+		}
+	}
+	return false
+}
+
+func parseDockerInfo(raw []byte, socketPath string) (EngineInfo, bool) {
+	var shape dockerInfoShape
+	if err := json.Unmarshal(raw, &shape); err != nil || shape.ServerVersion == "" {
+		return EngineInfo{}, false
+	}
+	return EngineInfo{
+		Engine:        EngineDocker,
+		ServerVersion: shape.ServerVersion,
+		ComposePlugin: hasComposePlugin(shape),
+		SocketPath:    socketPath,
+	}, true
+}
+
+func parsePodmanInfo(raw []byte, socketPath string) (EngineInfo, bool) {
+	var shape podmanInfoShape
+	if err := json.Unmarshal(raw, &shape); err != nil {
+		return EngineInfo{}, false
+	}
+	if shape.Version.Version == "" || (shape.Host.RemoteSocket.Path == "" && shape.Store.GraphDriverName == "") {
+		return EngineInfo{}, false
+	}
+	resolvedSocket := socketPath
+	if resolvedSocket == "" {
+		resolvedSocket = shape.Host.RemoteSocket.Path
+	}
+	return EngineInfo{
+		Engine:        EnginePodman,
+		ServerVersion: shape.Version.Version,
+		SocketPath:    resolvedSocket,
+		Rootless:      shape.Host.Security.Rootless,
+	}, true
+}
+
+func DetectEngine(dockerBin, socketPath string, run InfoRunner) (EngineInfo, error) {
+	raw, err := run(dockerBin, "info", "--format", "json")
+	if err != nil {
+		return EngineInfo{}, err
+	}
+	if info, ok := parseDockerInfo(raw, socketPath); ok {
+		return info, nil
+	}
+	if info, ok := parsePodmanInfo(raw, socketPath); ok {
+		return info, nil
+	}
+	return dockerFallbackEngineInfo(socketPath), nil
+}
+
+func (r *Runner) DetectEngine(socketPath string) (EngineInfo, error) {
+	return DetectEngine(r.dockerBin(), socketPath, func(dockerBin string, args ...string) ([]byte, error) {
+		return exec.Command(dockerBin, args...).Output()
+	})
+}

--- a/internal/devenv/dockercli/engine_test.go
+++ b/internal/devenv/dockercli/engine_test.go
@@ -1,0 +1,86 @@
+package dockercli
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func readTestdata(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read testdata %q: %v", name, err)
+	}
+	return b
+}
+
+func runnerReturning(raw []byte, err error) InfoRunner {
+	return func(string, ...string) ([]byte, error) { return raw, err }
+}
+
+func TestDetectEngineClassifiesDockerInfo(t *testing.T) {
+	info, err := DetectEngine("docker", "/var/run/docker.sock", runnerReturning(readTestdata(t, "docker-info.json"), nil))
+	if err != nil {
+		t.Fatalf("DetectEngine: %v", err)
+	}
+	if info.Engine != EngineDocker {
+		t.Fatalf("Engine = %q, want docker", info.Engine)
+	}
+	if info.ServerVersion != "27.3.1" {
+		t.Fatalf("ServerVersion = %q, want 27.3.1", info.ServerVersion)
+	}
+	if !info.ComposePlugin {
+		t.Fatal("ComposePlugin = false, want true (docker-info.json lists the compose plugin)")
+	}
+	if info.Rootless {
+		t.Fatal("Rootless = true, want false for docker")
+	}
+}
+
+func TestDetectEngineClassifiesPodmanInfo(t *testing.T) {
+	info, err := DetectEngine("docker", "/run/user/1000/podman/podman.sock", runnerReturning(readTestdata(t, "podman-info.json"), nil))
+	if err != nil {
+		t.Fatalf("DetectEngine: %v", err)
+	}
+	if info.Engine != EnginePodman {
+		t.Fatalf("Engine = %q, want podman", info.Engine)
+	}
+	if info.ServerVersion != "5.5.2" {
+		t.Fatalf("ServerVersion = %q, want 5.5.2", info.ServerVersion)
+	}
+	if info.ComposePlugin {
+		t.Fatal("ComposePlugin = true, want false (podman info carries no plugin list)")
+	}
+	if !info.Rootless {
+		t.Fatal("Rootless = false, want true (podman-info.json declares host.security.rootless)")
+	}
+}
+
+func TestDetectEngineFallsBackOnUnrecognizedShape(t *testing.T) {
+	info, err := DetectEngine("docker", "/var/run/docker.sock", runnerReturning(readTestdata(t, "unrecognized-info.json"), nil))
+	if err != nil {
+		t.Fatalf("DetectEngine returned an error for an unrecognized (but parseable) info shape: %v", err)
+	}
+	if info.Engine != EngineDocker || info.ServerVersion != "unknown" {
+		t.Fatalf("got %+v, want the docker/unknown fallback", info)
+	}
+}
+
+func TestDetectEngineFallsBackOnInvalidJSON(t *testing.T) {
+	info, err := DetectEngine("docker", "/var/run/docker.sock", runnerReturning([]byte("not json"), nil))
+	if err != nil {
+		t.Fatalf("DetectEngine returned an error for invalid JSON: %v", err)
+	}
+	if info.Engine != EngineDocker || info.ServerVersion != "unknown" {
+		t.Fatalf("got %+v, want the docker/unknown fallback", info)
+	}
+}
+
+func TestDetectEngineReturnsErrorOnExecFailure(t *testing.T) {
+	execErr := errors.New("exec: \"docker\": executable file not found in $PATH")
+	_, err := DetectEngine("docker", "/var/run/docker.sock", runnerReturning(nil, execErr))
+	if err == nil {
+		t.Fatal("DetectEngine should surface a genuine exec/I-O failure, not fall back silently")
+	}
+}

--- a/internal/devenv/dockercli/parity_fixture_test.go
+++ b/internal/devenv/dockercli/parity_fixture_test.go
@@ -1,0 +1,98 @@
+package dockercli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+type detectFixtureCase struct {
+	Name        string `json:"name"`
+	InfoFixture string `json:"info_fixture"`
+	Expected    struct {
+		Engine        string `json:"engine"`
+		ServerVersion string `json:"server_version"`
+		ComposePlugin bool   `json:"compose_plugin"`
+		Rootless      bool   `json:"rootless"`
+	} `json:"expected"`
+}
+
+type detectFixture struct {
+	Cases []detectFixtureCase `json:"cases"`
+}
+
+type composeFixtureCase struct {
+	Name                 string  `json:"name"`
+	Engine               string  `json:"engine"`
+	DockerComposeVersion *string `json:"docker_compose_version"`
+	Expected             struct {
+		OK     bool   `json:"ok"`
+		Reason string `json:"reason"`
+	} `json:"expected"`
+}
+
+type composeFixture struct {
+	Cases []composeFixtureCase `json:"cases"`
+}
+
+func loadParityFixture(t *testing.T, name string, into any) {
+	t.Helper()
+	b, err := os.ReadFile("../../../testdata/parity/" + name)
+	if err != nil {
+		t.Fatalf("read parity fixture %q: %v", name, err)
+	}
+	if err := json.Unmarshal(b, into); err != nil {
+		t.Fatalf("parse parity fixture %q: %v", name, err)
+	}
+}
+
+func TestParityFixtureDevenvPodmanDetect(t *testing.T) {
+	var fixture detectFixture
+	loadParityFixture(t, "devenv-podman-detect.json", &fixture)
+	for _, c := range fixture.Cases {
+		t.Run(c.Name, func(t *testing.T) {
+			raw, err := os.ReadFile("../../../" + c.InfoFixture)
+			if err != nil {
+				t.Fatalf("read info fixture: %v", err)
+			}
+			info, err := DetectEngine("docker", "", runnerReturning(raw, nil))
+			if err != nil {
+				t.Fatalf("DetectEngine: %v", err)
+			}
+			if string(info.Engine) != c.Expected.Engine {
+				t.Fatalf("Engine = %q, want %q", info.Engine, c.Expected.Engine)
+			}
+			if info.ServerVersion != c.Expected.ServerVersion {
+				t.Fatalf("ServerVersion = %q, want %q", info.ServerVersion, c.Expected.ServerVersion)
+			}
+			if info.ComposePlugin != c.Expected.ComposePlugin {
+				t.Fatalf("ComposePlugin = %v, want %v", info.ComposePlugin, c.Expected.ComposePlugin)
+			}
+			if info.Rootless != c.Expected.Rootless {
+				t.Fatalf("Rootless = %v, want %v", info.Rootless, c.Expected.Rootless)
+			}
+		})
+	}
+}
+
+func TestParityFixtureDevenvPodmanCompose(t *testing.T) {
+	var fixture composeFixture
+	loadParityFixture(t, "devenv-podman-compose.json", &fixture)
+	for _, c := range fixture.Cases {
+		t.Run(c.Name, func(t *testing.T) {
+			info := EngineInfo{Engine: Engine(c.Engine)}
+			result := ComposeRequirement(info, func() (string, error) {
+				if c.DockerComposeVersion == nil {
+					return "", os.ErrNotExist
+				}
+				return *c.DockerComposeVersion, nil
+			})
+			if result.OK != c.Expected.OK {
+				t.Fatalf("OK = %v, want %v", result.OK, c.Expected.OK)
+			}
+			if c.Expected.Reason != "" && result.Reason != c.Expected.Reason {
+				t.Fatalf("Reason = %q, want %q", result.Reason, c.Expected.Reason)
+			}
+		})
+	}
+}

--- a/internal/devenv/dockercli/socket.go
+++ b/internal/devenv/dockercli/socket.go
@@ -65,6 +65,16 @@ func podmanSocketCandidates(home string) []string {
 	return candidates
 }
 
+func DockerBin(lookPath func(string) (string, error)) string {
+	if _, err := lookPath("docker"); err == nil {
+		return ""
+	}
+	if _, err := lookPath("podman"); err == nil {
+		return "podman"
+	}
+	return ""
+}
+
 func PodmanMachineSocketPath(inspect func() (string, error)) (string, error) {
 	path, err := inspect()
 	if err != nil {

--- a/internal/devenv/dockercli/socket.go
+++ b/internal/devenv/dockercli/socket.go
@@ -41,6 +41,7 @@ func DockerSocket() (string, error) {
 		filepath.Join(home, ".colima", "default", "docker.sock"),
 		filepath.Join(home, ".orbstack", "run", "docker.sock"),
 	)
+	candidates = append(candidates, podmanSocketCandidates(home)...)
 
 	for _, p := range candidates {
 		info, err := os.Stat(p)
@@ -53,4 +54,29 @@ func DockerSocket() (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func podmanSocketCandidates(home string) []string {
+	var candidates []string
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		candidates = append(candidates, filepath.Join(runtimeDir, "podman", "podman.sock"))
+	}
+	candidates = append(candidates, filepath.Join(home, ".local", "share", "containers", "podman", "machine", "podman.sock"))
+	return candidates
+}
+
+func PodmanMachineSocketPath(inspect func() (string, error)) (string, error) {
+	path, err := inspect()
+	if err != nil {
+		return "", err
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", nil
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode()&os.ModeSocket == 0 {
+		return "", nil
+	}
+	return path, nil
 }

--- a/internal/devenv/dockercli/socket_test.go
+++ b/internal/devenv/dockercli/socket_test.go
@@ -1,6 +1,7 @@
 package dockercli
 
 import (
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -48,5 +49,72 @@ func TestDockerSocketFindsUnixSocket(t *testing.T) {
 	}
 	if _, err := os.Stat(sockPath); err != nil {
 		t.Fatalf("socket should exist: %v", err)
+	}
+}
+
+func TestPodmanSocketCandidatesUsesXDGRuntimeDirThenMachinePath(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+	got := podmanSocketCandidates("/home/dev")
+	want := []string{
+		"/run/user/1000/podman/podman.sock",
+		"/home/dev/.local/share/containers/podman/machine/podman.sock",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("candidate %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPodmanSocketCandidatesOmitsXDGWhenUnset(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	got := podmanSocketCandidates("/home/dev")
+	if len(got) != 1 || got[0] != "/home/dev/.local/share/containers/podman/machine/podman.sock" {
+		t.Fatalf("got %v, want only the machine socket path", got)
+	}
+}
+
+
+func TestPodmanMachineSocketPathReturnsInspectedSocket(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "pm")
+	if err != nil {
+		t.Skipf("cannot create short temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	sockPath := filepath.Join(dir, "machine.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Skipf("cannot create unix socket: %v", err)
+	}
+	defer ln.Close()
+
+	got, err := PodmanMachineSocketPath(func() (string, error) { return sockPath + "\n", nil })
+	if err != nil {
+		t.Fatalf("PodmanMachineSocketPath: %v", err)
+	}
+	if got != sockPath {
+		t.Fatalf("got %q, want %q", got, sockPath)
+	}
+}
+
+func TestPodmanMachineSocketPathEmptyWhenNoMachineRunning(t *testing.T) {
+	got, err := PodmanMachineSocketPath(func() (string, error) { return "", nil })
+	if err != nil {
+		t.Fatalf("PodmanMachineSocketPath: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("got %q, want empty when no machine is running", got)
+	}
+}
+
+func TestPodmanMachineSocketPathPropagatesInspectError(t *testing.T) {
+	inspectErr := errors.New("podman: command not found")
+	_, err := PodmanMachineSocketPath(func() (string, error) { return "", inspectErr })
+	if err == nil {
+		t.Fatal("PodmanMachineSocketPath should propagate a genuine inspect failure")
 	}
 }

--- a/internal/devenv/dockercli/socket_test.go
+++ b/internal/devenv/dockercli/socket_test.go
@@ -118,3 +118,34 @@ func TestPodmanMachineSocketPathPropagatesInspectError(t *testing.T) {
 		t.Fatal("PodmanMachineSocketPath should propagate a genuine inspect failure")
 	}
 }
+
+func TestDockerBinKeepsTodaysResolutionUnchangedWhenDockerIsPresent(t *testing.T) {
+	lookPath := func(name string) (string, error) {
+		if name == "docker" {
+			return "/usr/local/bin/docker", nil
+		}
+		return "", errors.New("not found")
+	}
+	if got := DockerBin(lookPath); got != "" {
+		t.Fatalf("got %q, want empty so the default docker resolution is untouched", got)
+	}
+}
+
+func TestDockerBinResolvesPodmanWhenNoDockerBinaryExists(t *testing.T) {
+	lookPath := func(name string) (string, error) {
+		if name == "podman" {
+			return "/opt/homebrew/bin/podman", nil
+		}
+		return "", errors.New("not found")
+	}
+	if got := DockerBin(lookPath); got != "podman" {
+		t.Fatalf("got %q, want %q", got, "podman")
+	}
+}
+
+func TestDockerBinEmptyWhenNeitherBinaryExists(t *testing.T) {
+	lookPath := func(string) (string, error) { return "", errors.New("not found") }
+	if got := DockerBin(lookPath); got != "" {
+		t.Fatalf("got %q, want empty, preserving the could-not-be-located error path", got)
+	}
+}

--- a/internal/devenv/dockercli/testdata/docker-info.json
+++ b/internal/devenv/dockercli/testdata/docker-info.json
@@ -1,0 +1,9 @@
+{
+  "ServerVersion": "27.3.1",
+  "ClientInfo": {
+    "Plugins": [
+      { "Name": "compose", "Version": "v2.29.7" },
+      { "Name": "buildx", "Version": "v0.17.1" }
+    ]
+  }
+}

--- a/internal/devenv/dockercli/testdata/podman-info.json
+++ b/internal/devenv/dockercli/testdata/podman-info.json
@@ -1,0 +1,16 @@
+{
+  "version": {
+    "Version": "5.5.2"
+  },
+  "host": {
+    "remoteSocket": {
+      "path": "/run/user/1000/podman/podman.sock"
+    },
+    "security": {
+      "rootless": true
+    }
+  },
+  "store": {
+    "graphDriverName": "overlay"
+  }
+}

--- a/internal/devenv/dockercli/testdata/unrecognized-info.json
+++ b/internal/devenv/dockercli/testdata/unrecognized-info.json
@@ -1,0 +1,4 @@
+{
+  "SomeOtherEngine": "totally-unknown-shape",
+  "Nested": { "Whatever": true }
+}

--- a/internal/devenv/lifecycle/start.go
+++ b/internal/devenv/lifecycle/start.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Automattic/vip/internal/devenv/compose"
+	"github.com/Automattic/vip/internal/devenv/dockercli"
 	"github.com/Automattic/vip/internal/devenv/hostops"
 	"github.com/Automattic/vip/internal/devenv/proxy"
 )
@@ -23,6 +24,7 @@ type StartParams struct {
 	SkipRebuild  bool // omit --force-recreate (only start non-running services)
 	GOOS         string
 	PollEvery    time.Duration // 0 => default; tests pass tiny
+	Engine       dockercli.EngineInfo
 }
 
 // nonWildcard drops wildcard SANs — valid for TLS, invalid as /etc/hosts entries.
@@ -41,7 +43,7 @@ func nonWildcard(hosts []string) []string {
 // write /etc/hosts under ONE elevation (after setup, so wp_blogs is queryable
 // for subdomain-multisite subsites). Returns the bound proxy ports.
 func Start(ctx context.Context, deps Deps, p StartParams) (proxy.Ports, error) {
-	ports, err := deps.Proxy.Ensure(ctx, proxy.EnsureOptions{Domain: p.View.Domain})
+	ports, err := deps.Proxy.Ensure(ctx, proxy.EnsureOptions{Domain: p.View.Domain, Engine: p.Engine})
 	if err != nil {
 		return proxy.Ports{}, err
 	}

--- a/internal/devenv/proxy/ca_test.go
+++ b/internal/devenv/proxy/ca_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/Automattic/vip/internal/devenv/dockercli"
 )
 
 func TestProxyRunArgsMountsCertsVolume(t *testing.T) {
-	joined := strings.Join(proxyRunArgs(Ports{HTTP: 80, HTTPS: 443}, "vipdev.lndo.site"), " ")
+	joined := strings.Join(proxyRunArgs(Ports{HTTP: 80, HTTPS: 443}, "vipdev.lndo.site", dockercli.EngineInfo{}), " ")
 	if !strings.Contains(joined, ProxyCertsVolume+":/certs") {
 		t.Fatalf("proxy run args missing certs volume mount:\n%s", joined)
 	}

--- a/internal/devenv/proxy/parity_fixture_test.go
+++ b/internal/devenv/proxy/parity_fixture_test.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/Automattic/vip/internal/devenv/dockercli"
+)
+
+type preflightFixtureCase struct {
+	Name   string `json:"name"`
+	Engine string `json:"engine"`
+	Probes struct {
+		UnprivilegedPortStart int  `json:"unprivileged_port_start"`
+		RunsInsideMachine     bool `json:"runs_inside_machine"`
+	} `json:"probes"`
+	ExpectedFindings []struct {
+		Remedy string `json:"remedy"`
+	} `json:"expected_findings"`
+}
+
+type preflightFixture struct {
+	Cases []preflightFixtureCase `json:"cases"`
+}
+
+type proxySpecFixtureCase struct {
+	Name       string `json:"name"`
+	Engine     string `json:"engine"`
+	SocketPath string `json:"socket_path"`
+	Expected   struct {
+		BindAddress             string `json:"bind_address"`
+		SocketMountSource       string `json:"socket_mount_source"`
+		SocketMountTarget       string `json:"socket_mount_target"`
+		SecurityOptDisableLabel bool   `json:"security_opt_disable_label"`
+	} `json:"expected"`
+}
+
+type proxySpecFixture struct {
+	Cases []proxySpecFixtureCase `json:"cases"`
+}
+
+func loadProxyParityFixture(t *testing.T, name string, into any) {
+	t.Helper()
+	b, err := os.ReadFile("../../../testdata/parity/" + name)
+	if err != nil {
+		t.Fatalf("read parity fixture %q: %v", name, err)
+	}
+	if err := json.Unmarshal(b, into); err != nil {
+		t.Fatalf("parse parity fixture %q: %v", name, err)
+	}
+}
+
+func TestParityFixtureDevenvPodmanPreflight(t *testing.T) {
+	var fixture preflightFixture
+	loadProxyParityFixture(t, "devenv-podman-preflight.json", &fixture)
+	for _, c := range fixture.Cases {
+		t.Run(c.Name, func(t *testing.T) {
+			info := dockercli.EngineInfo{Engine: dockercli.Engine(c.Engine)}
+			findings := Preflight(info, PreflightProbes{
+				UnprivilegedPortStart: c.Probes.UnprivilegedPortStart,
+				RunsInsideMachine:     c.Probes.RunsInsideMachine,
+			})
+			if len(findings) != len(c.ExpectedFindings) {
+				t.Fatalf("got %d findings, want %d: %+v", len(findings), len(c.ExpectedFindings), findings)
+			}
+			for i, want := range c.ExpectedFindings {
+				if findings[i].Remedy != want.Remedy {
+					t.Fatalf("finding %d remedy = %q, want %q", i, findings[i].Remedy, want.Remedy)
+				}
+			}
+		})
+	}
+}
+
+func TestParityFixtureDevenvPodmanProxySpec(t *testing.T) {
+	var fixture proxySpecFixture
+	loadProxyParityFixture(t, "devenv-podman-proxy-spec.json", &fixture)
+	for _, c := range fixture.Cases {
+		t.Run(c.Name, func(t *testing.T) {
+			info := dockercli.EngineInfo{Engine: dockercli.Engine(c.Engine), SocketPath: c.SocketPath}
+			if got := ProxyBindAddressFor(info); got != c.Expected.BindAddress {
+				t.Fatalf("ProxyBindAddressFor = %q, want %q", got, c.Expected.BindAddress)
+			}
+			mount := ProxySocketMountFor(info)
+			if mount.Source != c.Expected.SocketMountSource {
+				t.Fatalf("socket mount source = %q, want %q", mount.Source, c.Expected.SocketMountSource)
+			}
+			if mount.Target != c.Expected.SocketMountTarget {
+				t.Fatalf("socket mount target = %q, want %q", mount.Target, c.Expected.SocketMountTarget)
+			}
+			if mount.SecurityOptDisableLabel != c.Expected.SecurityOptDisableLabel {
+				t.Fatalf("SecurityOptDisableLabel = %v, want %v", mount.SecurityOptDisableLabel, c.Expected.SecurityOptDisableLabel)
+			}
+		})
+	}
+}

--- a/internal/devenv/proxy/preflight.go
+++ b/internal/devenv/proxy/preflight.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"fmt"
+
+	"github.com/Automattic/vip/internal/devenv/dockercli"
+)
+
+const unprivilegedPortStartSysctl = "net.ipv4.ip_unprivileged_port_start"
+
+type PreflightProbes struct {
+	UnprivilegedPortStart int
+	RunsInsideMachine     bool
+}
+
+type PreflightFinding struct {
+	Message string
+	Remedy  string
+}
+
+func unprivilegedPortRemedy(runsInsideMachine bool) string {
+	if runsInsideMachine {
+		return fmt.Sprintf("podman machine ssh -- sudo sysctl %s=80", unprivilegedPortStartSysctl)
+	}
+	return fmt.Sprintf("sudo sysctl %s=80 (persist via /etc/sysctl.d/99-podman-rootless-ports.conf)", unprivilegedPortStartSysctl)
+}
+
+func Preflight(info dockercli.EngineInfo, probes PreflightProbes) []PreflightFinding {
+	if info.Engine != dockercli.EnginePodman {
+		return nil
+	}
+	var findings []PreflightFinding
+	if probes.UnprivilegedPortStart > DefaultHTTP {
+		findings = append(findings, PreflightFinding{
+			Message: fmt.Sprintf("podman rootless cannot bind port %d: %s is %d", DefaultHTTP, unprivilegedPortStartSysctl, probes.UnprivilegedPortStart),
+			Remedy:  unprivilegedPortRemedy(probes.RunsInsideMachine),
+		})
+	}
+	return findings
+}

--- a/internal/devenv/proxy/preflight_test.go
+++ b/internal/devenv/proxy/preflight_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/Automattic/vip/internal/devenv/dockercli"
+)
+
+func TestPreflightReturnsNoFindingsForDocker(t *testing.T) {
+	findings := Preflight(dockercli.EngineInfo{Engine: dockercli.EngineDocker}, PreflightProbes{UnprivilegedPortStart: 1024})
+	if len(findings) != 0 {
+		t.Fatalf("got %v, want zero findings for docker regardless of probes", findings)
+	}
+}
+
+func TestPreflightSurfacesSysctlRemedyForPodmanRootless(t *testing.T) {
+	findings := Preflight(dockercli.EngineInfo{Engine: dockercli.EnginePodman}, PreflightProbes{UnprivilegedPortStart: 1024, RunsInsideMachine: false})
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want exactly 1", len(findings))
+	}
+	if findings[0].Remedy == "" {
+		t.Fatal("finding must carry a printable remedy, never mutate the host itself")
+	}
+	if got := findings[0].Remedy; got != "sudo sysctl net.ipv4.ip_unprivileged_port_start=80 (persist via /etc/sysctl.d/99-podman-rootless-ports.conf)" {
+		t.Fatalf("unexpected remedy: %q", got)
+	}
+}
+
+func TestPreflightSurfacesMachineSSHRemedyWhenInsideMachine(t *testing.T) {
+	findings := Preflight(dockercli.EngineInfo{Engine: dockercli.EnginePodman}, PreflightProbes{UnprivilegedPortStart: 1024, RunsInsideMachine: true})
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want exactly 1", len(findings))
+	}
+	if got := findings[0].Remedy; got != "podman machine ssh -- sudo sysctl net.ipv4.ip_unprivileged_port_start=80" {
+		t.Fatalf("unexpected remedy: %q", got)
+	}
+}
+
+func TestPreflightIsCleanWhenSysctlAlreadyAllowsPort80(t *testing.T) {
+	findings := Preflight(dockercli.EngineInfo{Engine: dockercli.EnginePodman}, PreflightProbes{UnprivilegedPortStart: 80})
+	if len(findings) != 0 {
+		t.Fatalf("got %v, want zero findings when the sysctl already permits port 80", findings)
+	}
+}

--- a/internal/devenv/proxy/proxy.go
+++ b/internal/devenv/proxy/proxy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/Automattic/vip/internal/devenv/dockercli"
 )
 
 // EnsureOptions configures an Ensure call. Domain is used in Traefik env vars.
@@ -11,6 +13,7 @@ import (
 // production falls back to ListenProbe.
 type EnsureOptions struct {
 	Domain string
+	Engine dockercli.EngineInfo
 	free   func(int) bool
 }
 
@@ -64,7 +67,7 @@ func Ensure(ctx context.Context, r DockerRunner, opts EnsureOptions) (Ports, err
 			continue
 		}
 		ports := Ports{HTTP: hp, HTTPS: httpsPort}
-		if err := r.Docker(ctx, proxyRunArgs(ports, opts.Domain)...); err != nil {
+		if err := r.Docker(ctx, proxyRunArgs(ports, opts.Domain, opts.Engine)...); err != nil {
 			lastErr = err
 			// Clean up the name-collision / partial container before retrying.
 			_ = r.Docker(ctx, "rm", "-f", ProxyContainerName)

--- a/internal/devenv/proxy/spec.go
+++ b/internal/devenv/proxy/spec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Automattic/vip/internal/devenv/compose"
+	"github.com/Automattic/vip/internal/devenv/dockercli"
 )
 
 // ProxyContainerName is the shared proxy container (parity: dev-environment-lando.ts:330).
@@ -31,19 +32,50 @@ var proxyCommand = []string{
 	"--providers.file.watch=true",
 }
 
+func ProxyBindAddressFor(info dockercli.EngineInfo) string {
+	if info.Engine == dockercli.EnginePodman {
+		return "0.0.0.0"
+	}
+	return ProxyBindAddress
+}
+
+type ProxySocketMount struct {
+	Source                  string
+	Target                  string
+	SecurityOptDisableLabel bool
+}
+
+func ProxySocketMountFor(info dockercli.EngineInfo) ProxySocketMount {
+	if info.Engine == dockercli.EnginePodman {
+		source := info.SocketPath
+		if source == "" {
+			source = "/run/podman/podman.sock"
+		}
+		return ProxySocketMount{Source: source, Target: "/var/run/docker.sock", SecurityOptDisableLabel: true}
+	}
+	return ProxySocketMount{Source: "/var/run/docker.sock", Target: "/var/run/docker.sock"}
+}
+
 // proxyRunArgs builds the `docker run` argv for the shared proxy. The cert
 // volume + boot-script mounts are appended per Task 1 findings (see Task 7);
 // this builder establishes the network, ports, socket mount, env, and command.
-func proxyRunArgs(ports Ports, domain string) []string {
+func proxyRunArgs(ports Ports, domain string, info dockercli.EngineInfo) []string {
+	bindAddress := ProxyBindAddressFor(info)
+	socketMount := ProxySocketMountFor(info)
 	args := []string{
 		"run", "-d",
 		"--name", ProxyContainerName,
 		"--network", compose.ProxyNetwork,
 		"--restart", "unless-stopped",
-		"-p", fmt.Sprintf("%s:%d:80", ProxyBindAddress, ports.HTTP),
-		"-p", fmt.Sprintf("%s:%d:443", ProxyBindAddress, ports.HTTPS),
-		"-p", fmt.Sprintf("%s::8080", ProxyBindAddress),
-		"-v", "/var/run/docker.sock:/var/run/docker.sock",
+		"-p", fmt.Sprintf("%s:%d:80", bindAddress, ports.HTTP),
+		"-p", fmt.Sprintf("%s:%d:443", bindAddress, ports.HTTPS),
+		"-p", fmt.Sprintf("%s::8080", bindAddress),
+		"-v", fmt.Sprintf("%s:%s", socketMount.Source, socketMount.Target),
+	}
+	if socketMount.SecurityOptDisableLabel {
+		args = append(args, "--security-opt", "label=disable")
+	}
+	args = append(args,
 		"-v", ProxyConfigVolume + ":/proxy_config",
 		"-v", ProxyCertsVolume + ":/certs",
 		// The four LANDO_* vars below are retained for Lando image parity but are
@@ -54,7 +86,7 @@ func proxyRunArgs(ports Ports, domain string) []string {
 		"-e", "LANDO_PROXY_CONFIG_FILE=/proxy_config/proxy.yaml",
 		"-e", "LANDO_PROXY_PASSTHRU=true",
 		ProxyImage,
-	}
+	)
 	args = append(args, proxyCommand...)
 	return args
 }

--- a/internal/devenv/proxy/spec_test.go
+++ b/internal/devenv/proxy/spec_test.go
@@ -3,10 +3,12 @@ package proxy
 import (
 	"strings"
 	"testing"
+
+	"github.com/Automattic/vip/internal/devenv/dockercli"
 )
 
 func TestProxyRunArgs(t *testing.T) {
-	args := proxyRunArgs(Ports{HTTP: 8080, HTTPS: 4433}, "vipdev.lndo.site")
+	args := proxyRunArgs(Ports{HTTP: 8080, HTTPS: 4433}, "vipdev.lndo.site", dockercli.EngineInfo{})
 	joined := strings.Join(args, " ")
 
 	for _, want := range []string{
@@ -40,5 +42,63 @@ func TestProxyRunArgs(t *testing.T) {
 	// wildcard SAN env for the domain
 	if !strings.Contains(joined, "LANDO_EXTRA_NAMES=DNS.100 = *.vipdev.lndo.site") {
 		t.Fatalf("missing wildcard extra-names env: %s", joined)
+	}
+}
+
+func TestProxyBindAddressForDockerIsLoopback(t *testing.T) {
+	if got := ProxyBindAddressFor(dockercli.EngineInfo{Engine: dockercli.EngineDocker}); got != "127.0.0.1" {
+		t.Fatalf("got %q, want 127.0.0.1 for docker", got)
+	}
+}
+
+func TestProxyBindAddressForUnknownEngineIsLoopback(t *testing.T) {
+	if got := ProxyBindAddressFor(dockercli.EngineInfo{}); got != "127.0.0.1" {
+		t.Fatalf("got %q, want 127.0.0.1 for an unspecified/unknown engine", got)
+	}
+}
+
+func TestProxyBindAddressForPodmanIsWildcard(t *testing.T) {
+	if got := ProxyBindAddressFor(dockercli.EngineInfo{Engine: dockercli.EnginePodman}); got != "0.0.0.0" {
+		t.Fatalf("got %q, want 0.0.0.0 for podman", got)
+	}
+}
+
+func TestProxySocketMountForDockerIsUnchanged(t *testing.T) {
+	mount := ProxySocketMountFor(dockercli.EngineInfo{Engine: dockercli.EngineDocker})
+	if mount.Source != "/var/run/docker.sock" || mount.Target != "/var/run/docker.sock" {
+		t.Fatalf("got %+v, want the existing docker.sock mount unchanged", mount)
+	}
+	if mount.SecurityOptDisableLabel {
+		t.Fatal("docker must never get the SELinux label=disable security-opt")
+	}
+}
+
+func TestProxySocketMountForPodmanUsesRealSocketAndDisablesLabel(t *testing.T) {
+	mount := ProxySocketMountFor(dockercli.EngineInfo{Engine: dockercli.EnginePodman, SocketPath: "/run/user/1000/podman/podman.sock"})
+	if mount.Source != "/run/user/1000/podman/podman.sock" {
+		t.Fatalf("got source %q, want the real podman socket path", mount.Source)
+	}
+	if mount.Target != "/var/run/docker.sock" {
+		t.Fatalf("got target %q, want the container-side path unchanged", mount.Target)
+	}
+	if !mount.SecurityOptDisableLabel {
+		t.Fatal("podman socket mount must set SecurityOptDisableLabel")
+	}
+}
+
+func TestProxyRunArgsPublishesWildcardAndRealSocketUnderPodman(t *testing.T) {
+	info := dockercli.EngineInfo{Engine: dockercli.EnginePodman, SocketPath: "/run/user/1000/podman/podman.sock"}
+	joined := strings.Join(proxyRunArgs(Ports{HTTP: 80, HTTPS: 443}, "vipdev.lndo.site", info), " ")
+	if !strings.Contains(joined, "-p 0.0.0.0:80:80") {
+		t.Fatalf("missing wildcard http port binding: %s", joined)
+	}
+	if !strings.Contains(joined, "-p 0.0.0.0:443:443") {
+		t.Fatalf("missing wildcard https port binding: %s", joined)
+	}
+	if !strings.Contains(joined, "/run/user/1000/podman/podman.sock:/var/run/docker.sock") {
+		t.Fatalf("missing real podman socket mount: %s", joined)
+	}
+	if !strings.Contains(joined, "--security-opt label=disable") {
+		t.Fatalf("missing SELinux label=disable security-opt: %s", joined)
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^5.0.0",
         "jwt-decode": "4.0.0",
-        "lando": "github:automattic/lando-cli#78d382fcf40357c4a4cebe4a3cfaef032eab743a",
+        "lando": "github:automattic/lando-cli#fcd3119869c7bfa8175e287e37bde66690add9e0",
         "node-stream-zip": "1.16.0",
         "open": "^11.0.0",
         "proxy-from-env": "^2.0.0",
@@ -372,6 +372,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2375,7 +2376,6 @@
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -2390,8 +2390,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
       "version": "1.1.18",
@@ -2399,7 +2398,6 @@
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2411,7 +2409,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2425,7 +2422,6 @@
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -2439,7 +2435,6 @@
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -2453,7 +2448,6 @@
       "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.14.0",
         "debug": "^4.3.2",
@@ -2477,8 +2471,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.18",
@@ -2486,7 +2479,6 @@
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2498,7 +2490,6 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2522,7 +2513,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2536,7 +2526,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2550,7 +2539,6 @@
       "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2564,7 +2552,6 @@
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -2575,7 +2562,6 @@
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -2673,7 +2659,6 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -2684,7 +2669,6 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -2699,7 +2683,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -2714,7 +2697,6 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -4238,8 +4220,7 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -4367,6 +4348,7 @@
       "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.0",
@@ -4406,6 +4388,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -4948,6 +4931,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4981,7 +4965,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5857,6 +5840,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6511,6 +6495,7 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -6553,8 +6538,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -7136,6 +7120,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7286,6 +7271,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7770,7 +7756,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -7786,8 +7771,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.18",
@@ -7795,7 +7779,6 @@
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7807,7 +7790,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -7825,7 +7807,6 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -7838,8 +7819,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "8.4.0",
@@ -7847,7 +7827,6 @@
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -7865,7 +7844,6 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -7879,7 +7857,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -7893,7 +7870,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7907,7 +7883,6 @@
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -7926,7 +7901,6 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -8051,8 +8025,7 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-diff": {
       "version": "1.3.0",
@@ -8090,8 +8063,7 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -8133,7 +8105,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -8167,7 +8138,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -8185,7 +8155,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -8199,8 +8168,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -8654,6 +8622,7 @@
       "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
       }
@@ -8680,6 +8649,7 @@
       "integrity": "sha512-NMbPNeTwXpUOxmczdMtzEnynLNbbR267E9hRcJ81SSbQeIvZup3cMjbD1ZT3jpS2xkpxooisitvO7LZNOyz17Q==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -8888,7 +8858,6 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -8899,7 +8868,6 @@
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -9725,6 +9693,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -11285,8 +11254,7 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -11300,16 +11268,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -11376,7 +11342,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -11404,24 +11369,24 @@
     "node_modules/lando": {
       "name": "@lando/cli",
       "version": "3.6.5",
-      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#78d382fcf40357c4a4cebe4a3cfaef032eab743a",
-      "integrity": "sha512-2FOCUCo9kKatRQsvYDUKtR9j8Ev2t+zSAOC2o64arGd8qdIqDtCcMOJaSTmWrWVUgAJNjs3ezXrUjPSd2Keu2w==",
+      "resolved": "git+ssh://git@github.com/automattic/lando-cli.git#fcd3119869c7bfa8175e287e37bde66690add9e0",
+      "integrity": "sha512-GjoLKzbs69kkaVHrotLVQJDYXgdx0qfQZu38JBfNSgvs93aRRp5SQ9SQtWhBASpx6hLdUrFRfZd4aRu5s+Gm2g==",
       "inBundle": true,
       "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^1.15.2",
+        "axios": "^1.18.1",
         "bluebird": "^3.4.1",
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.5",
         "copy-dir": "^1.3.0",
-        "dockerode": "^5.0.0",
+        "dockerode": "^5.0.1",
         "glob": "^13.0.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "jsonfile": "^6.2.1",
         "lodash": "^4.18.1",
         "node-cache": "^5.1.2",
         "object-hash": "^3.0.0",
-        "semver": "^7.7.3",
+        "semver": "^7.8.5",
         "shelljs": "^0.10.0",
         "string-argv": "0.1.1",
         "transliteration": "^2.6.1",
@@ -11670,7 +11635,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -11692,7 +11656,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -11729,8 +11692,7 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -12301,7 +12263,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -12354,7 +12315,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -12407,7 +12367,6 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -12650,7 +12609,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -12662,6 +12620,7 @@
       "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12796,7 +12755,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -13140,7 +13098,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -13209,6 +13166,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "inBundle": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14216,6 +14174,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14353,7 +14312,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -14471,6 +14429,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14600,6 +14559,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -14751,7 +14711,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -15066,7 +15025,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15251,6 +15209,7 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15408,6 +15367,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^5.0.0",
     "jwt-decode": "4.0.0",
-    "lando": "github:automattic/lando-cli#78d382fcf40357c4a4cebe4a3cfaef032eab743a",
+    "lando": "github:automattic/lando-cli#fcd3119869c7bfa8175e287e37bde66690add9e0",
     "node-stream-zip": "1.16.0",
     "open": "^11.0.0",
     "proxy-from-env": "^2.0.0",

--- a/src/bin/vip-dev-env-create.js
+++ b/src/bin/vip-dev-env-create.js
@@ -104,7 +104,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	}
 
 	const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
-	validateDependencies( lando );
+	await validateDependencies( lando );
 
 	debug( 'Args: ', arg, 'Options: ', opt );
 

--- a/src/bin/vip-dev-env-destroy.js
+++ b/src/bin/vip-dev-env-destroy.js
@@ -52,7 +52,7 @@ command( {
 		const slug = await getEnvironmentName( opt );
 
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_destroy_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-exec.js
+++ b/src/bin/vip-dev-env-exec.js
@@ -80,7 +80,7 @@ command( {
 	.argv( process.argv, async ( unmatchedArgs, opt ) => {
 		const slug = await getEnvironmentName( opt, opt.quiet );
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ), quiet: opt.quiet } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_exec_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-info.js
+++ b/src/bin/vip-dev-env-info.js
@@ -58,7 +58,7 @@ command( {
 		}
 
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 		await trackEvent( 'dev_env_info_command_execute', trackingInfo );
 
 		debug( 'Args: ', arg, 'Options: ', opt );

--- a/src/bin/vip-dev-env-list.js
+++ b/src/bin/vip-dev-env-list.js
@@ -27,7 +27,7 @@ command( {
 	.argv( process.argv, async () => {
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile() } );
 		lando.events.constructor.prototype.setMaxListeners( 1024 );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		const trackingInfo = { all: true };
 		await trackEvent( 'dev_env_list_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-logs.js
+++ b/src/bin/vip-dev-env-logs.js
@@ -53,7 +53,7 @@ command( {
 		const slug = await getEnvironmentName( opt );
 
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_logs_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-purge.js
+++ b/src/bin/vip-dev-env-purge.js
@@ -78,7 +78,7 @@ command( {
 
 		const trackingInfo = { all: true };
 		await trackEvent( 'dev_env_purge_command_execute', trackingInfo );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 		const removeFiles = ! ( opt.soft || false );
 
 		try {

--- a/src/bin/vip-dev-env-shell.js
+++ b/src/bin/vip-dev-env-shell.js
@@ -92,7 +92,7 @@ command( {
 		const slug = await getEnvironmentName( opt );
 
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		const trackingInfo = getEnvTrackingInfo( slug );
 		await trackEvent( 'dev_env_shell_command_execute', trackingInfo );

--- a/src/bin/vip-dev-env-start.js
+++ b/src/bin/vip-dev-env-start.js
@@ -78,7 +78,7 @@ command( {
 	.argv( process.argv, async ( arg, opt ) => {
 		const slug = await getEnvironmentName( opt );
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		const startProcessing = new Date();
 

--- a/src/bin/vip-dev-env-stop.js
+++ b/src/bin/vip-dev-env-stop.js
@@ -65,7 +65,7 @@ command( {
 		}
 
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( logSlug ) } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		await trackEvent( 'dev_env_stop_command_execute', trackingInfo );
 

--- a/src/bin/vip-dev-env-update.js
+++ b/src/bin/vip-dev-env-update.js
@@ -70,7 +70,7 @@ cmd.argv( process.argv, async ( arg, opt ) => {
 	const slug = await getEnvironmentName( opt );
 
 	const lando = await bootstrapLando( { logFile: getDevEnvLogFile( slug ) } );
-	validateDependencies( lando );
+	await validateDependencies( lando );
 
 	const trackingInfo = getEnvTrackingInfo( slug );
 	await trackEvent( 'dev_env_update_command_execute', trackingInfo );

--- a/src/commands/dev-env-import-sql.ts
+++ b/src/commands/dev-env-import-sql.ts
@@ -41,7 +41,7 @@ export class DevEnvImportSQLCommand {
 
 	public async run(): Promise< void > {
 		const lando = await bootstrapLando( { logFile: getDevEnvLogFile( this.slug ) } );
-		validateDependencies( lando );
+		await validateDependencies( lando );
 
 		validateImportFileExtension( this.fileName );
 

--- a/src/lib/dev-environment/dev-environment-cli.ts
+++ b/src/lib/dev-environment/dev-environment-cli.ts
@@ -135,10 +135,10 @@ export async function handleCLIException(
 	}
 }
 
-export const validateDependencies = ( lando: Lando ) => {
+export const validateDependencies = async ( lando: Lando ) => {
 	const now = new Date();
 
-	validateDockerInstalled( lando );
+	await validateDockerInstalled( lando );
 	const duration = new Date().getTime() - now.getTime();
 	debug( 'Validation checks completed in %d ms', duration );
 };

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -17,6 +17,7 @@ import {
 	writeEnvironmentData,
 } from './dev-environment-core';
 import { getDockerSocket, getEngineConfig } from './docker-utils';
+import { detectEngine } from './engine';
 import { loadLandoModule, resolveLandoModule } from './lando-loader';
 import { getRuntimeModeLabel } from '../cli/runtime-mode';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../constants/dev-environment';
@@ -55,6 +56,7 @@ interface LandoConfigWithLogging extends Omit< LandoConfig, 'composeBin' | 'dock
 	logDir?: string;
 	dockerBin?: string;
 	composeBin?: string;
+	socketPath?: string;
 }
 
 const execFileAsync = promisify( execFile );
@@ -175,59 +177,12 @@ const formatBytes = ( bytes: number ): string => {
 	return `${ gb.toFixed( 1 ) } GB`;
 };
 
-type DockerPluginInfo = {
-	Name?: string;
-	Version?: string;
-};
-
-type DockerClientInfo = {
-	Plugins?: DockerPluginInfo[];
-};
-
-type DockerInfo = {
-	ServerVersion?: string;
-	ClientInfo?: DockerClientInfo;
-};
-
-const isRecord = ( value: unknown ): value is Record< string, unknown > =>
-	typeof value === 'object' && value !== null;
-
-const isDockerPluginInfo = ( value: unknown ): value is DockerPluginInfo => isRecord( value );
-
 const getDockerVersions = async ( config: LandoConfigWithLogging ) => {
 	const dockerBin = config.dockerBin ?? '';
 	const composeBin = config.composeBin ?? '';
-	let engine = 'unknown';
 	let compose = 'unknown';
-	let composePlugin = 'unknown';
 
-	try {
-		if ( dockerBin ) {
-			const { stdout } = await execFileAsync( dockerBin, [ 'info', '--format', 'json' ] );
-			const dockerData = JSON.parse( stdout ) as DockerInfo;
-			if ( isRecord( dockerData ) ) {
-				const serverVersion = dockerData.ServerVersion;
-				if ( typeof serverVersion === 'string' ) {
-					engine = serverVersion;
-				}
-
-				const clientInfo = dockerData.ClientInfo;
-				if ( isRecord( clientInfo ) ) {
-					const plugins = clientInfo.Plugins;
-					if ( Array.isArray( plugins ) ) {
-						const composePluginEntry = plugins.find(
-							plugin => isDockerPluginInfo( plugin ) && plugin.Name === 'compose'
-						);
-						if ( composePluginEntry && typeof composePluginEntry.Version === 'string' ) {
-							composePlugin = composePluginEntry.Version;
-						}
-					}
-				}
-			}
-		}
-	} catch ( error ) {
-		debug( 'Failed to read docker version info: %O', error );
-	}
+	const engineInfo = await detectEngine( dockerBin, config.socketPath ?? '' );
 
 	try {
 		if ( composeBin ) {
@@ -238,7 +193,12 @@ const getDockerVersions = async ( config: LandoConfigWithLogging ) => {
 		debug( 'Failed to read docker-compose version info: %O', error );
 	}
 
-	return { engine, compose, composePlugin };
+	return {
+		engine: engineInfo.serverVersion,
+		compose,
+		composePlugin: engineInfo.composePlugin ?? 'unknown',
+		engineName: engineInfo.engine,
+	};
 };
 
 const formatBannerLine = ( label: string, value: string ): string =>
@@ -263,6 +223,10 @@ const writeLogBanner = async ( config: LandoConfigWithLogging ): Promise< void >
 
 	const dockerVersions = await getDockerVersions( config );
 	const command = process.argv.slice( 1 ).join( ' ' );
+	const engineBannerLine =
+		dockerVersions.engineName === 'podman'
+			? formatBannerLine( 'ENGINE', `podman ${ dockerVersions.engine }` )
+			: formatBannerLine( 'DOCKER ENGINE', dockerVersions.engine );
 	const bannerLines = [
 		'=== VIP Dev Env Log ===',
 		formatBannerLine( 'COMMAND', command ),
@@ -270,7 +234,7 @@ const writeLogBanner = async ( config: LandoConfigWithLogging ): Promise< void >
 		formatBannerLine( 'NODE', env.node.version ),
 		formatBannerLine( 'VIP-CLI', env.app.version ),
 		formatBannerLine( 'RUNTIME', getRuntimeModeLabel() ),
-		formatBannerLine( 'DOCKER ENGINE', dockerVersions.engine ),
+		engineBannerLine,
 		formatBannerLine( 'DOCKER COMPOSE', dockerVersions.compose ),
 		formatBannerLine( 'COMPOSE PLUGIN', dockerVersions.composePlugin ),
 		formatBannerLine( 'DOCKER BIN', config.dockerBin ?? 'unknown' ),
@@ -455,8 +419,11 @@ export async function bootstrapLando( options: LandoBootstrapOptions = {} ): Pro
 			debug( 'Engine config: %j', config.engineConfig );
 		}
 
-		registerLogPathOutput( config as LandoConfigWithLogging, Boolean( options.quiet ) );
-		await writeLogBanner( config as LandoConfigWithLogging );
+		const configWithLogging = config as LandoConfigWithLogging;
+		configWithLogging.socketPath = socket ?? '';
+
+		registerLogPathOutput( configWithLogging, Boolean( options.quiet ) );
+		await writeLogBanner( configWithLogging );
 
 		const LandoClass = getLandoConstructor();
 		const lando = new LandoClass( config );

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -17,7 +17,13 @@ import {
 	writeEnvironmentData,
 } from './dev-environment-core';
 import { getDockerSocket, getEngineConfig } from './docker-utils';
-import { composeRequirement, detectEngine, podmanPreflight } from './engine';
+import {
+	composeRequirement,
+	detectEngine,
+	podmanPreflight,
+	proxyPublishAddress,
+	proxySocketMount,
+} from './engine';
 import { loadLandoModule, resolveLandoModule } from './lando-loader';
 import { getRuntimeModeLabel } from '../cli/runtime-mode';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../constants/dev-environment';
@@ -25,7 +31,7 @@ import env from '../env';
 import UserError from '../user-error';
 import { xdgData } from '../xdg-data';
 
-import type { PreflightProbes } from './engine';
+import type { PreflightProbes, ProxyPublishAddress, ProxySocketMount } from './engine';
 import type { NetworkInspectInfo } from 'dockerode';
 import type App from 'lando/lib/app';
 import type { ScanResult } from 'lando/lib/app';
@@ -58,6 +64,8 @@ interface LandoConfigWithLogging extends Omit< LandoConfig, 'composeBin' | 'dock
 	dockerBin?: string;
 	composeBin?: string;
 	socketPath?: string;
+	proxyPublishAddress?: ProxyPublishAddress;
+	proxySocket?: ProxySocketMount;
 }
 
 const execFileAsync = promisify( execFile );
@@ -1072,6 +1080,9 @@ export async function validateDockerInstalled( lando: Lando ): Promise< void > {
 		configWithLogging.dockerBin ?? '',
 		configWithLogging.socketPath ?? ''
 	);
+
+	configWithLogging.proxyPublishAddress = proxyPublishAddress( engineInfo );
+	configWithLogging.proxySocket = proxySocketMount( engineInfo );
 
 	const composeCheck = composeRequirement( { ...engineInfo, composeBinaryVersion: compose } );
 	if ( ! composeCheck.ok ) {

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -17,7 +17,7 @@ import {
 	writeEnvironmentData,
 } from './dev-environment-core';
 import { getDockerSocket, getEngineConfig } from './docker-utils';
-import { detectEngine } from './engine';
+import { composeRequirement, detectEngine, podmanPreflight } from './engine';
 import { loadLandoModule, resolveLandoModule } from './lando-loader';
 import { getRuntimeModeLabel } from '../cli/runtime-mode';
 import { DEV_ENVIRONMENT_NOT_FOUND } from '../constants/dev-environment';
@@ -25,6 +25,7 @@ import env from '../env';
 import UserError from '../user-error';
 import { xdgData } from '../xdg-data';
 
+import type { PreflightProbes } from './engine';
 import type { NetworkInspectInfo } from 'dockerode';
 import type App from 'lando/lib/app';
 import type { ScanResult } from 'lando/lib/app';
@@ -60,6 +61,8 @@ interface LandoConfigWithLogging extends Omit< LandoConfig, 'composeBin' | 'dock
 }
 
 const execFileAsync = promisify( execFile );
+
+type ExecFn = typeof execFileAsync;
 
 type LandoConstructor = new ( config: LandoConfig ) => Lando;
 type LandoBuildTask = (
@@ -983,16 +986,62 @@ async function ensureNoOrphantProxyContainer( lando: Lando ): Promise< void > {
 	}
 }
 
-export function validateDockerInstalled( lando: Lando ): void {
+const PODMAN_DOCS_LINK =
+	'https://github.com/Automattic/vip-cli/blob/trunk/docs/dev-environment-podman.md';
+
+const formatSteeredMessage = ( why: string, remedy: string ): string =>
+	`${ why }\n\nRemedy: ${ remedy }\n\nDocs: ${ PODMAN_DOCS_LINK }`;
+
+const UNPRIVILEGED_PORT_SYSCTL_KEY = 'net.ipv4.ip_unprivileged_port_start';
+
+async function readUnprivilegedPortStart(
+	isPodmanMacMachine: boolean,
+	exec: ExecFn
+): Promise< number | null > {
+	try {
+		const { stdout } = isPodmanMacMachine
+			? await exec( 'podman', [
+					'machine',
+					'ssh',
+					'--',
+					'sysctl',
+					'-n',
+					UNPRIVILEGED_PORT_SYSCTL_KEY,
+			  ] )
+			: await exec( 'sysctl', [ '-n', UNPRIVILEGED_PORT_SYSCTL_KEY ] );
+
+		const value = Number.parseInt( stdout.trim(), 10 );
+		return Number.isNaN( value ) ? null : value;
+	} catch ( error ) {
+		debug( 'Failed to read %s: %O', UNPRIVILEGED_PORT_SYSCTL_KEY, error );
+		return null;
+	}
+}
+
+async function gatherPodmanPreflightProbes(
+	exec: ExecFn = execFileAsync
+): Promise< PreflightProbes > {
+	const isPodmanMacMachine = process.platform === 'darwin';
+	const unprivilegedPortStart = await readUnprivilegedPortStart( isPodmanMacMachine, exec );
+
+	return {
+		unprivilegedPortStartAllowsPort80:
+			unprivilegedPortStart !== null && unprivilegedPortStart <= 80,
+		isPodmanMacMachine,
+	};
+}
+
+export async function validateDockerInstalled( lando: Lando ): Promise< void > {
 	const { engine, composePlugin, compose } = lando.config.versions as {
 		engine: string;
 		composePlugin: string;
 		compose: string;
 	};
+	const configWithLogging = lando.config as LandoConfigWithLogging;
 
 	lando.log.verbose( 'docker-engine version: %s', engine );
 	if ( ! engine ) {
-		if ( ! lando.config.dockerBin ) {
+		if ( ! configWithLogging.dockerBin ) {
 			throw new UserError(
 				'docker binary could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/'
 			);
@@ -1018,6 +1067,21 @@ export function validateDockerInstalled( lando: Lando ): void {
 			);
 		}
 	}
+
+	const engineInfo = await detectEngine(
+		configWithLogging.dockerBin ?? '',
+		configWithLogging.socketPath ?? ''
+	);
+
+	const composeCheck = composeRequirement( { ...engineInfo, composeBinaryVersion: compose } );
+	if ( ! composeCheck.ok ) {
+		throw new UserError( formatSteeredMessage( composeCheck.reason, composeCheck.remedy ) );
+	}
+
+	const probes = await gatherPodmanPreflightProbes();
+	podmanPreflight( engineInfo, probes ).forEach( finding => {
+		lando.log.warn( formatSteeredMessage( finding.message, finding.remedy ) );
+	} );
 }
 
 export async function isContainerRunning(

--- a/src/lib/dev-environment/dev-environment-lando.ts
+++ b/src/lib/dev-environment/dev-environment-lando.ts
@@ -16,7 +16,7 @@ import {
 	updateEnvironment,
 	writeEnvironmentData,
 } from './dev-environment-core';
-import { getDockerSocket, getEngineConfig } from './docker-utils';
+import { getDockerBin, getDockerSocket, getEngineConfig } from './docker-utils';
 import {
 	composeRequirement,
 	detectEngine,
@@ -312,6 +312,11 @@ async function getLandoConfig( options: LandoBootstrapOptions = {} ): Promise< L
 			LANDO_HOST_GROUP_ID: process.platform === 'win32' ? '1000' : `${ userInfo().gid }`,
 		},
 	};
+
+	const dockerBin = await getDockerBin();
+	if ( dockerBin ) {
+		( config as Record< string, unknown > ).dockerBin = dockerBin;
+	}
 
 	return getLandoBuildConfig()( config );
 }

--- a/src/lib/dev-environment/docker-utils.ts
+++ b/src/lib/dev-environment/docker-utils.ts
@@ -1,8 +1,14 @@
 /* eslint-disable no-await-in-loop */
+import { execFile } from 'node:child_process';
 import { constants } from 'node:fs';
 import { access, readFile, stat } from 'node:fs/promises';
 import { homedir, platform } from 'node:os';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify( execFile );
+
+type ExecFn = typeof execFileAsync;
 
 /**
  * Reads a Certificate Authority file and returns it as an array of certificates
@@ -42,7 +48,48 @@ async function canReadWrite( what: string ): Promise< boolean > {
 	}
 }
 
-export async function getDockerSocket(): Promise< string | null > {
+async function checkSocketCandidate( socketPath: string ): Promise< boolean > {
+	try {
+		const stats = await stat( socketPath );
+		return stats.isSocket() && ( await canReadWrite( socketPath ) );
+	} catch {
+		return false;
+	}
+}
+
+async function findPodmanMachineSocket( exec: ExecFn ): Promise< string | null > {
+	try {
+		await exec( 'podman', [ '--version' ] );
+	} catch {
+		return null;
+	}
+
+	try {
+		const { stdout } = await exec( 'podman', [ 'machine', 'inspect' ] );
+		const parsed: unknown = JSON.parse( String( stdout ) );
+		if ( ! Array.isArray( parsed ) ) {
+			return null;
+		}
+
+		for ( const machine of parsed ) {
+			const socketPath = (
+				machine as {
+					ConnectionInfo?: { PodmanSocket?: { Path?: string } };
+				}
+			 )?.ConnectionInfo?.PodmanSocket?.Path;
+
+			if ( typeof socketPath === 'string' && ( await checkSocketCandidate( socketPath ) ) ) {
+				return socketPath;
+			}
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
+}
+
+export async function getDockerSocket( exec: ExecFn = execFileAsync ): Promise< string | null > {
 	if ( platform() !== 'win32' ) {
 		const possibleSocket = process.env.DOCKER_HOST ?? '';
 		// If `DOCKER_HOST` is set and not empty, and if it does not point to a unix socket, return - not much that we can do here.
@@ -65,16 +112,24 @@ export async function getDockerSocket(): Promise< string | null > {
 		paths.push( join( homedir(), '.colima', 'default', 'docker.sock' ) );
 		paths.push( join( homedir(), '.orbstack', 'run', 'docker.sock' ) );
 
+		paths.push(
+			join( homedir(), '.local', 'share', 'containers', 'podman', 'machine', 'podman.sock' )
+		);
+		if ( process.env.XDG_RUNTIME_DIR ) {
+			paths.push( join( process.env.XDG_RUNTIME_DIR, 'podman', 'podman.sock' ) );
+		}
+
 		for ( const socketPath of paths ) {
-			try {
-				const stats = await stat( socketPath );
-				if ( stats.isSocket() && ( await canReadWrite( socketPath ) ) ) {
-					process.env.DOCKER_HOST = `unix://${ socketPath }`;
-					return socketPath;
-				}
-			} catch {
-				// Do nothing
+			if ( await checkSocketCandidate( socketPath ) ) {
+				process.env.DOCKER_HOST = `unix://${ socketPath }`;
+				return socketPath;
 			}
+		}
+
+		const podmanMachineSocket = await findPodmanMachineSocket( exec );
+		if ( podmanMachineSocket ) {
+			process.env.DOCKER_HOST = `unix://${ podmanMachineSocket }`;
+			return podmanMachineSocket;
 		}
 	}
 

--- a/src/lib/dev-environment/docker-utils.ts
+++ b/src/lib/dev-environment/docker-utils.ts
@@ -136,6 +136,27 @@ export async function getDockerSocket( exec: ExecFn = execFileAsync ): Promise< 
 	return null;
 }
 
+async function isBinaryUsable( command: string, exec: ExecFn ): Promise< boolean > {
+	try {
+		await exec( command, [ '--version' ] );
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function getDockerBin( exec: ExecFn = execFileAsync ): Promise< string | null > {
+	if ( await isBinaryUsable( 'docker', exec ) ) {
+		return null;
+	}
+
+	if ( await isBinaryUsable( 'podman', exec ) ) {
+		return 'podman';
+	}
+
+	return null;
+}
+
 export async function getEngineConfig( dockerHost: string ): Promise< Record< string, unknown > > {
 	const opts: Record< string, unknown > = {};
 	if ( dockerHost.startsWith( 'tcp://' ) ) {

--- a/src/lib/dev-environment/engine.ts
+++ b/src/lib/dev-environment/engine.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 import { satisfies } from 'semver';
 
@@ -171,6 +172,45 @@ const macMachineUnprivilegedPortRemedy = () =>
 
 const linuxHostUnprivilegedPortRemedy = () =>
 	`Run on this host: sudo sysctl -w ${ UNPRIVILEGED_PORT_SYSCTL_KEY }=80 (persist it in /etc/sysctl.d/)`;
+
+export type ProxyPublishAddress = '127.0.0.1' | '0.0.0.0';
+
+export interface ProxySocketMount {
+	source: string;
+	target: '/var/run/docker.sock';
+	selinuxLabelDisable: boolean;
+}
+
+const DOCKER_DEFAULT_SOCKET_PATH = '/var/run/docker.sock';
+const PROXY_SOCKET_MOUNT_TARGET = '/var/run/docker.sock';
+const SELINUX_ENFORCE_STATUS_PATH = '/sys/fs/selinux/enforce';
+const SELINUX_ENFORCING_STATUS_VALUE = '1';
+
+export function proxyPublishAddress( info: EngineInfo ): ProxyPublishAddress {
+	return info.engine === 'podman' ? '0.0.0.0' : '127.0.0.1';
+}
+
+const isSelinuxEnforcingHost = (): boolean => {
+	if ( process.platform !== 'linux' ) {
+		return false;
+	}
+
+	try {
+		return (
+			readFileSync( SELINUX_ENFORCE_STATUS_PATH, 'utf8' ).trim() === SELINUX_ENFORCING_STATUS_VALUE
+		);
+	} catch {
+		return false;
+	}
+};
+
+export function proxySocketMount( info: EngineInfo ): ProxySocketMount {
+	return {
+		source: info.socketPath || DOCKER_DEFAULT_SOCKET_PATH,
+		target: PROXY_SOCKET_MOUNT_TARGET,
+		selinuxLabelDisable: info.engine === 'podman' && isSelinuxEnforcingHost(),
+	};
+}
 
 export function podmanPreflight( info: EngineInfo, probes: PreflightProbes ): PreflightFinding[] {
 	if ( info.engine !== 'podman' ) {

--- a/src/lib/dev-environment/engine.ts
+++ b/src/lib/dev-environment/engine.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { satisfies } from 'semver';
 
 const execFileAsync = promisify( execFile );
 
@@ -9,8 +10,24 @@ export interface EngineInfo {
 	engine: ContainerEngine;
 	serverVersion: string;
 	composePlugin?: string;
+	composeBinaryVersion?: string;
 	socketPath: string;
 	rootless: boolean;
+}
+
+export type ComposeRequirementResult = { ok: true } | { ok: false; reason: string; remedy: string };
+
+export interface PreflightProbes {
+	unprivilegedPortStartAllowsPort80: boolean;
+	isPodmanMacMachine: boolean;
+}
+
+export type PreflightSeverity = 'error' | 'warning';
+
+export interface PreflightFinding {
+	severity: PreflightSeverity;
+	message: string;
+	remedy: string;
 }
 
 type ExecFn = typeof execFileAsync;
@@ -116,4 +133,61 @@ export async function detectEngine(
 	} catch {
 		return fallbackEngineInfo( socketPath );
 	}
+}
+
+const DOCKER_COMPOSE_INSTALL_REMEDY =
+	'Install the standalone docker-compose v2 binary: https://docs.docker.com/compose/install/';
+
+export function composeRequirement( info: EngineInfo ): ComposeRequirementResult {
+	if ( info.engine !== 'podman' ) {
+		return { ok: true };
+	}
+
+	const composeBinaryVersion = info.composeBinaryVersion;
+	if ( ! composeBinaryVersion ) {
+		return {
+			ok: false,
+			reason:
+				'podman does not ship a Compose v2-compatible docker-compose, and no standalone docker-compose binary was found',
+			remedy: DOCKER_COMPOSE_INSTALL_REMEDY,
+		};
+	}
+
+	if ( ! satisfies( composeBinaryVersion, '>=2.0.0' ) ) {
+		return {
+			ok: false,
+			reason: `docker-compose version ${ composeBinaryVersion } is not Compose v2`,
+			remedy: DOCKER_COMPOSE_INSTALL_REMEDY,
+		};
+	}
+
+	return { ok: true };
+}
+
+const UNPRIVILEGED_PORT_SYSCTL_KEY = 'net.ipv4.ip_unprivileged_port_start';
+
+const macMachineUnprivilegedPortRemedy = () =>
+	`Run inside the podman machine: podman machine ssh -- sudo sysctl -w ${ UNPRIVILEGED_PORT_SYSCTL_KEY }=80`;
+
+const linuxHostUnprivilegedPortRemedy = () =>
+	`Run on this host: sudo sysctl -w ${ UNPRIVILEGED_PORT_SYSCTL_KEY }=80 (persist it in /etc/sysctl.d/)`;
+
+export function podmanPreflight( info: EngineInfo, probes: PreflightProbes ): PreflightFinding[] {
+	if ( info.engine !== 'podman' ) {
+		return [];
+	}
+
+	if ( probes.unprivilegedPortStartAllowsPort80 ) {
+		return [];
+	}
+
+	return [
+		{
+			severity: 'error',
+			message: `podman cannot publish port 80 until ${ UNPRIVILEGED_PORT_SYSCTL_KEY } allows unprivileged ports below 1024`,
+			remedy: probes.isPodmanMacMachine
+				? macMachineUnprivilegedPortRemedy()
+				: linuxHostUnprivilegedPortRemedy(),
+		},
+	];
 }

--- a/src/lib/dev-environment/engine.ts
+++ b/src/lib/dev-environment/engine.ts
@@ -1,0 +1,119 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify( execFile );
+
+export type ContainerEngine = 'docker' | 'podman';
+
+export interface EngineInfo {
+	engine: ContainerEngine;
+	serverVersion: string;
+	composePlugin?: string;
+	socketPath: string;
+	rootless: boolean;
+}
+
+type ExecFn = typeof execFileAsync;
+
+const fallbackEngineInfo = ( socketPath: string ): EngineInfo => ( {
+	engine: 'docker',
+	serverVersion: 'unknown',
+	socketPath,
+	rootless: false,
+} );
+
+const isRecord = ( value: unknown ): value is Record< string, unknown > =>
+	typeof value === 'object' && value !== null;
+
+const isDockerShape = (
+	info: Record< string, unknown >
+): info is Record< string, unknown > & { ServerVersion: string } =>
+	typeof info.ServerVersion === 'string';
+
+const isPodmanShape = ( info: Record< string, unknown > ): boolean => {
+	const version = info.version;
+	const host = info.host;
+	const store = info.store;
+
+	const hasVersion = isRecord( version ) && typeof version.Version === 'string';
+	const hasPodmanHostShape = isRecord( host ) && 'remoteSocket' in host;
+	const hasPodmanStoreShape = isRecord( store ) && typeof store.graphDriverName === 'string';
+
+	return hasVersion && ( hasPodmanHostShape || hasPodmanStoreShape );
+};
+
+const findComposePluginVersion = ( info: Record< string, unknown > ): string | undefined => {
+	const clientInfo = info.ClientInfo;
+	if ( ! isRecord( clientInfo ) ) {
+		return undefined;
+	}
+
+	const plugins: unknown = clientInfo.Plugins;
+	if ( ! Array.isArray( plugins ) ) {
+		return undefined;
+	}
+
+	const composePlugin: unknown = ( plugins as unknown[] ).find(
+		plugin => isRecord( plugin ) && plugin.Name === 'compose'
+	);
+
+	return isRecord( composePlugin ) && typeof composePlugin.Version === 'string'
+		? composePlugin.Version
+		: undefined;
+};
+
+const isPodmanRootless = ( info: Record< string, unknown > ): boolean => {
+	const host = info.host;
+	if ( ! isRecord( host ) ) {
+		return false;
+	}
+
+	const security = host.security;
+	return isRecord( security ) && security.rootless === true;
+};
+
+const parseDockerInfo = ( info: Record< string, unknown >, socketPath: string ): EngineInfo => ( {
+	engine: 'docker',
+	serverVersion: info.ServerVersion as string,
+	composePlugin: findComposePluginVersion( info ),
+	socketPath,
+	rootless: false,
+} );
+
+const parsePodmanInfo = ( info: Record< string, unknown >, socketPath: string ): EngineInfo => {
+	const version = info.version as Record< string, unknown >;
+	return {
+		engine: 'podman',
+		serverVersion: version.Version as string,
+		composePlugin: findComposePluginVersion( info ),
+		socketPath,
+		rootless: isPodmanRootless( info ),
+	};
+};
+
+export async function detectEngine(
+	dockerBin: string,
+	socketPath: string,
+	exec: ExecFn = execFileAsync
+): Promise< EngineInfo > {
+	try {
+		const { stdout } = await exec( dockerBin, [ 'info', '--format', 'json' ] );
+		const info: unknown = JSON.parse( String( stdout ) );
+
+		if ( ! isRecord( info ) ) {
+			return fallbackEngineInfo( socketPath );
+		}
+
+		if ( isDockerShape( info ) ) {
+			return parseDockerInfo( info, socketPath );
+		}
+
+		if ( isPodmanShape( info ) ) {
+			return parsePodmanInfo( info, socketPath );
+		}
+
+		return fallbackEngineInfo( socketPath );
+	} catch {
+		return fallbackEngineInfo( socketPath );
+	}
+}

--- a/testdata/parity/devenv-podman-compose.json
+++ b/testdata/parity/devenv-podman-compose.json
@@ -1,0 +1,10 @@
+{
+  "name": "devenv-podman-compose",
+  "description": "ComposeRequirement is always OK for docker; refuses podman without a real docker-compose v2 binary and passes with one.",
+  "cases": [
+    { "name": "docker-always-ok", "engine": "docker", "docker_compose_version": null, "expected": { "ok": true } },
+    { "name": "podman-with-compose-v2", "engine": "podman", "docker_compose_version": "v2.29.7", "expected": { "ok": true } },
+    { "name": "podman-without-compose-binary", "engine": "podman", "docker_compose_version": null, "expected": { "ok": false, "reason": "podman requires a real docker-compose v2 binary; podman-compose is not supported" } },
+    { "name": "podman-with-compose-v1", "engine": "podman", "docker_compose_version": "1.29.2", "expected": { "ok": false, "reason": "podman requires a real docker-compose v2 binary; podman-compose is not supported" } }
+  ]
+}

--- a/testdata/parity/devenv-podman-detect.json
+++ b/testdata/parity/devenv-podman-detect.json
@@ -1,0 +1,21 @@
+{
+  "name": "devenv-podman-detect",
+  "description": "DetectEngine classifies a real podman `info --format json` shape as podman, with server version and rootless carried through; a docker shape still classifies as docker.",
+  "cases": [
+    {
+      "name": "docker-info",
+      "info_fixture": "internal/devenv/dockercli/testdata/docker-info.json",
+      "expected": { "engine": "docker", "server_version": "27.3.1", "compose_plugin": true, "rootless": false }
+    },
+    {
+      "name": "podman-info",
+      "info_fixture": "internal/devenv/dockercli/testdata/podman-info.json",
+      "expected": { "engine": "podman", "server_version": "5.5.2", "compose_plugin": false, "rootless": true }
+    },
+    {
+      "name": "unrecognized-info-falls-back-to-docker",
+      "info_fixture": "internal/devenv/dockercli/testdata/unrecognized-info.json",
+      "expected": { "engine": "docker", "server_version": "unknown", "compose_plugin": false, "rootless": false }
+    }
+  ]
+}

--- a/testdata/parity/devenv-podman-preflight.json
+++ b/testdata/parity/devenv-podman-preflight.json
@@ -1,0 +1,24 @@
+{
+  "name": "devenv-podman-preflight",
+  "description": "Preflight is pure and never mutates the host: docker gets zero findings regardless of probes; podman surfaces the unprivileged-port sysctl remedy only when the probed value exceeds 80, with a machine-aware remedy string.",
+  "cases": [
+    { "name": "docker-no-findings", "engine": "docker", "probes": { "unprivileged_port_start": 1024, "runs_inside_machine": false }, "expected_findings": [] },
+    {
+      "name": "podman-rootless-linux-needs-sysctl",
+      "engine": "podman",
+      "probes": { "unprivileged_port_start": 1024, "runs_inside_machine": false },
+      "expected_findings": [
+        { "remedy": "sudo sysctl net.ipv4.ip_unprivileged_port_start=80 (persist via /etc/sysctl.d/99-podman-rootless-ports.conf)" }
+      ]
+    },
+    {
+      "name": "podman-mac-machine-needs-ssh-sysctl",
+      "engine": "podman",
+      "probes": { "unprivileged_port_start": 1024, "runs_inside_machine": true },
+      "expected_findings": [
+        { "remedy": "podman machine ssh -- sudo sysctl net.ipv4.ip_unprivileged_port_start=80" }
+      ]
+    },
+    { "name": "podman-already-permits-port-80", "engine": "podman", "probes": { "unprivileged_port_start": 80, "runs_inside_machine": false }, "expected_findings": [] }
+  ]
+}

--- a/testdata/parity/devenv-podman-proxy-spec.json
+++ b/testdata/parity/devenv-podman-proxy-spec.json
@@ -1,0 +1,24 @@
+{
+  "name": "devenv-podman-proxy-spec",
+  "description": "Proxy publish address, socket mount, and security-opt derived from EngineInfo. Docker keeps 127.0.0.1 + the existing /var/run/docker.sock mount unchanged; podman publishes on 0.0.0.0, mounts the real podman socket path, and disables the SELinux label.",
+  "cases": [
+    {
+      "name": "docker-unchanged",
+      "engine": "docker",
+      "socket_path": "/var/run/docker.sock",
+      "expected": { "bind_address": "127.0.0.1", "socket_mount_source": "/var/run/docker.sock", "socket_mount_target": "/var/run/docker.sock", "security_opt_disable_label": false }
+    },
+    {
+      "name": "podman-wildcard-and-real-socket",
+      "engine": "podman",
+      "socket_path": "/run/user/1000/podman/podman.sock",
+      "expected": { "bind_address": "0.0.0.0", "socket_mount_source": "/run/user/1000/podman/podman.sock", "socket_mount_target": "/var/run/docker.sock", "security_opt_disable_label": true }
+    },
+    {
+      "name": "podman-missing-socket-path-falls-back-to-default",
+      "engine": "podman",
+      "socket_path": "",
+      "expected": { "bind_address": "0.0.0.0", "socket_mount_source": "/run/podman/podman.sock", "socket_mount_target": "/var/run/docker.sock", "security_opt_disable_label": true }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Makes podman (machine on macOS, rootless on Linux) a first-class, detected
container engine for `vip dev-env`, in both the Node.js and Go runtimes, so
the external `~/dotfiles/podman-docker` shim stack is no longer needed.
Docker users see no behavior change: every new function is a no-op /
identity function for `engine === 'docker'`.

Companion fix (separate repo, own draft PR): the two new lando config keys
this branch sets (`proxyPublishAddress`, `proxySocket`) require Lando's
`lando-proxy` plugin to honor them, which the previously pinned
`Automattic/lando-cli` fork commit did not yet do. That fix now lives at
https://github.com/Automattic/lando-cli/pull/245 (branch
`add/podman-proxy-config`), and this branch's `package.json#lando` is pinned
to that commit.

## Defects addressed

Running `vip dev-env create`/`start` under podman without the dotfiles shim
surfaces a chain of masking defects — fixing the first only reveals the
next. This PR addresses defects A through J:

| # | Defect | Where it lived | Fix |
| --- | --- | --- | --- |
| A | Engine identity (`docker info` vs `podman info` JSON shape) was never distinguished; every downstream decision assumed Docker | `src/lib/dev-environment/engine.ts`, `internal/devenv/dockercli/engine.go` | `detectEngine`/`DetectEngine`: parse both JSON shapes into a shared `EngineInfo{engine, serverVersion, socketPath, rootless, composePlugin}`; falls back to `docker`/`unknown` on any unrecognized shape or exec failure, so unrecognized `info` output never regresses a working Docker setup |
| B | Docker socket discovery never looked for a podman socket | `src/lib/dev-environment/docker-utils.ts`, `internal/devenv/dockercli` | `getDockerSocket`/its Go mirror add the podman machine socket path (macOS), the XDG rootless socket path (Linux), and a `podman machine inspect` fallback, appended after the existing Docker candidate paths — Docker's own resolution order is unchanged |
| C | No compose-version gate; podman ships `podman-compose`, not Compose v2 | `engine.ts`/Go mirror | `composeRequirement`: no-op (`{ok:true}`) for Docker; for podman, requires a real standalone `docker-compose` binary satisfying `>=2.0.0`, otherwise refuses with a steered remedy message and a docs link. podman-compose translation is explicitly not supported |
| D | Docker Desktop binds the proxy to `127.0.0.1`; podman machine's user-mode networking needs `0.0.0.0` to be reachable from the host | `engine.ts`/Go `proxy/spec.go` | `proxyPublishAddress(info)` returns `0.0.0.0` under podman, `127.0.0.1` under Docker; the proxy's own port-availability scan still probes `127.0.0.1` regardless of engine |
| E | The proxy container's docker.sock bind-mount assumed Docker's path and never disabled SELinux labeling for podman's rootless socket | `engine.ts`/Go `proxy/spec.go` | `proxySocketMount(info)` mounts the real discovered socket path at `/var/run/docker.sock` inside the proxy container, and sets `security_opt: [label=disable]` only when running podman on an SELinux-enforcing Linux host |
| F | No preflight signal for the unprivileged-port-80 sysctl podman needs; vip-cli must never mutate the host itself | `engine.ts`/Go `proxy/preflight.go` | `podmanPreflight` is a pure function over `EngineInfo` + injected probe results; under podman, if `net.ipv4.ip_unprivileged_port_start` doesn't allow port 80, it returns a warning naming the exact remedy command (`podman machine ssh -- sudo sysctl -w ...` on macOS, `sudo sysctl -w ...` on Linux). It never runs a probe or mutates state itself |
| G | `assets/dev-env.lando.template.yml.ejs`: an `initOnly` service's dependents used `service_started`, which podman does not treat the same way Docker Desktop does, causing dependent services to race the init container | template | Every `initOnly` dependency condition now uses `service_completed_successfully`. Real for Docker too — this is a template correctness bug, not podman-specific |
| H | The `wordpress` init container's `rsync --delete /wp/ /shared/` deleted sibling bind-mount targets (config, log, vip-config, wp-content/uploads, app-code dirs) that podman does not recreate at container start, unlike Docker Desktop | template | rsync now excludes every sibling bind-mount target explicitly |
| I | Lando addresses containers by Compose v2 project/service names; a v1-style name pattern makes every `isRunning` check false, so build steps start-then-kill each service and the VIP health check's retry logic rescans proxy ports and lands on the wrong port | CI / detection requirement | Compose v2 is now a hard requirement under podman (defect C), which keeps container naming Compose-v2-shaped; documented as a `docker-compose` version requirement rather than a separate code path |
| J | Lando's own config resolves `dockerBin` via a stock `env.getDockerExecutable()` that only recognizes a binary literally named `docker`, so on a podman-only machine `dockerBin` is empty and every downstream check fails before any of A–I ever run | `src/lib/dev-environment/docker-utils.ts` | `getDockerBin()`: tries `docker` first (no-op / unchanged for Docker users), falls back to `podman` when only that's usable; wired into `getLandoConfig()` before Lando's own config merge |

## Testing

- `npm test` (lint, check-types, jest): 92 suites, 980 passed / 1 todo, 0 lint errors.
- `go test ./...`: all packages pass (with `VIP_PROXY` unset — an ambient SOCKS proxy in this environment otherwise breaks unrelated loopback-server tests in `internal/gql`, `internal/sqlexport`, `internal/telemetry`, `internal/wpstream`; unrelated to this change).
- `make require-node-vip-bin` + `make test-parity-unit`: parity suite green, including new `testdata/parity/devenv-podman-*.json` fixtures; existing scenarios unchanged (22 pre-existing `expected_drift` entries, none newly added).
- `internal/parity` Docker scenarios unmodified.

## Real-hardware acceptance run (this Mac, podman machine, dotfiles shims unstowed)

With `~/dotfiles/podman-docker` genuinely unstowed (`stow -D podman-docker` —
confirmed no `docker`/`docker-compose` binary on `PATH` afterward) and a real
standalone `docker-compose` v2 binary installed via Homebrew:

**First run** (before the `getDockerBin` fix below), `vip dev-env create
--slug=podman-support …` failed immediately:

```
Error:  docker binary could not be located! Please follow the following instructions to install it - https://docs.docker.com/engine/install/
```

Root cause: `getLandoConfig()` never set `dockerBin`, so Lando's own config
merge filled it via the stock (unforked) `env.getDockerExecutable()`, which
only searches for a binary literally named `docker`. Fixed by
`getDockerBin()` in `src/lib/dev-environment/docker-utils.ts`: tries a
`docker`-named binary first (Docker users see no behavior change — returns
`null`, leaving Lando's own default in place), falls back to `podman` when
only that's usable, wired into `getLandoConfig()` before Lando's own config
merge runs.

**Second run**, with that fix in place, `docker`/`podman` correctly resolves
and `getDockerSocket()` correctly discovers the podman socket
(`/var/run/docker.sock`, a symlink to the podman machine socket, installed
by `podman-mac-helper`) — but `vip dev-env create` still fails, with a
**different** error:

```
Error:  Failed to connect to Docker. Please verify that Docker engine (service) is running and follow the troubleshooting instructions for your platform.
```

Root cause (traced in source): this is Lando's own stock, unforked
`daemon.js#getVersions()`, invoked from `lando.js` during bootstrap and
assigned directly to `lando.config.versions` — it shells `podman info
--format json` successfully, but reads only `dockerData.ServerVersion`
(Docker's JSON shape) and has no podman-shape awareness, so it silently
returns `engine: ''`. `validateDockerInstalled()` in this PR gates on that
exact `lando.config.versions.engine` value *before* it ever reaches this
PR's own podman-aware `detectEngine()` — so `detectEngine`,
`composeRequirement`, `proxyPublishAddress`, `proxySocketMount`, and
`podmanPreflight` (defects A, C, D, E, F — all merged and unit-tested) are
provably correct in isolation but are currently unreachable from the real
CLI entry point under podman, because a stock-Lando health check upstream
of them fails first.

This is reported rather than patched in this run, since it was found by the
real-hardware verification pass rather than planned work — it needs a
follow-up fix: either make `validateDockerInstalled` call this PR's own
`detectEngine()` before/instead of trusting `lando.config.versions.engine`
for the emptiness check, or teach a podman-aware version query into the
Lando bootstrap path itself.

No `podman-support`-slugged environment or containers were created by
either run (confirmed via `podman ps -a` and `vip dev-env list` — both
failures happen before any container/network state is touched). The
machine was restored afterward: `stow podman-docker` was re-run to restore
the dotfiles shims to their pre-run state.

## Related

- Lando fork PR (proxy publish address / socket mount support): https://github.com/Automattic/lando-cli/pull/245
