### PR TITLE
feat: add Go CLI update notifications and self-updates

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -111,3 +111,27 @@ jobs:
 
       - name: smoke
         run: ./bin/vip-next --version
+
+  updater-native:
+    name: Go updater (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    env:
+      DO_NOT_TRACK: '1'
+      GO_ENV: test
+      VIP_NO_UPDATE_NOTIFIER: '1'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.27'
+          cache: true
+      - name: Test native self-replacement and recovery
+        run: go test -count=1 -v ./internal/update
+      - name: Test update command bootstrap
+        run: go test -count=1 -v ./cmd/vip-next -run Update

--- a/cmd/vip-next/auth_bootstrap.go
+++ b/cmd/vip-next/auth_bootstrap.go
@@ -5,6 +5,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
+	"github.com/Automattic/vip/cmd/vip-next/commands"
 	"github.com/Automattic/vip/internal/auth"
 	"github.com/Automattic/vip/internal/keychain"
 	"github.com/Automattic/vip/internal/telemetry"
@@ -104,9 +107,11 @@ func isNonInteractiveArgv(argv []string) bool {
 }
 
 type runDeps struct {
-	Tracker     *telemetry.Tracker
-	NewKeychain func(apiHost string) *keychain.Keychain
-	NewLogin    func(store *auth.Store) func() (*auth.Token, error)
+	UpdateRunner      commands.UpdateRunner
+	StartUpdateNotice func(*cobra.Command) func()
+	Tracker           *telemetry.Tracker
+	NewKeychain       func(apiHost string) *keychain.Keychain
+	NewLogin          func(store *auth.Store) func() (*auth.Token, error)
 }
 
 type telemetryLoginTracker struct {
@@ -119,8 +124,9 @@ func (a telemetryLoginTracker) Track(name string, props map[string]any) {
 
 func productionRunDeps(tracker *telemetry.Tracker) runDeps {
 	return runDeps{
-		Tracker:     tracker,
-		NewKeychain: keychain.New,
+		Tracker:           tracker,
+		StartUpdateNotice: startUpdateNotice,
+		NewKeychain:       keychain.New,
 		NewLogin: func(store *auth.Store) func() (*auth.Token, error) {
 			flow := auth.NewProductionLoginFlow(
 				store,

--- a/cmd/vip-next/commands/update.go
+++ b/cmd/vip-next/commands/update.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/Automattic/vip/internal/update"
+)
+
+type UpdateRunner interface {
+	Run(context.Context, update.Request, func(update.Step)) (update.Outcome, error)
+}
+
+func NewUpdateCmd(runner UpdateRunner) *cobra.Command {
+	var check bool
+	var channel string
+	cmd := &cobra.Command{Use: "update", Short: "Check for or install a newer standalone Go CLI release", Args: cobra.NoArgs, Example: "  vip-next update\n  vip-next update --check\n  vip-next update --channel preview\n  vip-next update --channel stable"}
+	cmd.Flags().BoolVar(&check, "check", false, "Check for an update without installing it")
+	cmd.Flags().StringVar(&channel, "channel", "", "Select and remember the stable or preview release channel")
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		explicit := cmd.Flags().Changed("channel")
+		if explicit && channel != "stable" && channel != "preview" {
+			return fmt.Errorf("channel must be stable or preview")
+		}
+		stderr := cmd.ErrOrStderr()
+		interactive := false
+		if f, ok := stderr.(*os.File); ok {
+			interactive = term.IsTerminal(int(f.Fd()))
+		}
+		open := ""
+		progress := func(s update.Step) {
+			if s.Done {
+				if open != s.Name {
+					fmt.Fprintf(stderr, "%s… ", s.Name)
+				}
+				if interactive {
+					fmt.Fprintln(stderr, "✓")
+				} else {
+					fmt.Fprintln(stderr, "done")
+				}
+				open = ""
+			} else {
+				fmt.Fprintf(stderr, "%s… ", s.Name)
+				open = s.Name
+			}
+		}
+		out, err := runner.Run(cmd.Context(), update.Request{CheckOnly: check, Channel: update.Channel(channel), ExplicitChannel: explicit}, progress)
+		if open != "" {
+			fmt.Fprintln(stderr, "failed")
+		}
+		if err != nil {
+			return err
+		}
+		for _, warning := range out.Warnings {
+			fmt.Fprintln(stderr, warning)
+		}
+		return writeUpdateOutcome(cmd.OutOrStdout(), out)
+	}
+	return cmd
+}
+func writeUpdateOutcome(w io.Writer, out update.Outcome) error {
+	switch {
+	case out.Instructions != "":
+		_, err := fmt.Fprintln(w, out.Instructions)
+		return err
+	case out.Updated:
+		_, err := fmt.Fprintf(w, "Updated to %s\n", out.Available)
+		return err
+	case out.Available != "":
+		_, err := fmt.Fprintf(w, "Installed: %s\nChannel: %s\nAvailable: %s\nRun vip-next update to install.\n", out.Installed, out.Channel, out.Available)
+		return err
+	case out.Channel == update.Stable && strings.Contains(out.Installed, "-"):
+		_, err := fmt.Fprintf(w, "Installed: %s\nChannel: stable\nNo newer stable release is available; waiting for stable to catch up.\n", out.Installed)
+		return err
+	default:
+		_, err := fmt.Fprintf(w, "Already up to date: %s (channel: %s)\n", out.Installed, out.Channel)
+		return err
+	}
+}

--- a/cmd/vip-next/commands/update_test.go
+++ b/cmd/vip-next/commands/update_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Automattic/vip/internal/update"
+)
+
+type updateRunnerFunc func(context.Context, update.Request, func(update.Step)) (update.Outcome, error)
+
+func (f updateRunnerFunc) Run(c context.Context, r update.Request, p func(update.Step)) (update.Outcome, error) {
+	return f(c, r, p)
+}
+func TestUpdateCheckAndInvalidArguments(t *testing.T) {
+	called := 0
+	runner := updateRunnerFunc(func(_ context.Context, r update.Request, _ func(update.Step)) (update.Outcome, error) {
+		called++
+		if !r.CheckOnly || !r.ExplicitChannel || r.Channel != update.Preview {
+			t.Fatal(r)
+		}
+		return update.Outcome{Installed: "5.0.0", Available: "5.1.0-beta.1", Channel: update.Preview}, nil
+	})
+	cmd := NewUpdateCmd(runner)
+	var out, stderr bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--check", "--channel", "preview"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if called != 1 || !strings.Contains(out.String(), "5.1.0-beta.1") || stderr.Len() != 0 {
+		t.Fatal(called, out.String(), stderr.String())
+	}
+	for _, args := range [][]string{{"--channel", "invalid"}, {"--channel="}, {"unexpected"}, {"--bogus"}} {
+		cmd = NewUpdateCmd(runner)
+		cmd.SetOut(&out)
+		cmd.SetErr(&stderr)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err == nil {
+			t.Fatal("accepted", args)
+		}
+	}
+	if called != 1 {
+		t.Fatal("invalid arguments reached updater")
+	}
+}

--- a/cmd/vip-next/flags_node_parity_test.go
+++ b/cmd/vip-next/flags_node_parity_test.go
@@ -28,6 +28,8 @@ import (
 // Keys are Go command paths; values map the Go flag name to Node's short.
 // Where vip-next renamed a flag, the Node source line is called out.
 var nodeShortFlags = map[string]map[string]string{
+	// Explicitly approved Go-only standalone updater; no command-specific short flags.
+	"vip-next update": {},
 	// src/bin/vip.js — only the three globals.
 	"vip-next": {"debug": "d"},
 

--- a/cmd/vip-next/main.go
+++ b/cmd/vip-next/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Automattic/vip/internal/nodeflags"
 	"github.com/Automattic/vip/internal/rechallenge"
 	"github.com/Automattic/vip/internal/telemetry"
+	"github.com/Automattic/vip/internal/update"
 )
 
 func main() {
@@ -100,11 +101,27 @@ func runWithDeps(argv []string, deps runDeps) error {
 	// rootRef is guaranteed non-nil by the time the closure runs in
 	// production. The closure falls back to env-only detection if the
 	// closure somehow fires pre-Execute (shouldn't happen, but defensive).
+	// Probe only the local update route; ordinary commands must be constructed
+	// after configureAuthenticated/configureBypassed has supplied API context.
+	probe := newRootBase(&rootContext{aliasApp: app, aliasEnv: env})
+	runner := deps.UpdateRunner
+	if runner == nil {
+		runner = update.NewService()
+	}
+	probe.AddCommand(commands.NewUpdateCmd(runner))
+	preparedUpdate := prepareArgs(probe, rewritten)
+	if isUpdateInvocation(probe, preparedUpdate) {
+		probe.SetArgs(preparedUpdate)
+		return probe.Execute()
+	}
+
 	var rootRef *cobra.Command
 	executeRoot := func() error {
 		rc := &rootContext{aliasApp: app, aliasEnv: env}
 		rootRef = newRootCmd(rc)
 		rootRef.SetArgs(prepareArgs(rootRef, rewritten))
+		finish := installUpdateNotifier(rootRef, deps.StartUpdateNotice)
+		defer finish()
 		return rootRef.Execute()
 	}
 

--- a/cmd/vip-next/root.go
+++ b/cmd/vip-next/root.go
@@ -7,15 +7,17 @@ import (
 
 	"github.com/Automattic/vip/cmd/vip-next/commands"
 	"github.com/Automattic/vip/internal/appctx"
+	"github.com/Automattic/vip/internal/update"
 	"github.com/Automattic/vip/internal/version"
 )
 
 type rootContext struct {
-	aliasApp string
-	aliasEnv string
+	updateRunner commands.UpdateRunner
+	aliasApp     string
+	aliasEnv     string
 }
 
-func newRootCmd(rc *rootContext) *cobra.Command {
+func newRootBase(rc *rootContext) *cobra.Command {
 	root := &cobra.Command{
 		Use:           "vip-next",
 		Short:         "WordPress VIP command-line interface (Go edition)",
@@ -57,6 +59,16 @@ func newRootCmd(rc *rootContext) *cobra.Command {
 		return nil
 	}
 
+	return root
+}
+
+func newRootCmd(rc *rootContext) *cobra.Command {
+	root := newRootBase(rc)
+	runner := rc.updateRunner
+	if runner == nil {
+		runner = update.NewService()
+	}
+	root.AddCommand(commands.NewUpdateCmd(runner))
 	root.AddCommand(commands.LoginCmd())
 	root.AddCommand(commands.LogoutCmd())
 	root.AddCommand(commands.NewWhoamiCmd())

--- a/cmd/vip-next/update_bootstrap.go
+++ b/cmd/vip-next/update_bootstrap.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/Automattic/vip/internal/appctx"
+	"github.com/Automattic/vip/internal/update"
+)
+
+func isUpdateInvocation(root *cobra.Command, prepared []string) bool {
+	for i, arg := range prepared {
+		if arg == "--" {
+			prepared = prepared[:i]
+			break
+		}
+	}
+	cmd, _, err := root.Find(prepared)
+	return err == nil && cmd.Parent() == root && cmd.Name() == "update"
+}
+func installUpdateNotifier(root *cobra.Command, start func(*cobra.Command) func()) func() {
+	if start == nil {
+		return func() {}
+	}
+	var finish func()
+	var wrap func(*cobra.Command)
+	wrap = func(cmd *cobra.Command) {
+		if old := cmd.RunE; old != nil {
+			cmd.RunE = func(c *cobra.Command, a []string) error { finish = start(c); return old(c, a) }
+		} else if old := cmd.Run; old != nil {
+			cmd.Run = func(c *cobra.Command, a []string) { finish = start(c); old(c, a) }
+		}
+		for _, child := range cmd.Commands() {
+			wrap(child)
+		}
+	}
+	wrap(root)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			if finish != nil {
+				finish()
+			}
+		})
+	}
+}
+func startUpdateNotice(cmd *cobra.Command) func() {
+	if !updateNoticeAllowed(cmd, appctx.IsInteractive(cmd), stderrTerminal(cmd), os.Getenv) {
+		return nil
+	}
+	service := update.NewService()
+	n := update.Notifier{State: service.State, Installed: service.Installed, Platform: service.Platform, Now: service.Now, Fetch: service.Fetch}
+	finish := n.Start(cmd.Context())
+	return func() {
+		if notice := finish(); notice != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "A newer vip-next release is available: %s. Run vip-next update to install.\n", notice.Version)
+		}
+	}
+}
+func stderrTerminal(cmd *cobra.Command) bool {
+	f, ok := cmd.ErrOrStderr().(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+func updateNoticeAllowed(cmd *cobra.Command, interactive, stderrTTY bool, getenv func(string) string) bool {
+	if !interactive || !stderrTTY || cmd.Parent() == nil {
+		return false
+	}
+	for _, key := range []string{"CI", "GITHUB_ACTIONS", "BUILDKITE"} {
+		if v := getenv(key); v != "" && v != "false" && v != "0" {
+			return false
+		}
+	}
+	if getenv("GO_ENV") == "test" || getenv("NODE_ENV") == "test" || getenv("VIP_NO_UPDATE_NOTIFIER") == "1" {
+		return false
+	}
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "update" && c.Parent() == cmd.Root() || c.Name() == "help" || c.Name() == "completion" || c.Name() == "wp" {
+			return false
+		}
+	}
+	if f := cmd.Flag("format"); f != nil && (f.Value.String() == "json" || f.Value.String() == "csv") {
+		return false
+	}
+	for _, name := range []string{"help", "version"} {
+		if f := cmd.Flag(name); f != nil && f.Value.String() == "true" {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/vip-next/update_bootstrap_test.go
+++ b/cmd/vip-next/update_bootstrap_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Automattic/vip/internal/auth"
+	"github.com/Automattic/vip/internal/keychain"
+	"github.com/Automattic/vip/internal/update"
+)
+
+type updateRunnerFunc func(context.Context, update.Request, func(update.Step)) (update.Outcome, error)
+
+func (f updateRunnerFunc) Run(c context.Context, r update.Request, p func(update.Step)) (update.Outcome, error) {
+	return f(c, r, p)
+}
+func TestIsUpdateInvocation(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+		want bool
+	}{{[]string{"update", "--check"}, true}, {[]string{"--debug=update", "update", "--check"}, true}, {[]string{"--app", "update", "whoami"}, false}, {[]string{"config", "software", "update"}, false}, {[]string{"wp", "plugin", "update"}, false}, {[]string{"--", "update"}, false}, {[]string{"whoami", "update"}, false}} {
+		root := newRootCmd(&rootContext{})
+		if got := isUpdateInvocation(root, prepareArgs(root, tc.args)); got != tc.want {
+			t.Errorf("%q: got %v", tc.args, got)
+		}
+	}
+}
+func TestUpdateBypassesCredentialConstruction(t *testing.T) {
+	ran := false
+	deps := runDeps{NewKeychain: func(string) *keychain.Keychain { t.Fatal("update constructed credential store"); return nil }, NewLogin: func(*auth.Store) func() (*auth.Token, error) { t.Fatal("update requested login"); return nil }, UpdateRunner: updateRunnerFunc(func(_ context.Context, r update.Request, _ func(update.Step)) (update.Outcome, error) {
+		ran = true
+		return update.Outcome{Installed: "5.0.0", Channel: update.Stable}, nil
+	})}
+	if err := runWithDeps([]string{"update", "--check"}, deps); err != nil || !ran {
+		t.Fatal(err, ran)
+	}
+	ran = false
+	if err := runWithDeps([]string{"update", "--badflag"}, deps); err == nil || ran {
+		t.Fatal("invalid update dispatched", err, ran)
+	}
+}
+
+func TestUpdateNotificationGates(t *testing.T) {
+	root := newRootCmd(&rootContext{})
+	leaf, _, err := root.Find([]string{"whoami"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty := func(string) string { return "" }
+	if !updateNoticeAllowed(leaf, true, true, empty) {
+		t.Fatal("interactive command suppressed")
+	}
+	for _, key := range []string{"CI", "GITHUB_ACTIONS", "BUILDKITE", "GO_ENV", "NODE_ENV", "VIP_NO_UPDATE_NOTIFIER"} {
+		get := func(k string) string {
+			if k != key {
+				return ""
+			}
+			if key == "GO_ENV" || key == "NODE_ENV" {
+				return "test"
+			}
+			return "1"
+		}
+		if updateNoticeAllowed(leaf, true, true, get) {
+			t.Error("not suppressed", key)
+		}
+	}
+	if updateNoticeAllowed(leaf, false, true, empty) || updateNoticeAllowed(leaf, true, false, empty) {
+		t.Fatal("nonterminal notice")
+	}
+	for _, argv := range [][]string{{"update"}, {"wp"}, {"logs"}} {
+		r := newRootCmd(&rootContext{})
+		c, _, e := r.Find(argv)
+		if e != nil {
+			t.Fatal(e)
+		}
+		if argv[0] == "logs" {
+			if e = c.ParseFlags([]string{"--format=json"}); e != nil {
+				t.Fatal(e)
+			}
+		}
+		if updateNoticeAllowed(c, true, true, empty) {
+			t.Fatal("unsafe output notice", argv)
+		}
+	}
+}

--- a/cmd/vip-next/update_integration_test.go
+++ b/cmd/vip-next/update_integration_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	json "encoding/json/v2"
+
+	"github.com/Automattic/vip/internal/auth"
+	"github.com/Automattic/vip/internal/keychain"
+	"github.com/Automattic/vip/internal/update"
+)
+
+type updateTransport func(*http.Request) (*http.Response, error)
+
+func (f updateTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// The subprocess executes the actual command/service/downloader/installer. Its
+// endpoint and installation injection live only in this test, never in the CLI.
+func TestUpdateServiceEndToEnd(t *testing.T) {
+	if os.Getenv("VIP_UPDATE_TEST_CHILD") != "1" {
+		exe, err := os.Executable()
+		if err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command(exe, "-test.run=^TestUpdateServiceEndToEnd$")
+		cmd.Env = append(os.Environ(), "VIP_UPDATE_TEST_CHILD=1", "DO_NOT_TRACK=1", "GO_ENV=test")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("update subprocess: %v\n%s", err, output)
+		}
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	root := t.TempDir()
+	cli := filepath.Join(root, "vip-next"+suffix)
+	helper := filepath.Join(root, "go-search-replace"+suffix)
+	for _, path := range []string{cli, helper} {
+		if err := os.WriteFile(path, []byte("old installation"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var archive bytes.Buffer
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+	for _, name := range []string{filepath.Base(cli), filepath.Base(helper)} {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0755, Size: int64(len(payload))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	name := "vip-next-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz"
+	checksum := fmt.Sprintf("%x *%s", sha256.Sum256(archive.Bytes()), name)
+	downloadPath := "/Automattic/vip-cli/releases/download/5.0.1/"
+	metadata, err := json.Marshal([]update.Release{{Tag: "5.0.1", Assets: []update.Asset{{Name: name, URL: "https://github.com" + downloadPath + name}, {Name: name + ".sha256", URL: "https://github.com" + downloadPath + name + ".sha256"}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Error("credential reached release server")
+		}
+		switch r.URL.Path {
+		case "/repos/Automattic/vip-cli/releases":
+			w.Write(metadata)
+		case downloadPath + name:
+			w.Write(archive.Bytes())
+		case downloadPath + name + ".sha256":
+			fmt.Fprint(w, checksum)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	localURL, _ := url.Parse(server.URL)
+	client := server.Client()
+	transport := client.Transport
+	client.Transport = updateTransport(func(r *http.Request) (*http.Response, error) {
+		copy := r.Clone(r.Context())
+		u := *r.URL
+		u.Scheme = localURL.Scheme
+		u.Host = localURL.Host
+		copy.URL = &u
+		return transport.RoundTrip(copy)
+	})
+	service := update.NewService()
+	service.Installed = "5.0.0"
+	service.State = update.State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}
+	service.Executable = func() (string, error) { return cli, nil }
+	service.Fetch = (update.GitHub{Client: client, BaseURL: server.URL}).Releases
+	service.Stage = (update.Downloader{Client: client}).Stage
+	service.Installer.InspectOwnership = func(context.Context, update.Layout) (update.Ownership, error) { return update.Ownership{}, nil }
+	deps := runDeps{UpdateRunner: service, NewKeychain: func(string) *keychain.Keychain { t.Fatal("updater accessed VIP credentials"); return nil }, NewLogin: func(*auth.Store) func() (*auth.Token, error) { t.Fatal("updater requested login"); return nil }}
+	if err := runWithDeps([]string{"update", "--channel", "stable", "--non-interactive"}, deps); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{cli, helper} {
+		got, err := os.ReadFile(path)
+		if err != nil || !bytes.Equal(got, payload) {
+			t.Fatalf("bundle not fully installed: %s %v", path, err)
+		}
+	}
+	ch, err := service.State.ReadChannel()
+	if err != nil || ch != update.Stable {
+		t.Fatal("channel not persisted", ch, err)
+	}
+}

--- a/docs/CUTOVER-BREAKING-CHANGES.md
+++ b/docs/CUTOVER-BREAKING-CHANGES.md
@@ -116,7 +116,9 @@ Announce these explicitly; they fail at parse time, not at runtime.
 - `--help` is rendered by Cobra rather than commander: usage and option layout differ, and
   Node's appended `Examples` block is not reproduced
 - `vip wp` supports only the `@app.env` alias — explicit `--app`/`--env` are ignored (known WP1 limitation)
-- No update-notifier: vip-next ships as a signed binary, so there is no in-CLI update channel
+- Go now has an invocation-driven update notifier and a Go-only `vip-next update` command.
+  See [Updating the standalone Go CLI](GO-UPDATES.md) for channels and recovery.
+  This runtime difference is explicitly approved; Node retains its npm notifier.
 
 **Restored during remediation — no longer breaking, remove from migration notes:**
 `--xdebug_config` (underscore form is canonical again), `dev-env start --vscode`,

--- a/docs/GO-UPDATES.md
+++ b/docs/GO-UPDATES.md
@@ -1,0 +1,91 @@
+# Updating the standalone Go CLI
+
+`vip-next` can check for and install newer 5.x releases from the
+[official GitHub releases](https://github.com/Automattic/vip-cli/releases).
+This feature is specific to the Go runtime; the Node CLI retains its npm
+update notifier.
+
+```sh
+vip-next update
+vip-next update --check
+vip-next update --channel preview
+vip-next update --channel stable
+```
+
+`update` authorizes installation without another prompt, including in
+non-interactive mode. `--check` reports availability without downloading or
+replacing executables. A successful check exits zero whether or not an update
+exists; a failed check or installation exits nonzero. Neither command needs a
+VIP login. Updates use the existing `VIP_PROXY` / `VIP_USE_SYSTEM_PROXY` policy.
+
+## Release channels
+
+Without an explicit preference, a prerelease installation follows newer
+previews through the stable release, then follows stable releases. Selecting
+`--channel preview` keeps following previews even after installing a stable
+release. `--channel stable` follows stable releases only. The preference is
+saved after a successful operation. Combining `--check --channel preview`
+changes that preference without installing binaries.
+
+Updates never downgrade. If the selected stable channel is behind an installed
+preview, the CLI waits for a newer stable release. Development builds, including
+`5.0.0-dev.<commit>`, must be replaced manually with an official release first.
+
+## Notifications
+
+Interactive invocations check at most once every 24 hours after a successful
+check. A request runs alongside the current command and has a five-second
+limit. The command never waits for that request at exit; very short commands
+may finish without refreshing the cache. There is no scheduled process.
+Completed failed checks back off for one hour and do not fail ordinary commands.
+
+Notices appear on interactive stderr. Automatic checks and notices are disabled
+in CI, tests, non-interactive use, JSON/CSV output, help/version, raw `wp`
+commands, and update commands. Set `VIP_NO_UPDATE_NOTIFIER=1` to disable automatic
+checks; explicit update commands still check immediately.
+
+The cache is under the operating system's user cache directory in `vip/update/`.
+The explicit channel preference is under the user configuration directory in
+`vip/update.json`. These files are separate from credentials.
+
+## Installation and recovery
+
+The updater downloads the matching archive and SHA-256 file, verifies them,
+and checks that the archive contains exactly the two executables for the target
+platform. If GitHub supplies an asset digest, that digest must match too.
+This trusts the official GitHub release over HTTPS; the checksums are not an
+independent publisher signature. Binary bytes, including existing code
+signatures, are preserved. The updater does not perform a separate native
+signer or notarization assessment.
+
+Both executables are staged before installation. Progress reports each step:
+
+```text
+Downloading 5.0.0-alpha.4… ✓
+Verifying download… ✓
+Updating vip-next… ✓
+Updating go-search-replace… ✓
+Updated to 5.0.0-alpha.4
+```
+
+The updater replaces the CLI and its bundled helper sequentially, retaining
+backups until both succeed. Ordinary failures attempt to restore the original
+files. If restoration fails, the error identifies the recovery record and backup
+paths. Inspect those paths and restore the original files or reinstall the
+complete release archive before retrying. The updater does not silently resume
+an incomplete update.
+
+This is not a crash-proof two-file transaction. Power loss or forced termination
+can require manual restoration, and another CLI process can observe the interval
+between replacements. Windows may retain the old loaded executable as a backup
+until a subsequent explicit update can remove it.
+
+The real CLI path is resolved through any entrypoint symlink. The bundled helper
+is selected from the executable directory's `bin/` subdirectory first, then from
+beside the CLI. PATH and `VIP_SEARCH_REPLACE_BIN` targets are never overwritten;
+an active override continues to control helper execution.
+
+Recognized package-managed installations receive package-manager instructions
+instead of file replacement. Missing bundles, ambiguous layouts, and unwritable
+locations require manual installation. The updater does not elevate privileges.
+Supported release assets are macOS and Linux amd64/arm64, and Windows amd64.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -107,6 +107,7 @@ TODO: Update description of the variables.
 - `SOCKS_PROXY`:
 - `HTTP_PROXY`:
 - `NO_PROXY`:
+- `VIP_NO_UPDATE_NOTIFIER`: Set to `1` to disable automatic update checks and notices in the Go CLI. Explicit `vip-next update` commands remain available. See [Go CLI updates](GO-UPDATES.md).
 - `VIP_PROXY`: [For internal VIP use](TESTING.md#local-testing).
 - `VIP_USE_SYSTEM_PROXY`:
 - `WPVIP_DEPLOY_TOKEN`: For use with `vip app deploy` on sites that have custom deploys enabled.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.19
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.53.0
+	golang.org/x/mod v0.36.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0

--- a/internal/update/archive.go
+++ b/internal/update/archive.go
@@ -1,0 +1,134 @@
+package update
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const maxArchive int64 = 128 << 20
+const maxExtracted int64 = 256 << 20
+
+type Bundle struct{ Dir, CLI, Helper string }
+
+func Extract(archivePath, stageDir string, p Platform) (Bundle, error) {
+	empty := Bundle{}
+	a, err := os.Open(archivePath)
+	if err != nil {
+		return empty, err
+	}
+	defer a.Close()
+	gz, err := gzip.NewReader(a)
+	if err != nil {
+		return empty, err
+	}
+	defer gz.Close()
+	limited := &io.LimitedReader{R: gz, N: maxExtracted + (1 << 20) + 1}
+	tr := tar.NewReader(limited)
+	cli, helper := p.names()
+	expected := map[string]bool{cli: false, helper: false}
+	var total int64
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return empty, err
+		}
+		if h.Typeflag != tar.TypeReg && h.Typeflag != tar.TypeRegA {
+			return empty, fmt.Errorf("archive member %q is not a regular file", h.Name)
+		}
+		seen, ok := expected[h.Name]
+		if !ok || seen {
+			return empty, fmt.Errorf("unexpected or duplicate archive member %q", h.Name)
+		}
+		if h.Size <= 0 || h.Size > maxArchive || total+h.Size > maxExtracted {
+			return empty, fmt.Errorf("archive payload exceeds size limit")
+		}
+		total += h.Size
+		expected[h.Name] = true
+		f, err := os.OpenFile(filepath.Join(stageDir, h.Name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+		if err != nil {
+			return empty, err
+		}
+		_, err = io.CopyN(f, tr, h.Size)
+		closeErr := f.Close()
+		if err != nil {
+			return empty, err
+		}
+		if closeErr != nil {
+			return empty, closeErr
+		}
+	}
+	// Consume the gzip trailer and reject non-padding data after tar EOF.
+	tail, err := readBounded(limited, 1<<20)
+	if err != nil {
+		return empty, err
+	}
+	if limited.N <= 0 {
+		return empty, fmt.Errorf("archive exceeds extraction limit")
+	}
+	for _, b := range tail {
+		if b != 0 {
+			return empty, fmt.Errorf("unexpected trailing archive data")
+		}
+	}
+	for name, seen := range expected {
+		if !seen {
+			return empty, fmt.Errorf("archive missing %s", name)
+		}
+		if err := VerifyExecutable(filepath.Join(stageDir, name), p); err != nil {
+			return empty, fmt.Errorf("verify %s: %w", name, err)
+		}
+	}
+	return Bundle{Dir: stageDir, CLI: filepath.Join(stageDir, cli), Helper: filepath.Join(stageDir, helper)}, nil
+}
+func VerifyExecutable(path string, p Platform) error {
+	switch p.OS {
+	case "linux":
+		f, err := elf.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		machine := elf.EM_X86_64
+		if p.Arch == "arm64" {
+			machine = elf.EM_AARCH64
+		}
+		if f.Class != elf.ELFCLASS64 || f.Machine != machine || (f.Type != elf.ET_EXEC && f.Type != elf.ET_DYN) {
+			return fmt.Errorf("wrong ELF executable target")
+		}
+	case "darwin":
+		f, err := macho.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		cpu := macho.CpuAmd64
+		if p.Arch == "arm64" {
+			cpu = macho.CpuArm64
+		}
+		if f.Cpu != cpu || f.Type != macho.TypeExec {
+			return fmt.Errorf("wrong Mach-O executable target")
+		}
+	case "windows":
+		f, err := pe.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if f.Machine != pe.IMAGE_FILE_MACHINE_AMD64 || f.OptionalHeader == nil || f.Characteristics&pe.IMAGE_FILE_EXECUTABLE_IMAGE == 0 || f.Characteristics&pe.IMAGE_FILE_DLL != 0 {
+			return fmt.Errorf("wrong PE executable target")
+		}
+	default:
+		return fmt.Errorf("unsupported executable platform")
+	}
+	return nil
+}

--- a/internal/update/archive_test.go
+++ b/internal/update/archive_test.go
@@ -1,0 +1,132 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func tarBytes(t *testing.T, headers []*tar.Header, payloads [][]byte) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	tw := tar.NewWriter(gz)
+	for i, h := range headers {
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(payloads[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return b.Bytes()
+}
+func TestExtractRejectsUnsafeArchives(t *testing.T) {
+	for _, h := range []*tar.Header{{Name: "../escaped", Size: 1}, {Name: "/absolute", Size: 1}, {Name: "vip-next", Typeflag: tar.TypeSymlink, Linkname: "/tmp/a"}, {Name: "unexpected", Size: 1}} {
+		body := []byte("x")
+		if h.Typeflag == tar.TypeSymlink {
+			body = nil
+		}
+		root := t.TempDir()
+		archive := filepath.Join(root, "a.tar.gz")
+		if err := os.WriteFile(archive, tarBytes(t, []*tar.Header{h}, [][]byte{body}), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Extract(archive, root, Platform{"linux", "amd64"}); err == nil {
+			t.Fatal("accepted", h.Name)
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func TestStageChecksumAndBytePreservation(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := Platform{runtime.GOOS, runtime.GOARCH}
+	cli, helper := p.names()
+	name, _ := p.archiveName()
+	archive := tarBytes(t, []*tar.Header{{Name: cli, Size: int64(len(payload)), Mode: 0755}, {Name: helper, Size: int64(len(payload)), Mode: 0755}}, [][]byte{payload, payload})
+	digest := fmt.Sprintf("%x", sha256.Sum256(archive))
+	base := "https://github.com/Automattic/vip-cli/releases/download/5.0.1/"
+	c := Candidate{Version: "5.0.1", Archive: Asset{Name: name, URL: base + name, Digest: "sha256:" + digest}, Checksum: Asset{Name: name + ".sha256", URL: base + name + ".sha256"}}
+	for _, bad := range []bool{true, false} {
+		client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			data := archive
+			if strings.HasSuffix(r.URL.Path, ".sha256") {
+				d := digest
+				if bad {
+					d = strings.Repeat("0", 64)
+				}
+				data = []byte(d + " *" + name)
+			}
+			return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader(data)), ContentLength: int64(len(data)), Request: r}, nil
+		})}
+		bundle, err := (Downloader{Client: client}).Stage(context.Background(), c, p, t.TempDir())
+		if bad {
+			if err == nil {
+				t.Fatal("bad checksum accepted")
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, path := range []string{bundle.CLI, bundle.Helper} {
+			got, err := os.ReadFile(path)
+			if err != nil || !bytes.Equal(got, payload) {
+				t.Fatal("binary bytes changed", err)
+			}
+		}
+	}
+	c.Archive.URL = "https://evil.invalid/payload"
+	if _, err := (Downloader{}).Stage(context.Background(), c, p, t.TempDir()); err == nil {
+		t.Fatal("foreign URL accepted")
+	}
+}
+
+func TestStageRejectsMultilineChecksum(t *testing.T) {
+	p := Platform{"linux", "amd64"}
+	name, _ := p.archiveName()
+	base := "https://github.com/Automattic/vip-cli/releases/download/5.0.1/"
+	emptySum := fmt.Sprintf("%x", sha256.Sum256(nil))
+	c := Candidate{Version: "5.0.1", Archive: Asset{Name: name, URL: base + name}, Checksum: Asset{Name: name + ".sha256", URL: base + name + ".sha256"}}
+	archiveRequested := false
+	d := Downloader{Client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		body := emptySum + "\n" + name
+		if !strings.HasSuffix(r.URL.Path, ".sha256") {
+			archiveRequested = true
+			body = ""
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body)), Request: r}, nil
+	})}}
+	if _, err := d.Stage(context.Background(), c, p, t.TempDir()); err == nil {
+		t.Fatal("multiline checksum accepted")
+	}
+	if archiveRequested {
+		t.Fatal("invalid checksum was accepted before fetching the archive")
+	}
+}

--- a/internal/update/download.go
+++ b/internal/update/download.go
@@ -1,0 +1,129 @@
+package update
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Automattic/vip/internal/httpproxy"
+)
+
+type Downloader struct{ Client *http.Client }
+
+func (d Downloader) Stage(ctx context.Context, c Candidate, p Platform, parent string) (bundle Bundle, err error) {
+	name, err := p.archiveName()
+	if err != nil {
+		return bundle, err
+	}
+	if !validVersion(c.Version) || c.Archive.Name != name || c.Checksum.Name != name+".sha256" {
+		return bundle, fmt.Errorf("invalid release assets")
+	}
+	for _, a := range []Asset{c.Archive, c.Checksum} {
+		u, e := url.Parse(a.URL)
+		if e != nil || u.Scheme != "https" || u.Host != "github.com" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Path != "/"+Repository+"/releases/download/"+c.Version+"/"+a.Name {
+			return bundle, fmt.Errorf("invalid official release asset URL")
+		}
+	}
+	dir, err := os.MkdirTemp(parent, ".vip-update-stage-")
+	if err != nil {
+		return bundle, err
+	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(dir)
+		}
+	}()
+	checksum, err := d.fetch(ctx, c.Checksum, 4096)
+	if err != nil {
+		return bundle, err
+	}
+	line := strings.TrimSpace(string(checksum))
+	if strings.ContainsAny(line, "\r\n") {
+		return bundle, fmt.Errorf("checksum file must contain one non-empty line")
+	}
+	fields := strings.Fields(line)
+	if len(fields) != 2 || strings.TrimPrefix(strings.TrimPrefix(fields[1], "*"), "dist/") != name {
+		return bundle, fmt.Errorf("invalid release checksum file")
+	}
+	want, err := hex.DecodeString(fields[0])
+	if err != nil || len(want) != sha256.Size {
+		return bundle, fmt.Errorf("invalid SHA-256 checksum")
+	}
+	archive, err := d.fetch(ctx, c.Archive, maxArchive)
+	if err != nil {
+		return bundle, err
+	}
+	sum := sha256.Sum256(archive)
+	if !strings.EqualFold(hex.EncodeToString(sum[:]), fields[0]) {
+		return bundle, fmt.Errorf("release checksum mismatch")
+	}
+	archivePath := filepath.Join(dir, "release.tar.gz")
+	if err = os.WriteFile(archivePath, archive, 0600); err != nil {
+		return bundle, err
+	}
+	bundle, err = Extract(archivePath, dir, p)
+	return bundle, err
+}
+func (d Downloader) fetch(ctx context.Context, a Asset, limit int64) ([]byte, error) {
+	if a.Size < 0 || a.Size > limit {
+		return nil, fmt.Errorf("release asset exceeds size limit")
+	}
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	client := d.Client
+	if client == nil {
+		client = httpproxy.Client()
+	}
+	copyClient := *client
+	copyClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > 5 || req.URL.Scheme != "https" || req.URL.User != nil {
+			return fmt.Errorf("invalid release redirect")
+		}
+		req.Header.Del("Authorization")
+		req.Header.Del("Cookie")
+		return nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "vip-next-updater")
+	resp, err := copyClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("download %s failed", a.Name)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("download %s: HTTP %d", a.Name, resp.StatusCode)
+	}
+	if resp.ContentLength > limit {
+		return nil, fmt.Errorf("release asset exceeds size limit")
+	}
+	b, err := readBounded(resp.Body, limit)
+	if err != nil {
+		return nil, err
+	}
+	if a.Size > 0 && int64(len(b)) != a.Size {
+		return nil, fmt.Errorf("release asset size mismatch")
+	}
+	if a.Digest != "" {
+		if !strings.HasPrefix(a.Digest, "sha256:") {
+			return nil, fmt.Errorf("unsupported release asset digest")
+		}
+		sum := sha256.Sum256(b)
+		if !strings.EqualFold(a.Digest, "sha256:"+hex.EncodeToString(sum[:])) {
+			return nil, fmt.Errorf("release asset digest mismatch")
+		}
+	}
+	return b, nil
+}

--- a/internal/update/download.go
+++ b/internal/update/download.go
@@ -100,7 +100,16 @@ func (d Downloader) fetch(ctx context.Context, a Asset, limit int64) ([]byte, er
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		return nil, fmt.Errorf("download %s failed", a.Name)
+		// Client.Do wraps transport failures with a URL that may contain a
+		// signed CDN query. Retain the cause without that URL wrapper.
+		for {
+			urlErr, ok := err.(*url.Error)
+			if !ok {
+				break
+			}
+			err = urlErr.Err
+		}
+		return nil, fmt.Errorf("download %s failed: %w", a.Name, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {

--- a/internal/update/download_test.go
+++ b/internal/update/download_test.go
@@ -1,0 +1,32 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestDownloadReportsCauseWithoutRedirectURL(t *testing.T) {
+	cause := &net.DNSError{Err: "no such host", Name: "release-assets.githubusercontent.com", IsNotFound: true}
+	d := Downloader{Client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host == "github.com" {
+			return &http.Response{StatusCode: http.StatusFound, Header: http.Header{"Location": {"https://release-assets.githubusercontent.com/archive?sig=secret"}}, Body: http.NoBody}, nil
+		}
+		return nil, cause
+	})}}
+	_, err := d.fetch(context.Background(), Asset{Name: "release.tar.gz", URL: "https://github.com/Automattic/vip-cli/releases/download/5.0.1/release.tar.gz"}, 1024)
+	if err == nil || !strings.Contains(err.Error(), "no such host") || !errors.Is(err, cause) {
+		t.Fatalf("network cause lost: %v", err)
+	}
+	if strings.Contains(err.Error(), "sig=") || strings.Contains(err.Error(), "secret") {
+		t.Fatalf("redirect credentials leaked: %v", err)
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		t.Fatalf("redirect URL retained in error chain: %v", err)
+	}
+}

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -1,0 +1,102 @@
+package update
+
+import (
+	"context"
+	json "encoding/json/v2"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Automattic/vip/internal/httpproxy"
+)
+
+type GitHub struct {
+	Client  *http.Client
+	BaseURL string
+}
+
+func (g GitHub) Releases(ctx context.Context) ([]Release, error) {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	base := g.BaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	origin, err := url.Parse(base)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := strings.TrimRight(base, "/") + "/repos/" + Repository + "/releases"
+	client := g.Client
+	if client == nil {
+		client = httpproxy.Client()
+	}
+	// API pagination must never redirect to another source or forward credentials.
+	copyClient := *client
+	copyClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	var releases []Release
+	for page := 1; page <= 100; {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?per_page=100&page="+strconv.Itoa(page), nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", "vip-next-updater")
+		req.Header.Set("Accept", "application/vnd.github+json")
+		resp, err := copyClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("check GitHub releases: %w", err)
+		}
+		body, readErr := readBounded(resp.Body, 2<<20)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("check GitHub releases: HTTP %d", resp.StatusCode)
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+		var batch []Release
+		if err := json.Unmarshal(body, &batch); err != nil {
+			return nil, fmt.Errorf("invalid GitHub release metadata: %w", err)
+		}
+		releases = append(releases, batch...)
+		next := 0
+		for _, part := range strings.Split(resp.Header.Get("Link"), ",") {
+			if !strings.Contains(part, `rel="next"`) {
+				continue
+			}
+			left, right := strings.Index(part, "<"), strings.Index(part, ">")
+			if left < 0 || right <= left {
+				return nil, fmt.Errorf("invalid release pagination")
+			}
+			u, err := url.Parse(part[left+1 : right])
+			if err != nil {
+				return nil, fmt.Errorf("invalid release pagination")
+			}
+			u = origin.ResolveReference(u)
+			n, err := strconv.Atoi(u.Query().Get("page"))
+			if err != nil || n <= page || u.Scheme != origin.Scheme || u.Host != origin.Host || u.Path != "/repos/"+Repository+"/releases" || u.User != nil || next != 0 {
+				return nil, fmt.Errorf("invalid release pagination")
+			}
+			next = n
+		}
+		if next == 0 {
+			return releases, nil
+		}
+		page = next
+	}
+	return nil, fmt.Errorf("GitHub release pagination limit exceeded")
+}
+func readBounded(r io.Reader, max int64) ([]byte, error) {
+	b, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > max {
+		return nil, fmt.Errorf("response exceeds size limit")
+	}
+	return b, nil
+}

--- a/internal/update/install.go
+++ b/internal/update/install.go
@@ -1,0 +1,265 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type Layout struct{ CLI, Helper string }
+type Ownership struct {
+	Managed      bool
+	Instructions string
+}
+type Step struct {
+	Name string
+	Done bool
+}
+type InstallResult struct{ Warnings []string }
+type Installer struct {
+	Rename           func(string, string) error
+	Remove           func(string) error
+	InspectOwnership func(context.Context, Layout) (Ownership, error)
+}
+type replacement struct {
+	Target, New, Backup string
+	moved, placed       bool
+}
+type installMarker struct {
+	ID       string
+	Complete bool
+	Files    []replacement
+}
+
+func markerPath(l Layout) string {
+	return filepath.Join(filepath.Dir(l.CLI), "."+filepath.Base(l.CLI)+".update.json")
+}
+func ResolveLayout(exe string, p Platform) (Layout, error) {
+	real, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return Layout{}, err
+	}
+	real, err = filepath.Abs(real)
+	if err != nil {
+		return Layout{}, err
+	}
+	if _, err = regularFile(real); err != nil {
+		return Layout{}, err
+	}
+	_, helper := p.names()
+	for _, candidate := range []string{filepath.Join(filepath.Dir(real), "bin", helper), filepath.Join(filepath.Dir(real), helper)} {
+		if _, err := os.Lstat(candidate); os.IsNotExist(err) {
+			continue
+		}
+		if _, err := regularFile(candidate); err != nil {
+			return Layout{}, err
+		}
+		// Parent symlinks can lead outside the bundle; accept only a real bundled directory.
+		dir, err := filepath.EvalSymlinks(filepath.Dir(candidate))
+		if err != nil || dir != filepath.Dir(candidate) {
+			return Layout{}, fmt.Errorf("ambiguous bundled helper directory; install manually from %s", ReleasesURL)
+		}
+		if candidate == real {
+			return Layout{}, fmt.Errorf("CLI and helper refer to the same file")
+		}
+		return Layout{real, candidate}, nil
+	}
+	return Layout{}, fmt.Errorf("bundled go-search-replace not found; install the complete archive from %s", ReleasesURL)
+}
+func regularFile(path string) (os.FileInfo, error) {
+	s, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !s.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return s, nil
+}
+func (i Installer) Apply(ctx context.Context, l Layout, b Bundle, progress func(Step)) (res InstallResult, err error) {
+	if i.Rename == nil {
+		i.Rename = os.Rename
+	}
+	if i.Remove == nil {
+		i.Remove = os.Remove
+	}
+	if i.InspectOwnership == nil {
+		i.InspectOwnership = InspectOwnership
+	}
+	if progress == nil {
+		progress = func(Step) {}
+	}
+	if err = ctx.Err(); err != nil {
+		return res, err
+	}
+	if err = i.cleanPrevious(l); err != nil {
+		return res, err
+	}
+	owner, err := i.InspectOwnership(ctx, l)
+	if err != nil {
+		return res, err
+	}
+	if owner.Managed {
+		return res, fmt.Errorf("%s", owner.Instructions)
+	}
+	m := installMarker{ID: uuid.NewString()}
+	markerWritten := false
+	defer func() {
+		if !markerWritten {
+			for _, r := range m.Files {
+				_ = os.Remove(r.New)
+			}
+		}
+	}()
+	for idx, target := range []string{l.CLI, l.Helper} {
+		stat, e := regularFile(target)
+		if e != nil {
+			return res, e
+		}
+		source := b.CLI
+		if idx == 1 {
+			source = b.Helper
+		}
+		prefix := filepath.Join(filepath.Dir(target), "."+filepath.Base(target)+".vip-update-"+m.ID)
+		r := replacement{Target: target, New: prefix + "-new", Backup: prefix + "-old"}
+		if err = copyExclusive(source, r.New, stat.Mode().Perm()); err != nil {
+			for _, f := range m.Files {
+				os.Remove(f.New)
+			}
+			return res, err
+		}
+		m.Files = append(m.Files, r)
+	}
+	if err = writeJSON(markerPath(l), m); err != nil {
+		for _, f := range m.Files {
+			os.Remove(f.New)
+		}
+		return res, err
+	}
+	markerWritten = true
+	// Preserve this marker on abrupt termination or failed restoration.
+	for index := range m.Files {
+		r := &m.Files[index]
+		if err = ctx.Err(); err != nil {
+			break
+		}
+		progress(Step{Name: "Updating " + filepath.Base(r.Target)})
+		if err = i.Rename(r.Target, r.Backup); err != nil {
+			break
+		}
+		r.moved = true
+		if err = i.Rename(r.New, r.Target); err != nil {
+			break
+		}
+		r.placed = true
+		progress(Step{Name: "Updating " + filepath.Base(r.Target), Done: true})
+	}
+	if err != nil {
+		original := err
+		var recovery []error
+		for index := len(m.Files) - 1; index >= 0; index-- {
+			r := &m.Files[index]
+			if !r.moved {
+				continue
+			}
+			if r.placed {
+				if e := i.Rename(r.Target, r.New); e != nil {
+					recovery = append(recovery, fmt.Errorf("cannot move failed replacement %s; original at %s: %w", r.Target, r.Backup, e))
+					continue
+				}
+			}
+			if e := i.Rename(r.Backup, r.Target); e != nil {
+				recovery = append(recovery, fmt.Errorf("restore %s from %s: %w", r.Target, r.Backup, e))
+			}
+		}
+		if len(recovery) == 0 {
+			for _, r := range m.Files {
+				os.Remove(r.New)
+			}
+			os.Remove(markerPath(l))
+			return res, fmt.Errorf("update failed; original files restored: %w", original)
+		}
+		return res, errors.Join(append([]error{fmt.Errorf("update failed; manual recovery required (%s): %w", markerPath(l), original)}, recovery...)...)
+	}
+	m.Complete = true
+	if err = writeJSON(markerPath(l), m); err != nil {
+		res.Warnings = append(res.Warnings, "Files updated, but could not mark cleanup complete: "+markerPath(l))
+		return res, nil
+	}
+	if err = i.cleanPrevious(l); err != nil {
+		res.Warnings = append(res.Warnings, err.Error())
+	}
+	if err = os.RemoveAll(b.Dir); err != nil {
+		res.Warnings = append(res.Warnings, "Could not remove update staging: "+b.Dir)
+	}
+	return res, nil
+}
+func copyExclusive(source, target string, mode os.FileMode) (err error) {
+	in, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			os.Remove(target)
+		}
+	}()
+	_, err = io.Copy(out, in)
+	closeErr := out.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+func (i Installer) cleanPrevious(l Layout) error {
+	var m installMarker
+	err := readJSON(markerPath(l), 8192, &m)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unreadable update recovery record %s: %w", markerPath(l), err)
+	}
+	if !m.Complete {
+		return fmt.Errorf("incomplete update; inspect recovery record %s before retrying", markerPath(l))
+	}
+	if _, err = uuid.Parse(m.ID); err != nil || len(m.Files) != 2 {
+		return fmt.Errorf("invalid update recovery record")
+	}
+	for idx, r := range m.Files {
+		target := l.CLI
+		if idx == 1 {
+			target = l.Helper
+		}
+		prefix := filepath.Join(filepath.Dir(target), "."+filepath.Base(target)+".vip-update-"+m.ID)
+		if r.Target != target || r.Backup != prefix+"-old" || r.New != prefix+"-new" || strings.Contains(m.ID, "/") {
+			return fmt.Errorf("invalid update recovery paths")
+		}
+		for _, p := range []string{r.New, r.Backup} {
+			if _, e := regularFile(p); os.IsNotExist(e) {
+				continue
+			} else if e != nil {
+				return e
+			}
+			remove := i.Remove
+			if remove == nil {
+				remove = os.Remove
+			}
+			if e := remove(p); e != nil {
+				return fmt.Errorf("updated files are installed; cannot yet remove backup %s: %w", p, e)
+			}
+		}
+	}
+	return os.Remove(markerPath(l))
+}

--- a/internal/update/install_test.go
+++ b/internal/update/install_test.go
@@ -1,0 +1,151 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func installFixture(t *testing.T) (Layout, Bundle) {
+	t.Helper()
+	root, stage := t.TempDir(), t.TempDir()
+	l := Layout{filepath.Join(root, "vip-next"), filepath.Join(root, "go-search-replace")}
+	b := Bundle{stage, filepath.Join(stage, "vip-next"), filepath.Join(stage, "go-search-replace")}
+	for p, s := range map[string]string{l.CLI: "old-cli", l.Helper: "old-helper", b.CLI: "new-cli", b.Helper: "new-helper"} {
+		if err := os.WriteFile(p, []byte(s), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return l, b
+}
+func TestApplyRecovery(t *testing.T) {
+	for _, failAt := range []int{0, 1, 2, 3, 4} {
+		t.Run(string(rune('0'+failAt)), func(t *testing.T) {
+			l, b := installFixture(t)
+			calls := 0
+			i := Installer{Rename: func(a, z string) error {
+				calls++
+				if calls == failAt {
+					return errors.New("injected rename")
+				}
+				return os.Rename(a, z)
+			}, InspectOwnership: func(context.Context, Layout) (Ownership, error) { return Ownership{}, nil }}
+			var done int
+			_, err := i.Apply(context.Background(), l, b, func(s Step) {
+				if s.Done {
+					done++
+				}
+			})
+			if failAt == 0 {
+				if err != nil || done != 2 {
+					t.Fatal(err, done)
+				}
+			} else if err == nil {
+				t.Fatal("missing error")
+			}
+			wantCLI, wantHelper := "old-cli", "old-helper"
+			if failAt == 0 {
+				wantCLI, wantHelper = "new-cli", "new-helper"
+			}
+			for p, want := range map[string]string{l.CLI: wantCLI, l.Helper: wantHelper} {
+				got, err := os.ReadFile(p)
+				if err != nil || string(got) != want {
+					t.Fatal(p, string(got), err)
+				}
+			}
+		})
+	}
+}
+func TestApplyRollbackFailurePreservesRecovery(t *testing.T) {
+	l, b := installFixture(t)
+	calls := 0
+	i := Installer{Rename: func(a, z string) error {
+		calls++
+		if calls >= 4 {
+			return errors.New("locked")
+		}
+		return os.Rename(a, z)
+	}, InspectOwnership: func(context.Context, Layout) (Ownership, error) { return Ownership{}, nil }}
+	_, err := i.Apply(context.Background(), l, b, func(Step) {})
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if _, err = os.Stat(markerPath(l)); err != nil {
+		t.Fatal("recovery marker lost", err)
+	}
+	if _, err = (Installer{}).Apply(context.Background(), l, b, func(Step) {}); err == nil {
+		t.Fatal("incomplete update silently resumed")
+	}
+}
+func TestLayoutAndLock(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+	cli := filepath.Join(root, "vip-next")
+	for _, p := range []string{cli, filepath.Join(root, "go-search-replace")} {
+		if err := os.WriteFile(p, []byte("old"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	l, err := ResolveLayout(cli, Platform{"linux", "amd64"})
+	if err != nil || l.Helper != filepath.Join(root, "go-search-replace") {
+		t.Fatal(l, err)
+	}
+	if err = os.Mkdir(filepath.Join(root, "bin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(root, "bin", "go-search-replace")
+	if err = os.WriteFile(nested, []byte("nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	l, err = ResolveLayout(cli, Platform{"linux", "amd64"})
+	if err != nil || l.Helper != nested {
+		t.Fatal(l, err)
+	}
+	unlock, err := AcquireLock(cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release, err := AcquireLock(cli); err == nil {
+		release()
+		t.Fatal("concurrent lock")
+	}
+	if err = unlock(); err != nil {
+		t.Fatal(err)
+	}
+	unlock, err = AcquireLock(cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlock()
+}
+
+func TestApplyPreflightFailureCleansStagedCopies(t *testing.T) {
+	l, b := installFixture(t)
+	if err := os.Remove(l.Helper); err != nil {
+		t.Fatal(err)
+	}
+	_, err := (Installer{InspectOwnership: func(context.Context, Layout) (Ownership, error) { return Ownership{}, nil }}).Apply(context.Background(), l, b, nil)
+	if err == nil {
+		t.Fatal("missing helper accepted")
+	}
+	paths, err := filepath.Glob(filepath.Join(filepath.Dir(l.CLI), ".*.vip-update-*-new"))
+	if err != nil || len(paths) != 0 {
+		t.Fatal("preflight leaked staging", paths, err)
+	}
+}
+
+func TestManagedBundleNeverChangesFiles(t *testing.T) {
+	l, b := installFixture(t)
+	_, err := (Installer{InspectOwnership: func(context.Context, Layout) (Ownership, error) { return Ownership{true, "use package manager"}, nil }}).Apply(context.Background(), l, b, nil)
+	if err == nil {
+		t.Fatal("managed files accepted")
+	}
+	for path, want := range map[string]string{l.CLI: "old-cli", l.Helper: "old-helper"} {
+		got, e := os.ReadFile(path)
+		if e != nil || string(got) != want {
+			t.Fatal(path, e)
+		}
+	}
+}

--- a/internal/update/lock_unix.go
+++ b/internal/update/lock_unix.go
@@ -1,0 +1,23 @@
+//go:build darwin || linux
+
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func AcquireLock(cli string) (func() error, error) {
+	f, err := os.OpenFile(filepath.Join(filepath.Dir(cli), "."+filepath.Base(cli)+".update.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	if err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("another update is running: %w", err)
+	}
+	return func() error { return f.Close() }, nil
+}

--- a/internal/update/lock_windows.go
+++ b/internal/update/lock_windows.go
@@ -1,0 +1,22 @@
+package update
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+func AcquireLock(cli string) (func() error, error) {
+	f, err := os.OpenFile(filepath.Join(filepath.Dir(cli), "."+filepath.Base(cli)+".update.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+	var overlapped windows.Overlapped
+	if err = windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &overlapped); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("another update is running: %w", err)
+	}
+	return func() error { return f.Close() }, nil
+}

--- a/internal/update/native_test.go
+++ b/internal/update/native_test.go
@@ -1,0 +1,70 @@
+package update
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNativeSelfReplacement(t *testing.T) {
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	root := t.TempDir()
+	old := filepath.Join(root, "old"+suffix)
+	newBin := filepath.Join(root, "new"+suffix)
+	for path, v := range map[string]string{old: "old", newBin: "new"} {
+		cmd := exec.Command("go", "build", "-buildvcs=false", "-ldflags=-X main.fixtureVersion="+v, "-o", path, "../../testdata/update-fixture")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("build fixture: %v\n%s", err, out)
+		}
+	}
+	oldBytes, err := os.ReadFile(old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newBytes, err := os.ReadFile(newBin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, rollback := range []bool{false, true} {
+		install, stage := t.TempDir(), t.TempDir()
+		cli := filepath.Join(install, "vip-next"+suffix)
+		helper := filepath.Join(install, "go-search-replace"+suffix)
+		newCLI := filepath.Join(stage, "vip-next"+suffix)
+		newHelper := filepath.Join(stage, "go-search-replace"+suffix)
+		for path, data := range map[string][]byte{cli: oldBytes, helper: oldBytes, newCLI: newBytes, newHelper: newBytes} {
+			if err := os.WriteFile(path, data, 0755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		mode := "apply"
+		if rollback {
+			mode = "rollback"
+		}
+		cmd := exec.Command(cli, mode, stage, newCLI, newHelper)
+		out, err := cmd.CombinedOutput()
+		if rollback && err == nil || !rollback && err != nil {
+			t.Fatalf("rollback=%v: %v\n%s", rollback, err, out)
+		}
+		want, version := newBytes, "new"
+		if rollback {
+			want, version = oldBytes, "old"
+		}
+		for _, path := range []string{cli, helper} {
+			data, err := os.ReadFile(path)
+			if err != nil || !bytes.Equal(data, want) {
+				t.Fatal("installed bytes differ", path, err)
+			}
+			out, err := exec.Command(path, "--version").CombinedOutput()
+			if err != nil || strings.TrimSpace(string(out)) != version {
+				t.Fatal("installed executable does not run", path, err, string(out))
+			}
+		}
+	}
+}

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -1,0 +1,91 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+type Notifier struct {
+	State     State
+	Installed string
+	Platform  Platform
+	Now       func() time.Time
+	Fetch     func(context.Context) ([]Release, error)
+}
+type Notice struct {
+	Version string
+	Channel Channel
+}
+
+func (n Notifier) Start(parent context.Context) func() *Notice {
+	if n.Now == nil {
+		n.Now = time.Now
+	}
+	pref, err := n.State.ReadChannel()
+	if err != nil {
+		return func() *Notice { return nil }
+	}
+	ch, err := EffectiveChannel(n.Installed, pref)
+	if err != nil {
+		return func() *Notice { return nil }
+	}
+	cached, err := n.State.ReadCache(ch, n.Platform)
+	if err != nil {
+		cached = Cache{}
+	}
+	selectNotice := func(c Cache) *Notice {
+		candidate, err := Select(n.Installed, ch, n.Platform, c.Releases)
+		if err != nil || candidate == nil {
+			return nil
+		}
+		return &Notice{Version: candidate.Version, Channel: ch}
+	}
+	if !Due(cached, n.Now()) {
+		return func() *Notice { return selectNotice(cached) }
+	}
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	result := make(chan Cache, 1)
+	go func() {
+		rs, err := n.Fetch(ctx)
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return
+		}
+		c := cached
+		c.Schema = 1
+		c.Channel = ch
+		c.Platform = n.Platform
+		if err == nil {
+			if _, e := Select(n.Installed, ch, n.Platform, rs); e != nil {
+				err = e
+			}
+		}
+		if err == nil {
+			c.Releases = rs
+			c.LastCheckedAt = n.Now()
+			c.LastFailedAt = time.Time{}
+		} else {
+			c.LastFailedAt = n.Now()
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return
+		}
+		_ = n.State.WriteCache(c) // Optional cache failures never affect commands.
+		result <- c
+	}()
+	var once sync.Once
+	var notice *Notice
+	return func() *Notice {
+		once.Do(func() {
+			cancel()
+			select {
+			case c := <-result:
+				notice = selectNotice(c)
+			default:
+				notice = selectNotice(cached)
+			}
+		})
+		return notice
+	}
+}

--- a/internal/update/notify.go
+++ b/internal/update/notify.go
@@ -42,7 +42,7 @@ func (n Notifier) Start(parent context.Context) func() *Notice {
 		}
 		return &Notice{Version: candidate.Version, Channel: ch}
 	}
-	if !Due(cached, n.Now()) {
+	if n.Fetch == nil || !Due(cached, n.Now()) {
 		return func() *Notice { return selectNotice(cached) }
 	}
 	ctx, cancel := context.WithTimeout(parent, 5*time.Second)

--- a/internal/update/ownership.go
+++ b/internal/update/ownership.go
@@ -1,0 +1,95 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+func InspectOwnership(ctx context.Context, l Layout) (Ownership, error) {
+	return inspectOwnership(ctx, l, runtime.GOOS, func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return exec.CommandContext(ctx, name, args...).Output()
+	})
+}
+
+type ownershipQuery func(context.Context, string, ...string) ([]byte, error)
+
+func inspectOwnership(ctx context.Context, l Layout, goos string, query ownershipQuery) (Ownership, error) {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	for _, target := range []string{l.CLI, l.Helper} {
+		normalized := filepath.ToSlash(target)
+		switch goos {
+		case "darwin":
+			if before, after, ok := strings.Cut(normalized, "/Cellar/"); ok {
+				parts := strings.Split(after, "/")
+				if len(parts) >= 3 {
+					var receipt map[string]any
+					path := filepath.Join(before, "Cellar", parts[0], parts[1], "INSTALL_RECEIPT.json")
+					if readJSON(path, 1<<20, &receipt) == nil {
+						return Ownership{true, "This installation is managed by Homebrew. Run: brew upgrade " + parts[0]}, nil
+					}
+				}
+				return Ownership{true, "This installation is in a Homebrew-managed location; update it with Homebrew."}, nil
+			}
+		case "windows":
+			lower := strings.ToLower(normalized)
+			if strings.Contains(lower, "/scoop/apps/") {
+				_, after, _ := strings.Cut(lower, "/scoop/apps/")
+				parts := strings.Split(after, "/")
+				if len(parts) >= 3 {
+					dir := filepath.Dir(target)
+					var install, manifest map[string]any
+					if readJSON(filepath.Join(dir, "install.json"), 1<<20, &install) == nil && readJSON(filepath.Join(dir, "manifest.json"), 1<<20, &manifest) == nil {
+						return Ownership{true, "This installation is managed by Scoop. Run: scoop update " + parts[0]}, nil
+					}
+				}
+				return Ownership{true, "Update this installation with Scoop."}, nil
+			}
+			if strings.Contains(lower, "/windowsapps/") || strings.Contains(lower, "/winget/") {
+				return Ownership{true, "This installation is package-managed; update it with its package manager."}, nil
+			}
+		case "linux":
+			for _, manager := range []string{"dpkg-query", "rpm"} {
+				args := []string{"-S", target}
+				if manager == "rpm" {
+					args = []string{"-qf", "--queryformat", "%{NAME}", target}
+				}
+				data, err := query(ctx, manager, args...)
+				if err != nil {
+					var ee *exec.ExitError
+					if os.IsNotExist(err) || strings.Contains(err.Error(), "executable file not found") {
+						continue
+					}
+					if errors.As(err, &ee) && ee.ExitCode() == 1 {
+						continue
+					}
+					return Ownership{}, fmt.Errorf("could not determine package ownership for %s: %w", target, err)
+				}
+				pkg := strings.TrimSpace(string(data))
+				if manager == "dpkg-query" {
+					idx := strings.LastIndex(pkg, ": ")
+					if idx < 1 {
+						return Ownership{}, fmt.Errorf("invalid package ownership response")
+					}
+					pkg = pkg[:idx]
+				}
+				if pkg == "" || strings.ContainsAny(pkg, "\r\n\t ") {
+					return Ownership{}, fmt.Errorf("ambiguous package ownership")
+				}
+				command := "apt install --only-upgrade "
+				if manager == "rpm" {
+					command = "your RPM package manager to update "
+				}
+				return Ownership{true, "This installation is package-managed. Use " + command + pkg}, nil
+			}
+		}
+	}
+	return Ownership{}, nil
+}

--- a/internal/update/ownership_test.go
+++ b/internal/update/ownership_test.go
@@ -1,0 +1,58 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOwnershipUsesReceiptsAndFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "Cellar", "vip-next", "5.0.0")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	l := Layout{filepath.Join(dir, "bin", "vip-next"), filepath.Join(dir, "bin", "go-search-replace")}
+	q := func(context.Context, string, ...string) ([]byte, error) { t.Fatal("unexpected query"); return nil, nil }
+	o, err := inspectOwnership(context.Background(), l, "darwin", q)
+	if err != nil || !o.Managed {
+		t.Fatal(o, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "INSTALL_RECEIPT.json"), []byte(`{"installed_on_request":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	o, err = inspectOwnership(context.Background(), l, "darwin", q)
+	if err != nil || o.Instructions != "This installation is managed by Homebrew. Run: brew upgrade vip-next" {
+		t.Fatal(o, err)
+	}
+	_, err = inspectOwnership(context.Background(), Layout{"/usr/bin/vip-next", "/usr/bin/go-search-replace"}, "linux", func(context.Context, string, ...string) ([]byte, error) {
+		return nil, errors.New("database unavailable")
+	})
+	if err == nil {
+		t.Fatal("database failure treated as unowned")
+	}
+	o, err = inspectOwnership(context.Background(), Layout{"/usr/local/bin/vip-next", "/usr/local/bin/go-search-replace"}, "darwin", q)
+	if err != nil || o.Managed {
+		t.Fatal("bare /usr/local/bin misclassified", o, err)
+	}
+}
+func TestResolveLayoutPreservesEntrypointSymlink(t *testing.T) {
+	l, _ := installFixture(t)
+	link := filepath.Join(t.TempDir(), "vip")
+	if err := os.Symlink(l.CLI, link); err != nil {
+		t.Skipf("symlink creation unavailable: %v", err)
+	}
+	got, err := ResolveLayout(link, Platform{"linux", "amd64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := filepath.EvalSymlinks(l.CLI)
+	if got.CLI != want {
+		t.Fatal(got, want)
+	}
+	if _, err := os.Readlink(link); err != nil {
+		t.Fatal("entry symlink changed", err)
+	}
+}

--- a/internal/update/release.go
+++ b/internal/update/release.go
@@ -1,0 +1,120 @@
+// Package update discovers and installs standalone Go CLI releases.
+package update
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+type Channel string
+
+const (
+	Stable  Channel = "stable"
+	Preview Channel = "preview"
+)
+const Repository = "Automattic/vip-cli"
+const ReleasesURL = "https://github.com/" + Repository + "/releases"
+
+type Platform struct{ OS, Arch string }
+type Asset struct {
+	Name   string `json:"name"`
+	URL    string `json:"browser_download_url"`
+	Digest string `json:"digest"`
+	Size   int64  `json:"size"`
+}
+type Release struct {
+	Tag        string  `json:"tag_name"`
+	Draft      bool    `json:"draft"`
+	Prerelease bool    `json:"prerelease"`
+	Assets     []Asset `json:"assets"`
+}
+type Candidate struct {
+	Version           string
+	Archive, Checksum Asset
+}
+
+var releaseTag = regexp.MustCompile(`^5\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.(0|[1-9][0-9]*))?$`)
+
+func validVersion(v string) bool { return releaseTag.MatchString(v) && semver.IsValid("v"+v) }
+func EffectiveChannel(installed string, explicit Channel) (Channel, error) {
+	if !validVersion(installed) {
+		return "", fmt.Errorf("%q is a development or unsupported build; install a release from %s", installed, ReleasesURL)
+	}
+	if explicit != "" {
+		if explicit != Stable && explicit != Preview {
+			return "", fmt.Errorf("channel must be stable or preview")
+		}
+		return explicit, nil
+	}
+	if strings.Contains(installed, "-") {
+		return Preview, nil
+	}
+	return Stable, nil
+}
+func (p Platform) archiveName() (string, error) {
+	switch p.OS + "/" + p.Arch {
+	case "darwin/amd64", "darwin/arm64", "linux/amd64", "linux/arm64", "windows/amd64":
+	default:
+		return "", fmt.Errorf("updates are unavailable for %s/%s", p.OS, p.Arch)
+	}
+	return "vip-next-" + p.OS + "-" + p.Arch + ".tar.gz", nil
+}
+func (p Platform) names() (string, string) {
+	s := ""
+	if p.OS == "windows" {
+		s = ".exe"
+	}
+	return "vip-next" + s, "go-search-replace" + s
+}
+func Select(installed string, channel Channel, p Platform, releases []Release) (*Candidate, error) {
+	channel, err := EffectiveChannel(installed, channel)
+	if err != nil {
+		return nil, err
+	}
+	name, err := p.archiveName()
+	if err != nil {
+		return nil, err
+	}
+	var best *Candidate
+	seen := map[string]bool{}
+	for _, r := range releases {
+		if r.Draft || !validVersion(r.Tag) {
+			continue
+		}
+		if r.Prerelease != strings.Contains(r.Tag, "-") {
+			return nil, fmt.Errorf("release %s has inconsistent prerelease metadata", r.Tag)
+		}
+		if seen[r.Tag] {
+			return nil, fmt.Errorf("duplicate release %s", r.Tag)
+		}
+		seen[r.Tag] = true
+		if channel == Stable && r.Prerelease || semver.Compare("v"+r.Tag, "v"+installed) <= 0 {
+			continue
+		}
+		c := Candidate{Version: r.Tag}
+		a, b := 0, 0
+		for _, asset := range r.Assets {
+			switch asset.Name {
+			case name:
+				c.Archive = asset
+				a++
+			case name + ".sha256":
+				c.Checksum = asset
+				b++
+			}
+		}
+		if a > 1 || b > 1 {
+			return nil, fmt.Errorf("release %s has duplicate update assets", r.Tag)
+		}
+		if a != 1 || b != 1 {
+			continue
+		}
+		if best == nil || semver.Compare("v"+r.Tag, "v"+best.Version) > 0 {
+			best = &c
+		}
+	}
+	return best, nil
+}

--- a/internal/update/release_test.go
+++ b/internal/update/release_test.go
@@ -1,0 +1,128 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func release(tag string) Release {
+	return Release{Tag: tag, Prerelease: strings.Contains(tag, "-"), Assets: []Asset{{Name: "vip-next-linux-amd64.tar.gz"}, {Name: "vip-next-linux-amd64.tar.gz.sha256"}}}
+}
+func TestChannelsAndSelection(t *testing.T) {
+	for _, tc := range []struct {
+		installed      string
+		explicit, want Channel
+	}{
+		{"5.0.0-alpha.3", "", Preview}, {"5.0.0", "", Stable}, {"5.0.0", Preview, Preview}, {"5.0.0-rc.2", Stable, Stable},
+	} {
+		got, err := EffectiveChannel(tc.installed, tc.explicit)
+		if err != nil || got != tc.want {
+			t.Fatalf("%+v: %s %v", tc, got, err)
+		}
+	}
+	for _, v := range []string{"dev", "5.0.0-dev.deadbee", "5.0.0-alpha.01", "4.9.0", "5.0.0-abc.1"} {
+		if _, err := EffectiveChannel(v, ""); err == nil {
+			t.Errorf("accepted %s", v)
+		}
+	}
+	for _, tc := range []struct {
+		installed string
+		channel   Channel
+		tags      []string
+		want      string
+	}{
+		{"5.0.0-alpha.3", Preview, []string{"5.0.0-alpha.9", "5.0.0-alpha.10"}, "5.0.0-alpha.10"},
+		{"5.0.0", Stable, []string{"4.9.0", "6.0.0", "5.1.0-beta.1", "5.0.1"}, "5.0.1"},
+		{"5.0.0-rc.2", Stable, []string{"4.9.0", "5.0.0-beta.1"}, ""},
+		{"5.0.0-rc.2", Preview, []string{"5.0.0", "5.0.0-alpha.9"}, "5.0.0"},
+		{"5.0.0", Preview, []string{"5.0.0", "5.1.0-alpha.1"}, "5.1.0-alpha.1"},
+	} {
+		var rs []Release
+		for _, v := range tc.tags {
+			rs = append(rs, release(v))
+		}
+		got, err := Select(tc.installed, tc.channel, Platform{"linux", "amd64"}, rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v := ""
+		if got != nil {
+			v = got.Version
+		}
+		if v != tc.want {
+			t.Errorf("%+v got %s", tc, v)
+		}
+	}
+}
+func TestSelectRejectsIncompleteAndInconsistentReleases(t *testing.T) {
+	p := Platform{"linux", "amd64"}
+	r := release("5.0.1")
+	r.Draft = true
+	got, err := Select("5.0.0", Stable, p, []Release{r})
+	if err != nil || got != nil {
+		t.Fatal(got, err)
+	}
+	r.Draft = false
+	r.Assets = r.Assets[:1]
+	got, err = Select("5.0.0", Stable, p, []Release{r})
+	if err != nil || got != nil {
+		t.Fatal(got, err)
+	}
+	r = release("5.0.1")
+	r.Assets = append(r.Assets, r.Assets[0])
+	if _, err = Select("5.0.0", Stable, p, []Release{r}); err == nil {
+		t.Fatal("duplicate accepted")
+	}
+	r = release("5.0.1")
+	r.Prerelease = true
+	if _, err = Select("5.0.0", Stable, p, []Release{r}); err == nil {
+		t.Fatal("inconsistent accepted")
+	}
+	if _, err = Select("5.0.0", Stable, Platform{"windows", "arm64"}, nil); err == nil {
+		t.Fatal("unsupported platform")
+	}
+}
+func TestGitHubPagination(t *testing.T) {
+	calls := 0
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Header.Get("Authorization") != "" {
+			t.Error("credentials")
+		}
+		if r.URL.Path != "/repos/Automattic/vip-cli/releases" {
+			t.Error(r.URL.Path)
+		}
+		if r.URL.Query().Get("page") == "1" {
+			w.Header().Set("Link", "<http://"+r.Host+"/repos/Automattic/vip-cli/releases?per_page=100&page=2>; rel=\"next\"")
+			fmt.Fprint(w, `[{"tag_name":"4.9.0"}]`)
+		} else {
+			fmt.Fprint(w, `[{"tag_name":"5.0.0"}]`)
+		}
+	}))
+	defer s.Close()
+	rs, err := (GitHub{Client: s.Client(), BaseURL: s.URL}).Releases(context.Background())
+	if err != nil || len(rs) != 2 || calls != 2 {
+		t.Fatal(rs, err, calls)
+	}
+}
+func TestGitHubErrors(t *testing.T) {
+	for _, tc := range []struct {
+		status     int
+		body, link string
+	}{{429, `{}`, ""}, {200, `broken`, ""}, {200, `[]`, `<https://evil.invalid/next>; rel="next"`}, {200, `[]`, `</repos/Automattic/vip-cli/releases?page=1>; rel="next"`}} {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Link", tc.link)
+			w.WriteHeader(tc.status)
+			fmt.Fprint(w, tc.body)
+		}))
+		_, err := (GitHub{Client: s.Client(), BaseURL: s.URL}).Releases(context.Background())
+		s.Close()
+		if err == nil {
+			t.Errorf("accepted %+v", tc)
+		}
+	}
+}

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -81,7 +81,7 @@ func (s Service) Run(ctx context.Context, r Request, progress func(Step)) (out O
 		if e != nil {
 			return out, e
 		}
-		initial, e = os.Stat(path)
+		initial, e = fileIdentity(path)
 		if e != nil {
 			return out, e
 		}
@@ -181,4 +181,15 @@ func (s Service) Run(ctx context.Context, r Request, progress func(Step)) (out O
 		return out, nil
 	}
 	return out, nil
+}
+
+// fileIdentity captures the ID immediately. On Windows, os.Stat defers reading
+// the ID until os.SameFile, which may run after the path has been replaced.
+func fileIdentity(path string) (os.FileInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.Stat()
 }

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -1,0 +1,184 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/Automattic/vip/internal/version"
+)
+
+type Request struct {
+	CheckOnly       bool
+	Channel         Channel
+	ExplicitChannel bool
+}
+type Outcome struct {
+	Installed, Available string
+	Channel              Channel
+	Updated              bool
+	Instructions         string
+	Warnings             []string
+}
+type Service struct {
+	Installed  string
+	Platform   Platform
+	State      State
+	Now        func() time.Time
+	Executable func() (string, error)
+	Fetch      func(context.Context) ([]Release, error)
+	Stage      func(context.Context, Candidate, Platform, string) (Bundle, error)
+	Installer  Installer
+	initErr    error
+}
+
+func NewService() *Service {
+	cache, e1 := os.UserCacheDir()
+	config, e2 := os.UserConfigDir()
+	s := &Service{Installed: version.Version, Platform: Platform{runtime.GOOS, runtime.GOARCH}, Now: time.Now, Executable: os.Executable, Fetch: (GitHub{}).Releases, Stage: (Downloader{}).Stage}
+	s.State = State{CacheDir: filepath.Join(cache, "vip", "update"), ConfigDir: filepath.Join(config, "vip")}
+	if e1 != nil {
+		s.initErr = e1
+	}
+	if e2 != nil {
+		s.initErr = e2
+	}
+	return s
+}
+func (s Service) Run(ctx context.Context, r Request, progress func(Step)) (out Outcome, err error) {
+	out.Installed = s.Installed
+	if s.initErr != nil {
+		return out, s.initErr
+	}
+	if s.Now == nil {
+		s.Now = time.Now
+	}
+	if progress == nil {
+		progress = func(Step) {}
+	}
+	pref := r.Channel
+	if !r.ExplicitChannel {
+		pref, err = s.State.ReadChannel()
+		if err != nil {
+			return out, err
+		}
+	} else if pref != Stable && pref != Preview {
+		return out, fmt.Errorf("channel must be stable or preview")
+	}
+	ch, err := EffectiveChannel(s.Installed, pref)
+	if err != nil {
+		return out, err
+	}
+	out.Channel = ch
+	// Capture the destination before network discovery so another updater cannot
+	// replace it during the check and leave this process using stale version data.
+	var initial os.FileInfo
+	if !r.CheckOnly && s.Executable != nil {
+		path, e := s.Executable()
+		if e != nil {
+			return out, e
+		}
+		initial, e = os.Stat(path)
+		if e != nil {
+			return out, e
+		}
+	}
+	releases, err := s.Fetch(ctx)
+	if err != nil {
+		return out, err
+	}
+	candidate, err := Select(s.Installed, ch, s.Platform, releases)
+	if err != nil {
+		return out, err
+	}
+	_ = s.State.WriteCache(Cache{Schema: 1, Platform: s.Platform, Channel: ch, LastCheckedAt: s.Now(), Releases: releases})
+	if candidate != nil {
+		out.Available = candidate.Version
+	}
+	persist := func() error {
+		if r.ExplicitChannel {
+			if err := s.State.WriteChannel(ch); err != nil {
+				return fmt.Errorf("could not save update channel: %w", err)
+			}
+		}
+		return nil
+	}
+	if r.CheckOnly || candidate == nil {
+		return out, persist()
+	}
+	exe, err := s.Executable()
+	if err != nil {
+		return out, err
+	}
+	l, err := ResolveLayout(exe, s.Platform)
+	if err != nil {
+		return out, err
+	}
+	expectedCLI, _ := s.Platform.names()
+	if filepath.Base(l.CLI) != expectedCLI {
+		return out, fmt.Errorf("executable has moved or was renamed; rerun the installed %s or install manually from %s", expectedCLI, ReleasesURL)
+	}
+	original, err := regularFile(l.CLI)
+	if err != nil {
+		return out, err
+	}
+	if initial != nil && !os.SameFile(initial, original) {
+		return out, fmt.Errorf("installation changed during update; rerun the command")
+	}
+	inspect := s.Installer.InspectOwnership
+	if inspect == nil {
+		inspect = InspectOwnership
+	}
+	owner, err := inspect(ctx, l)
+	if err != nil {
+		return out, err
+	}
+	if owner.Managed {
+		out.Instructions = owner.Instructions
+		return out, nil
+	}
+	unlock, err := AcquireLock(l.CLI)
+	if err != nil {
+		return out, err
+	}
+	defer func() {
+		if e := unlock(); e != nil {
+			out.Warnings = append(out.Warnings, "Could not close updater lock: "+e.Error())
+		}
+	}()
+	current, err := regularFile(l.CLI)
+	if err != nil {
+		return out, err
+	}
+	if !os.SameFile(original, current) {
+		return out, fmt.Errorf("installation changed during update; rerun the command")
+	}
+	if err = s.Installer.cleanPrevious(l); err != nil {
+		return out, err
+	}
+	progress(Step{Name: "Downloading " + candidate.Version})
+	b, err := s.Stage(ctx, *candidate, s.Platform, filepath.Dir(l.CLI))
+	if err != nil {
+		return out, err
+	}
+	defer os.RemoveAll(b.Dir)
+	progress(Step{Name: "Downloading " + candidate.Version, Done: true})
+	progress(Step{Name: "Verifying download", Done: true})
+	installed, err := s.Installer.Apply(ctx, l, b, progress)
+	if err != nil {
+		return out, err
+	}
+	out.Updated = true
+	out.Warnings = append(out.Warnings, installed.Warnings...)
+	if os.Getenv("VIP_SEARCH_REPLACE_BIN") != "" {
+		out.Warnings = append(out.Warnings, "Bundled go-search-replace updated; VIP_SEARCH_REPLACE_BIN still selects your override.")
+	}
+	if err = persist(); err != nil {
+		out.Warnings = append(out.Warnings, err.Error())
+		return out, nil
+	}
+	return out, nil
+}

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,11 +42,12 @@ func NewService() *Service {
 	s := &Service{Installed: version.Version, Platform: Platform{runtime.GOOS, runtime.GOARCH}, Now: time.Now, Executable: os.Executable, Fetch: (GitHub{}).Releases, Stage: (Downloader{}).Stage}
 	s.State = State{CacheDir: filepath.Join(cache, "vip", "update"), ConfigDir: filepath.Join(config, "vip")}
 	if e1 != nil {
-		s.initErr = e1
+		e1 = fmt.Errorf("update cache directory: %w", e1)
 	}
 	if e2 != nil {
-		s.initErr = e2
+		e2 = fmt.Errorf("update config directory: %w", e2)
 	}
+	s.initErr = errors.Join(e1, e2)
 	return s
 }
 func (s Service) Run(ctx context.Context, r Request, progress func(Step)) (out Outcome, err error) {

--- a/internal/update/service_test.go
+++ b/internal/update/service_test.go
@@ -1,0 +1,65 @@
+package update
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestServiceCheckAndChannelPersistence(t *testing.T) {
+	s := Service{Installed: "5.0.0-rc.2", Platform: Platform{"linux", "amd64"}, State: State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}, Now: time.Now, Fetch: func(context.Context) ([]Release, error) { return []Release{release("5.0.0")}, nil }, Executable: func() (string, error) { t.Fatal("check inspected installation"); return "", nil }}
+	out, err := s.Run(context.Background(), Request{CheckOnly: true, Channel: Stable, ExplicitChannel: true}, nil)
+	if err != nil || out.Available != "5.0.0" || out.Updated {
+		t.Fatal(out, err)
+	}
+	ch, err := s.State.ReadChannel()
+	if err != nil || ch != Stable {
+		t.Fatal(ch, err)
+	}
+	s.Fetch = func(context.Context) ([]Release, error) { return nil, errors.New("offline") }
+	if _, err = s.Run(context.Background(), Request{CheckOnly: true, Channel: Preview, ExplicitChannel: true}, nil); err == nil {
+		t.Fatal("missing failure")
+	}
+	ch, _ = s.State.ReadChannel()
+	if ch != Stable {
+		t.Fatal("failed check changed channel")
+	}
+}
+func TestServiceStableAheadAndManagedInstall(t *testing.T) {
+	s := Service{Installed: "5.1.0-beta.1", Platform: Platform{"linux", "amd64"}, State: State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}, Now: time.Now, Fetch: func(context.Context) ([]Release, error) { return []Release{release("5.0.0")}, nil }}
+	out, err := s.Run(context.Background(), Request{Channel: Stable, ExplicitChannel: true}, nil)
+	if err != nil || out.Updated || out.Available != "" {
+		t.Fatal(out, err)
+	}
+	l, _ := installFixture(t)
+	s.Installed = "5.0.0"
+	s.Executable = func() (string, error) { return l.CLI, nil }
+	s.Fetch = func(context.Context) ([]Release, error) { return []Release{release("5.0.1")}, nil }
+	s.Installer.InspectOwnership = func(context.Context, Layout) (Ownership, error) { return Ownership{true, "use manager"}, nil }
+	s.Stage = func(context.Context, Candidate, Platform, string) (Bundle, error) {
+		t.Fatal("managed installation staged")
+		return Bundle{}, nil
+	}
+	out, err = s.Run(context.Background(), Request{}, nil)
+	if err != nil || out.Instructions != "use manager" {
+		t.Fatal(out, err)
+	}
+}
+
+func TestServiceRejectsInstallationChangedDuringDiscovery(t *testing.T) {
+	l, b := installFixture(t)
+	s := Service{Installed: "5.0.0", Platform: Platform{"linux", "amd64"}, State: State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}, Executable: func() (string, error) { return l.CLI, nil }, Fetch: func(context.Context) ([]Release, error) {
+		if err := os.Rename(b.CLI, l.CLI); err != nil {
+			t.Fatal(err)
+		}
+		return []Release{release("5.0.1")}, nil
+	}, Stage: func(context.Context, Candidate, Platform, string) (Bundle, error) {
+		t.Fatal("stale process attempted installation")
+		return Bundle{}, nil
+	}, Installer: Installer{InspectOwnership: func(context.Context, Layout) (Ownership, error) { return Ownership{}, nil }}}
+	if _, err := s.Run(context.Background(), Request{}, nil); err == nil {
+		t.Fatal("changed executable accepted")
+	}
+}

--- a/internal/update/service_test.go
+++ b/internal/update/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -61,5 +62,18 @@ func TestServiceRejectsInstallationChangedDuringDiscovery(t *testing.T) {
 	}, Installer: Installer{InspectOwnership: func(context.Context, Layout) (Ownership, error) { return Ownership{}, nil }}}
 	if _, err := s.Run(context.Background(), Request{}, nil); err == nil {
 		t.Fatal("changed executable accepted")
+	}
+}
+
+func TestServiceReportsBothDirectoryFailures(t *testing.T) {
+	// Restore all environment changes after this test; no filesystem or network
+	// operations should run when the standard user directories are unavailable.
+	for _, name := range []string{"HOME", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "LocalAppData", "AppData"} {
+		t.Setenv(name, "")
+	}
+	s := NewService()
+	_, err := s.Run(context.Background(), Request{CheckOnly: true}, nil)
+	if err == nil || !strings.Contains(err.Error(), "update cache directory:") || !strings.Contains(err.Error(), "update config directory:") {
+		t.Fatalf("missing directory failure details: %v", err)
 	}
 }

--- a/internal/update/state.go
+++ b/internal/update/state.go
@@ -1,0 +1,116 @@
+package update
+
+import (
+	json "encoding/json/v2"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Cache struct {
+	Schema                      int
+	Platform                    Platform
+	Channel                     Channel
+	LastCheckedAt, LastFailedAt time.Time
+	Releases                    []Release
+}
+type State struct{ CacheDir, ConfigDir string }
+
+func (s State) cachePath(ch Channel, p Platform) (string, error) {
+	if ch != Stable && ch != Preview {
+		return "", fmt.Errorf("invalid channel")
+	}
+	if _, err := p.archiveName(); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.CacheDir, p.OS+"-"+p.Arch+"-"+string(ch)+".json"), nil
+}
+func (s State) ReadCache(ch Channel, p Platform) (Cache, error) {
+	var c Cache
+	name, err := s.cachePath(ch, p)
+	if err != nil {
+		return c, err
+	}
+	err = readJSON(name, 8<<20, &c)
+	if err != nil {
+		return c, err
+	}
+	if c.Schema != 1 || c.Channel != ch || c.Platform != p {
+		return Cache{}, fmt.Errorf("invalid update cache")
+	}
+	return c, nil
+}
+func (s State) WriteCache(c Cache) error {
+	name, err := s.cachePath(c.Channel, c.Platform)
+	if err != nil {
+		return err
+	}
+	return writeJSON(name, c)
+}
+func (s State) ReadChannel() (Channel, error) {
+	var pref struct{ Channel Channel }
+	err := readJSON(filepath.Join(s.ConfigDir, "update.json"), 4096, &pref)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read update preference (use --channel to repair): %w", err)
+	}
+	if pref.Channel != Stable && pref.Channel != Preview {
+		return "", fmt.Errorf("invalid update preference; use --channel stable or preview to repair")
+	}
+	return pref.Channel, nil
+}
+func (s State) WriteChannel(ch Channel) error {
+	if ch != Stable && ch != Preview {
+		return fmt.Errorf("invalid channel")
+	}
+	return writeJSON(filepath.Join(s.ConfigDir, "update.json"), struct{ Channel Channel }{ch})
+}
+func Due(c Cache, now time.Time) bool {
+	if c.Schema != 1 {
+		return true
+	}
+	if c.LastCheckedAt.After(now) || c.LastFailedAt.After(now) {
+		return true
+	}
+	if !c.LastFailedAt.IsZero() && now.Sub(c.LastFailedAt) < time.Hour {
+		return false
+	}
+	return c.LastCheckedAt.IsZero() || now.Sub(c.LastCheckedAt) >= 24*time.Hour
+}
+func readJSON(name string, max int64, v any) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	b, err := readBounded(f, max)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+func writeJSON(name string, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(filepath.Dir(name), 0700); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(name), ".update-state-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if _, err = f.Write(b); err != nil {
+		f.Close()
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), name)
+}

--- a/internal/update/state_test.go
+++ b/internal/update/state_test.go
@@ -106,3 +106,27 @@ func TestNotifierWithoutFetcherUsesCachedRelease(t *testing.T) {
 		t.Fatalf("missing fetcher recorded as failed request: %+v, %v", cached, err)
 	}
 }
+
+func TestStateOverwritesCacheAndChannel(t *testing.T) {
+	s := State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}
+	c := Cache{Schema: 1, Platform: Platform{"windows", "amd64"}, Channel: Stable}
+	for _, v := range []string{"5.0.1", "5.0.2"} {
+		c.Releases = []Release{release(v)}
+		if err := s.WriteCache(c); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cached, err := s.ReadCache(Stable, c.Platform)
+	if err != nil || len(cached.Releases) != 1 || cached.Releases[0].Tag != "5.0.2" {
+		t.Fatalf("cache was not replaced: %+v, %v", cached, err)
+	}
+	for _, ch := range []Channel{Preview, Stable} {
+		if err := s.WriteChannel(ch); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ch, err := s.ReadChannel()
+	if err != nil || ch != Stable {
+		t.Fatalf("channel was not replaced: %q, %v", ch, err)
+	}
+}

--- a/internal/update/state_test.go
+++ b/internal/update/state_test.go
@@ -1,0 +1,90 @@
+package update
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDueAndStateIsolation(t *testing.T) {
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	c := Cache{Schema: 1, Platform: Platform{"linux", "amd64"}, Channel: Preview, LastCheckedAt: now.Add(-23 * time.Hour)}
+	if Due(c, now) {
+		t.Fatal("fresh")
+	}
+	c.LastCheckedAt = now.Add(-25 * time.Hour)
+	if !Due(c, now) {
+		t.Fatal("expired")
+	}
+	c.LastFailedAt = now.Add(-30 * time.Minute)
+	if Due(c, now) {
+		t.Fatal("backoff")
+	}
+	c.LastFailedAt = now.Add(-time.Hour)
+	if !Due(c, now) {
+		t.Fatal("backoff expired")
+	}
+	c.LastCheckedAt = now.Add(time.Hour)
+	if !Due(c, now) {
+		t.Fatal("future")
+	}
+	s := State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}
+	c.LastCheckedAt = now
+	c.Releases = []Release{release("5.0.1")}
+	if err := s.WriteCache(c); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ReadCache(Preview, c.Platform)
+	if err != nil || len(got.Releases) != 1 {
+		t.Fatal(got, err)
+	}
+	if _, err = s.ReadCache(Stable, c.Platform); err == nil {
+		t.Fatal("cross channel cache")
+	}
+	if err = s.WriteChannel(Preview); err != nil {
+		t.Fatal(err)
+	}
+	ch, err := s.ReadChannel()
+	if err != nil || ch != Preview {
+		t.Fatal(ch, err)
+	}
+	if err = os.WriteFile(filepath.Join(s.ConfigDir, "update.json"), []byte(`{"Channel":"bogus"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = s.ReadChannel(); err == nil {
+		t.Fatal("invalid preference accepted")
+	}
+}
+func TestNotifierDoesNotWaitAndReevaluatesCache(t *testing.T) {
+	entered, canceled := make(chan struct{}), make(chan struct{})
+	s := State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}
+	n := Notifier{State: s, Installed: "5.0.0", Platform: Platform{"linux", "amd64"}, Now: time.Now, Fetch: func(ctx context.Context) ([]Release, error) {
+		close(entered)
+		<-ctx.Done()
+		close(canceled)
+		return nil, ctx.Err()
+	}}
+	finish := n.Start(context.Background())
+	<-entered
+	done := make(chan struct{})
+	go func() { finish(); finish(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("blocked")
+	}
+	<-canceled
+	if err := s.WriteCache(Cache{Schema: 1, Platform: n.Platform, Channel: Stable, LastCheckedAt: time.Now(), Releases: []Release{release("5.0.1")}}); err != nil {
+		t.Fatal(err)
+	}
+	notice := n.Start(context.Background())()
+	if notice == nil || notice.Version != "5.0.1" {
+		t.Fatal(notice)
+	}
+	n.Installed = "5.0.1"
+	if notice = n.Start(context.Background())(); notice != nil {
+		t.Fatal("stale notice", notice)
+	}
+}

--- a/internal/update/state_test.go
+++ b/internal/update/state_test.go
@@ -88,3 +88,21 @@ func TestNotifierDoesNotWaitAndReevaluatesCache(t *testing.T) {
 		t.Fatal("stale notice", notice)
 	}
 }
+
+func TestNotifierWithoutFetcherUsesCachedRelease(t *testing.T) {
+	n := Notifier{State: State{CacheDir: t.TempDir(), ConfigDir: t.TempDir()}, Installed: "5.0.0", Platform: Platform{"linux", "amd64"}}
+	if notice := n.Start(context.Background())(); notice != nil {
+		t.Fatalf("unexpected notice: %+v", notice)
+	}
+	if err := n.State.WriteCache(Cache{Schema: 1, Platform: n.Platform, Channel: Stable, LastCheckedAt: time.Now().Add(-48 * time.Hour), Releases: []Release{release("5.0.1")}}); err != nil {
+		t.Fatal(err)
+	}
+	notice := n.Start(context.Background())()
+	if notice == nil || notice.Version != "5.0.1" {
+		t.Fatalf("missing cached notice: %+v", notice)
+	}
+	cached, err := n.State.ReadCache(Stable, n.Platform)
+	if err != nil || !cached.LastFailedAt.IsZero() {
+		t.Fatalf("missing fetcher recorded as failed request: %+v, %v", cached, err)
+	}
+}

--- a/testdata/update-fixture/main.go
+++ b/testdata/update-fixture/main.go
@@ -1,0 +1,62 @@
+// This executable is built only by native updater integration tests.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/Automattic/vip/internal/update"
+)
+
+var fixtureVersion = "unset"
+
+func main() {
+	if len(os.Args) == 2 && os.Args[1] == "--version" {
+		fmt.Println(fixtureVersion)
+		return
+	}
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+func run() error {
+	if len(os.Args) != 5 {
+		return errors.New("expected apply or rollback and staged bundle paths")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return err
+	}
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	l := update.Layout{CLI: exe, Helper: filepath.Join(filepath.Dir(exe), "go-search-replace"+suffix)}
+	b := update.Bundle{Dir: os.Args[2], CLI: os.Args[3], Helper: os.Args[4]}
+	unlock, err := update.AcquireLock(exe)
+	if err != nil {
+		return err
+	}
+	i := update.Installer{InspectOwnership: func(context.Context, update.Layout) (update.Ownership, error) { return update.Ownership{}, nil }}
+	if os.Args[1] == "rollback" {
+		calls := 0
+		i.Rename = func(a, z string) error {
+			calls++
+			if calls == 4 {
+				return errors.New("injected helper replacement failure")
+			}
+			return os.Rename(a, z)
+		}
+	}
+	_, err = i.Apply(context.Background(), l, b, func(s update.Step) { fmt.Println(s.Name, s.Done) })
+	return errors.Join(err, unlock())
+}


### PR DESCRIPTION
## Description

Standalone Go CLI users currently have to discover and install new releases manually. Add invocation-driven update notices and `vip-next update`, with `--check` and persistent `--channel stable|preview` selection. Automatic checks use a 24-hour cache, run alongside the current command, and never install updates or delay command completion.

The updater downloads the matching published 5.x archive from GitHub, verifies SHA-256 checksums and executable targets, then replaces `vip-next` and its bundled `go-search-replace` sequentially with progress output and backups. Ordinary failures attempt restoration; incomplete recovery retains the backup paths. Package-managed installations receive upgrade instructions. Update commands bypass VIP login without broadening other commands' authentication bypasses.

This is an explicitly approved Go-only command; Node retains its npm notifier. Binary signatures are preserved byte for byte, but this does not add separate runtime signer/notarization verification. Sequential replacement is not a crash-proof two-file transaction.

## Changelog Description

### Added

- Go CLI: Added update notifications and an `update` command with stable and preview channels, download verification, and recovery from installation failures.

## Pull request checklist

- [x] Documented `VIP_NO_UPDATE_NOTIFIER` in `docs/SETUP.md`.
- [x] Added update documentation and revised the cutover notes.
- [x] Added unit, failure-recovery, native self-replacement, and subprocess end-to-end tests.
- [x] Smoke-tested updater help and exercised native macOS self-replacement and rollback using disposable installations.
- [x] Native Windows, Linux, and macOS execution validated by the new CI matrix.
- [ ] Reviewer approval and all required CI checks pass.

## Validation

- `make lint`, `make test` (55 packages with passing tests), and `make build` passed locally.
- Focused updater and bootstrap tests passed with race detection.
- Native macOS self-replacement and rollback passed. A separate subprocess test exercised the actual Cobra command, local TLS release discovery/downloads, verification, installation, channel persistence, and credential isolation.
- All five release targets cross-compiled: darwin amd64/arm64, linux amd64/arm64, windows amd64. Cross-compilation does not establish native execution support.
- Built the Node reference with `npm ci`; `make require-node-vip-bin` and `make test-parity-unit` passed. Structured results: 301 passing tests/subtests and 20 existing skips for documented runtime differences, with no credential-related skips. No existing expected-drift entry was broadened.
- Native Windows, Linux, and macOS updater CI jobs passed on commit `62c6ddb9`, including self-replacement, rollback, and command integration.
- Live Parker parity was not run.

## Steps to Test

1. Run `go test -count=1 -v ./internal/update` to exercise release selection, caching, verification, installation, recovery, and native self-replacement in temporary directories.
2. Run `go test -count=1 -v ./cmd/vip-next -run Update` for auth isolation, output suppression, and the complete updater command against a local TLS fixture server.
3. Run `make build`, then `DO_NOT_TRACK=1 ./bin/vip-next update --help` to inspect the command interface without installing anything.
4. Check the new `Go updater` CI jobs on macOS, Linux, and Windows.

