### PR TITLE
[PLTFRM-2783] Fix sync progress polling query

### DIFF
--- a/src/bin/vip-sync.generated.d.ts
+++ b/src/bin/vip-sync.generated.d.ts
@@ -14,7 +14,6 @@ export type SyncEnvironmentMutationMutation = {
 
 export type AppQueryVariables = Types.Exact< {
 	id?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
-	sync?: Types.InputMaybe< Types.Scalars[ 'Int' ][ 'input' ] >;
 } >;
 
 export type AppQuery = {

--- a/src/bin/vip-sync.js
+++ b/src/bin/vip-sync.js
@@ -118,7 +118,7 @@ command( {
 				api
 					.query( {
 						query: gql`
-							query App($id: Int, $sync: Int) {
+							query App($id: Int) {
 								app(id: $id) {
 									id
 									name
@@ -128,7 +128,7 @@ command( {
 										defaultDomain
 										branch
 										datacenter
-										syncProgress(sync: $sync) {
+										syncProgress {
 											status
 											sync
 											steps {
@@ -143,7 +143,6 @@ command( {
 						fetchPolicy: 'network-only',
 						variables: {
 							id: opts.app.id,
-							sync: environment.syncProgress.sync,
 						},
 					} )
 					.then( res => res.data.app )


### PR DESCRIPTION
## Description

`vip sync` starts a data sync but then exits with `Unknown argument "sync" on field "AppEnvironment.syncProgress"` when polling for progress. Remove the obsolete argument and its query variable so polling works with the current API schema. Regenerate the operation types accordingly.

## Changelog Description

### Fixed

- Fixed `vip sync` exiting with a GraphQL error while the data sync continues in the background.

## Validation

- Typecheck and focused ESLint passed in the development checkout.
- A temporary regression test reproduced the original GraphQL validation error and passed with the fix; no test file is included in this PR.
- `git diff --check` passed on the PR branch.
- Live data sync has not been run.

## Steps to Test

1. Build the CLI with `npm run build`.
2. On a disposable test application's non-production environment, run `node dist/bin/vip-sync.js @example-app.develop` and confirm the sync.
3. Verify progress polling does not report the unknown `sync` argument error and continues through completion.
