### PR TITLE
Fix vip-next GitHub release pagination

### DIFF
--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -64,24 +64,26 @@ func (g GitHub) Releases(ctx context.Context) ([]Release, error) {
 		}
 		releases = append(releases, batch...)
 		next := 0
-		for _, part := range strings.Split(resp.Header.Get("Link"), ",") {
-			if !strings.Contains(part, `rel="next"`) {
-				continue
+		for _, value := range resp.Header.Values("Link") {
+			for _, part := range strings.Split(value, ",") {
+				if !strings.Contains(part, `rel="next"`) {
+					continue
+				}
+				left, right := strings.Index(part, "<"), strings.Index(part, ">")
+				if left < 0 || right <= left {
+					return nil, fmt.Errorf("invalid release pagination")
+				}
+				u, err := url.Parse(part[left+1 : right])
+				if err != nil {
+					return nil, fmt.Errorf("invalid release pagination")
+				}
+				u = origin.ResolveReference(u)
+				n, err := strconv.Atoi(u.Query().Get("page"))
+				if err != nil || n <= page || u.Scheme != origin.Scheme || u.Host != origin.Host || !isReleasePaginationPath(u.Path) || u.User != nil || next != 0 {
+					return nil, fmt.Errorf("invalid release pagination")
+				}
+				next = n
 			}
-			left, right := strings.Index(part, "<"), strings.Index(part, ">")
-			if left < 0 || right <= left {
-				return nil, fmt.Errorf("invalid release pagination")
-			}
-			u, err := url.Parse(part[left+1 : right])
-			if err != nil {
-				return nil, fmt.Errorf("invalid release pagination")
-			}
-			u = origin.ResolveReference(u)
-			n, err := strconv.Atoi(u.Query().Get("page"))
-			if err != nil || n <= page || u.Scheme != origin.Scheme || u.Host != origin.Host || u.Path != "/repos/"+Repository+"/releases" || u.User != nil || next != 0 {
-				return nil, fmt.Errorf("invalid release pagination")
-			}
-			next = n
 		}
 		if next == 0 {
 			return releases, nil
@@ -90,6 +92,23 @@ func (g GitHub) Releases(ctx context.Context) ([]Release, error) {
 	}
 	return nil, fmt.Errorf("GitHub release pagination limit exceeded")
 }
+
+func isReleasePaginationPath(path string) bool {
+	if path == "/repos/"+Repository+"/releases" {
+		return true
+	}
+	repositoryID, ok := strings.CutPrefix(path, "/repositories/")
+	if !ok {
+		return false
+	}
+	repositoryID, ok = strings.CutSuffix(repositoryID, "/releases")
+	if !ok {
+		return false
+	}
+	id, err := strconv.ParseUint(repositoryID, 10, 64)
+	return err == nil && id > 0
+}
+
 func readBounded(r io.Reader, max int64) ([]byte, error) {
 	b, err := io.ReadAll(io.LimitReader(r, max+1))
 	if err != nil {

--- a/internal/update/release_test.go
+++ b/internal/update/release_test.go
@@ -87,33 +87,57 @@ func TestSelectRejectsIncompleteAndInconsistentReleases(t *testing.T) {
 	}
 }
 func TestGitHubPagination(t *testing.T) {
+	for _, tc := range []struct {
+		name, nextPath string
+	}{{"named repository", "/repos/Automattic/vip-cli/releases"}, {"numeric repository ID", "/repositories/116313791/releases"}} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if r.Header.Get("Authorization") != "" {
+					t.Error("credentials")
+				}
+				if r.URL.Path != "/repos/Automattic/vip-cli/releases" {
+					t.Error(r.URL.Path)
+				}
+				if r.URL.Query().Get("page") == "1" {
+					w.Header().Set("Link", "<http://"+r.Host+tc.nextPath+"?per_page=100&page=2>; rel=\"next\"")
+					fmt.Fprint(w, `[{"tag_name":"4.9.0"}]`)
+				} else {
+					fmt.Fprint(w, `[{"tag_name":"5.0.0"}]`)
+				}
+			}))
+			defer s.Close()
+			rs, err := (GitHub{Client: s.Client(), BaseURL: s.URL}).Releases(context.Background())
+			if err != nil || len(rs) != 2 || calls != 2 {
+				t.Fatal(rs, err, calls)
+			}
+		})
+	}
+}
+
+func TestGitHubRejectsDuplicateNextLinkHeaders(t *testing.T) {
 	calls := 0
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
-		if r.Header.Get("Authorization") != "" {
-			t.Error("credentials")
-		}
-		if r.URL.Path != "/repos/Automattic/vip-cli/releases" {
-			t.Error(r.URL.Path)
-		}
 		if r.URL.Query().Get("page") == "1" {
-			w.Header().Set("Link", "<http://"+r.Host+"/repos/Automattic/vip-cli/releases?per_page=100&page=2>; rel=\"next\"")
-			fmt.Fprint(w, `[{"tag_name":"4.9.0"}]`)
-		} else {
-			fmt.Fprint(w, `[{"tag_name":"5.0.0"}]`)
+			w.Header().Add("Link", "<http://"+r.Host+"/repositories/116313791/releases?page=2>; rel=\"next\"")
+			w.Header().Add("Link", "<http://"+r.Host+"/repositories/116313791/releases?page=3>; rel=\"next\"")
 		}
+		fmt.Fprint(w, `[]`)
 	}))
 	defer s.Close()
-	rs, err := (GitHub{Client: s.Client(), BaseURL: s.URL}).Releases(context.Background())
-	if err != nil || len(rs) != 2 || calls != 2 {
-		t.Fatal(rs, err, calls)
+	_, err := (GitHub{Client: s.Client(), BaseURL: s.URL}).Releases(context.Background())
+	if err == nil || calls != 1 {
+		t.Fatal(err, calls)
 	}
 }
+
 func TestGitHubErrors(t *testing.T) {
 	for _, tc := range []struct {
 		status     int
 		body, link string
-	}{{429, `{}`, ""}, {200, `broken`, ""}, {200, `[]`, `<https://evil.invalid/next>; rel="next"`}, {200, `[]`, `</repos/Automattic/vip-cli/releases?page=1>; rel="next"`}} {
+	}{{429, `{}`, ""}, {200, `broken`, ""}, {200, `[]`, `<https://evil.invalid/next>; rel="next"`}, {200, `[]`, `</repositories/not-a-number/releases?page=2>; rel="next"`}, {200, `[]`, `</repos/Automattic/vip-cli/releases?page=1>; rel="next"`}} {
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Link", tc.link)
 			w.WriteHeader(tc.status)


### PR DESCRIPTION
## Description

Fixes `vip-next update --check` failing with `invalid release pagination`.

GitHub accepts release-list requests at `/repos/Automattic/vip-cli/releases`, but its pagination `Link` header canonicalizes the next-page URL to `/repositories/<numeric-id>/releases`. The updater previously required the named-repository path exactly, so it rejected GitHub's valid response before requesting page 2.

This change accepts either release pagination path while preserving the existing safeguards:

- requests are still constructed against the original named-repository endpoint rather than following the supplied URL;
- pagination must remain on the configured scheme and host;
- repository IDs must be positive decimal integers;
- userinfo, malformed paths, backward pages, duplicate next links, and more than 100 pages remain rejected;
- duplicate next links are now also detected when delivered in separate `Link` header fields.

The change is limited to the Go `vip-next` updater. The Node CLI's existing update behavior is unchanged.

## Changelog Description

### Fixed

- VIP Next: Fixed update checks failing when GitHub returns numeric repository pagination URLs.

## Pull request checklist

- [x] No new environmental variables are introduced.
- [x] No documentation changes are needed for this internal compatibility fix.
- [x] Manually tested the check-only updater against the public GitHub Releases API.
- [x] Followed the repository pull request checklist.
- [x] Added automated regression coverage.

## Steps to Test

1. Run `go test ./internal/update -count=1`.
2. Run `make test`.
3. Run `make lint`.
4. Run a `vip-next` binary built from this branch with `update --check` and verify it reports update status instead of `invalid release pagination`.

Manual verification used an isolated temporary cache/config and a binary stamped as `5.0.0-alpha.4`; it traversed GitHub's live pagination and reported `5.0.0-alpha.5` as available on the preview channel.
