### PR TITLE
Bump Edge Workers SDK to 0.5.0

### DIFF
--- a/__tests__/lib/edge-workers/toolchains.js
+++ b/__tests__/lib/edge-workers/toolchains.js
@@ -44,7 +44,7 @@ describe( 'edge-workers toolchains', () => {
 			expect( fs.existsSync( path.join( project, 'workers' ) ) ).toBe( true );
 
 			const pkg = JSON.parse( fs.readFileSync( path.join( project, 'package.json' ), 'utf8' ) );
-			expect( pkg.dependencies[ '@automattic/vip-edge-workers-sdk' ] ).toBe( '0.4.0' );
+			expect( pkg.dependencies[ '@automattic/vip-edge-workers-sdk' ] ).toBe( '0.5.0' );
 			expect( pkg.devDependencies.assemblyscript ).toBe( '0.27.0' );
 
 			const readme = fs.readFileSync( path.join( project, 'README.md' ), 'utf8' );

--- a/docs/EDGE-WORKERS.md
+++ b/docs/EDGE-WORKERS.md
@@ -37,7 +37,7 @@ edge-workers/
 ```
 
 `build/` is created when a worker is compiled and is ignored by Git. The generated direct
-dependencies are exact: `@automattic/vip-edge-workers-sdk` is `0.4.0` and `assemblyscript` is
+dependencies are exact: `@automattic/vip-edge-workers-sdk` is `0.5.0` and `assemblyscript` is
 `0.27.0`. The starter exports only `alloc` and `on_client_response`; the other request phases are
 commented examples and are not active WASM exports.
 
@@ -48,7 +48,7 @@ The project descriptor selects the toolchain for every worker in the project:
 ```json
 {
 	"type": "assemblyscript",
-	"sdk": "@automattic/vip-edge-workers-sdk@0.4.0"
+	"sdk": "@automattic/vip-edge-workers-sdk@0.5.0"
 }
 ```
 

--- a/internal/edgeworkers/build_test.go
+++ b/internal/edgeworkers/build_test.go
@@ -16,7 +16,7 @@ func TestScaffoldDoesNotOverwriteOrInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 	before, _ := os.ReadFile(filepath.Join(dir, "package.json"))
-	if !strings.Contains(string(before), `"0.4.0"`) || !strings.Contains(string(before), `"0.27.0"`) {
+	if !strings.Contains(string(before), `"0.5.0"`) || !strings.Contains(string(before), `"0.27.0"`) {
 		t.Fatalf("dependencies: %s", before)
 	}
 	if err := ScaffoldProject(dir, "assemblyscript"); err == nil {

--- a/internal/edgeworkers/templates/edge-workers.json
+++ b/internal/edgeworkers/templates/edge-workers.json
@@ -1,4 +1,4 @@
 {
 	"type": "assemblyscript",
-	"sdk": "@automattic/vip-edge-workers-sdk@0.4.0"
+	"sdk": "@automattic/vip-edge-workers-sdk@0.5.0"
 }

--- a/internal/edgeworkers/templates/package.json
+++ b/internal/edgeworkers/templates/package.json
@@ -8,7 +8,7 @@
 		"build": "vip edge-workers build --all"
 	},
 	"dependencies": {
-		"@automattic/vip-edge-workers-sdk": "0.4.0"
+		"@automattic/vip-edge-workers-sdk": "0.5.0"
 	},
 	"devDependencies": {
 		"assemblyscript": "0.27.0"

--- a/src/lib/edge-workers/toolchains/assemblyscript/constants.ts
+++ b/src/lib/edge-workers/toolchains/assemblyscript/constants.ts
@@ -5,6 +5,6 @@
  */
 
 export const SDK_PACKAGE = '@automattic/vip-edge-workers-sdk';
-export const SDK_VERSION = '0.4.0';
+export const SDK_VERSION = '0.5.0';
 export const ASSEMBLYSCRIPT_VERSION = '0.27.0';
 export const DEFAULT_ENTRY = 'assembly/index.ts';


### PR DESCRIPTION
## Description

Bump the exact `@automattic/vip-edge-workers-sdk` version emitted by both the Node.js and Go Edge Workers project scaffolds from `0.4.0` to `0.5.0`.

This keeps the two runtimes aligned by updating the Node.js toolchain constant, both embedded Go templates, their scaffold contract tests, and the shared Edge Workers documentation. The SDK is generated-project metadata rather than a root VIP-CLI dependency, so neither the root `package-lock.json` nor `go.mod` changes.

The `0.5.0` package was independently confirmed as available from npm. Existing Edge Workers projects are not modified automatically; the new pin applies when scaffolding projects after this change.

SDK: https://github.com/Automattic/vip-edge-workers-sdk

## Pull request checklist

- [x] No environmental variables were added or changed.
- [x] Updated the Edge Workers documentation.
- [x] Updated the Node.js and Go scaffold contract tests.
- [x] Ran the relevant build, type, lint, unit, and cross-runtime parity checks.

## Steps to Test

1. Run `npm run build`.
2. Run `npm run jest -- --runTestsByPath __tests__/lib/edge-workers/toolchains.js --runInBand`.
3. Run `npm run check-types`.
4. Run `npx --no-install eslint src/lib/edge-workers/toolchains/assemblyscript/constants.ts __tests__/lib/edge-workers/toolchains.js`.
5. Run `make test`.
6. Run `make require-node-vip-bin` and confirm Node-vs-Go differential coverage is on.
7. Run `make test-parity-unit`.

All commands above passed locally. The aggregate `npm test` command is currently blocked on `trunk` during linting by JSON comments in the unrelated tracked `.vscode/launch.json`; the changed Node.js files pass targeted ESLint, Jest, type-checking, and build checks.
